### PR TITLE
feat: add marshmallow extension fields for Money, Rate, InterestRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ MoneyWarp is a Python library for working with the time value of money. It treat
 - 📋 **Installments & Settlements** — first-class views of the repayment plan and payment allocation
 - 🇧🇷 **Tax module** — Brazilian IOF with pluggable tax strategy, grossup, and preset rates
 - 🌐 **Timezone-aware** — all datetimes are UTC by default, configurable globally
+- 🔌 **Marshmallow extension** — custom fields for `Money`, `Rate`, and `InterestRate` serialization
 
 ## 📦 Installation
 
@@ -48,6 +49,14 @@ Or with Poetry:
 
 ```bash
 poetry add money-warp
+```
+
+### Marshmallow Extension
+
+To use the Marshmallow custom fields for `Money`, `Rate`, and `InterestRate`:
+
+```bash
+pip install money-warp[marshmallow]
 ```
 
 ## 🎯 Quick Start
@@ -226,6 +235,33 @@ banker = InterestRate("10% a", year_size=YearSize.banker)
 print(f"Commercial daily: {commercial.to_daily()}")  # 365-day year
 print(f"Banker daily: {banker.to_daily()}")          # 360-day year — slightly higher
 ```
+
+### Marshmallow Extension 🔌
+
+```python
+from marshmallow import Schema
+from money_warp import Money, InterestRate
+from money_warp.ext.marshmallow import MoneyField, InterestRateField
+
+class LoanSchema(Schema):
+    principal = MoneyField(representation="raw")     # "10000.00"
+    rate = InterestRateField(representation="string") # "5.250% annual"
+
+schema = LoanSchema()
+
+# Serialize
+data = schema.dump({"principal": Money("10000"), "rate": InterestRate("5.25% a")})
+# {"principal": "10000", "rate": "5.250% annual"}
+
+# Deserialize
+result = schema.load(data)
+# {"principal": Money(10000), "rate": InterestRate(5.25% annually)}
+```
+
+**Available fields:**
+- **MoneyField**: representations `"raw"` (default), `"real"`, `"cents"`
+- **RateField**: representations `"string"` (default), `"dict"`
+- **InterestRateField**: same as RateField, but rejects negative rates
 
 ### Easy Date Generation 📅
 

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -1,0 +1,48 @@
+# Extensions (`money_warp/ext/`)
+
+The `ext` package provides opt-in integrations with third-party serialization libraries. Each integration lives in its own module and requires an optional dependency.
+
+## Marshmallow (`ext/marshmallow.py`)
+
+Custom Marshmallow fields for `Money`, `Rate`, and `InterestRate`.
+
+**Install:** `pip install money-warp[marshmallow]` (adds `marshmallow >= 3.20`).
+
+### MoneyField
+
+Serializes/deserializes `Money` instances. Configurable `representation` parameter:
+
+| Representation | Serialized type | Serialize logic           | Deserialize logic      |
+|----------------|-----------------|---------------------------|------------------------|
+| `"raw"` (default) | `str`       | `str(money.raw_amount)`   | `Money(value)`         |
+| `"real"`       | `str`           | `str(money.real_amount)`  | `Money(value)`         |
+| `"cents"`      | `int`           | `money.cents`             | `Money.from_cents(value)` |
+
+### RateField
+
+Serializes/deserializes `Rate` instances. Configurable `representation` parameter:
+
+| Representation    | Serialized type | Example output                                     |
+|-------------------|-----------------|----------------------------------------------------|
+| `"string"` (default) | `str`       | `"5.250% annual"`                                  |
+| `"dict"`          | `dict`          | `{"rate": "0.0525", "period": "annually", ...}`    |
+
+**String mode** outputs a parseable format (`"5.250% annual"`) that feeds directly back into `Rate(...)`. Field-level defaults (`year_size`, `precision`, `rounding`, `str_style`) are applied on deserialization.
+
+**Dict mode** captures all constructor params (`rate`, `period`, `year_size`, `precision`, `rounding`, `str_style`) for lossless reconstruction.
+
+### InterestRateField
+
+Inherits from `RateField` with `RATE_CLASS = InterestRate`. Same representations, but constructs `InterestRate` on deserialization (rejects negative values).
+
+## Design Decisions
+
+- **`RATE_CLASS` pattern:** `RateField` uses `self.RATE_CLASS(...)` to construct instances. `InterestRateField` overrides this to `InterestRate`, avoiding code duplication.
+- **Parseable string serialization:** String mode uses `_FREQUENCY_TOKEN` mapping instead of `str(rate)` because `Rate.__str__()` outputs `"annually"` / `"semi_annually"` which the Rate parser does not accept. The mapping outputs parser-compatible tokens like `"annual"` and `"semi-annual"`.
+- **Private attribute access:** Dict serialization reads `value._precision`, `value._rounding`, `value._str_style` since there are no public getters. Acceptable because this is a first-party extension.
+- **Optional dependency:** Marshmallow is declared optional in `pyproject.toml` under `[tool.poetry.extras]`. Importing `money_warp.ext.marshmallow` without marshmallow installed raises `ImportError`.
+
+## Key Gotchas
+
+- String round-trip loses some precision: the percentage rate is formatted with 3 decimal places (`:.3f`). Rates with more than 3 decimal digits in the percentage form should use dict representation for lossless round-trips.
+- `None` handling: all fields pass through `None` in both serialize and deserialize (returns `None`).

--- a/money_warp/ext/__init__.py
+++ b/money_warp/ext/__init__.py
@@ -1,0 +1,1 @@
+"""Extensions for integrating money-warp types with third-party libraries."""

--- a/money_warp/ext/marshmallow.py
+++ b/money_warp/ext/marshmallow.py
@@ -22,6 +22,14 @@ __all__ = [
 _VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents")
 _VALID_RATE_REPRESENTATIONS = ("string", "dict")
 
+_FREQUENCY_TOKEN = {
+    CompoundingFrequency.ANNUALLY: "annual",
+    CompoundingFrequency.MONTHLY: "monthly",
+    CompoundingFrequency.DAILY: "daily",
+    CompoundingFrequency.QUARTERLY: "quarterly",
+    CompoundingFrequency.SEMI_ANNUALLY: "semi-annual",
+}
+
 
 class MoneyField(fields.Field):
     """Marshmallow field for :class:`~money_warp.money.Money`.
@@ -115,7 +123,8 @@ class RateField(fields.Field):
             raise self.make_error("invalid")
 
         if self.representation == "string":
-            return str(value)
+            token = _FREQUENCY_TOKEN[value.period]
+            return f"{value.as_percentage:.3f}% {token}"
 
         return {
             "rate": str(value.as_decimal),

--- a/money_warp/ext/marshmallow.py
+++ b/money_warp/ext/marshmallow.py
@@ -1,0 +1,193 @@
+"""Marshmallow custom fields for Money, Rate, and InterestRate.
+
+Requires the ``marshmallow`` extra::
+
+    pip install money-warp[marshmallow]
+"""
+
+from decimal import Decimal
+
+from marshmallow import fields
+
+from money_warp.interest_rate import InterestRate
+from money_warp.money import Money
+from money_warp.rate import CompoundingFrequency, Rate, YearSize
+
+__all__ = [
+    "MoneyField",
+    "RateField",
+    "InterestRateField",
+]
+
+_VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents")
+_VALID_RATE_REPRESENTATIONS = ("string", "dict")
+
+
+class MoneyField(fields.Field):
+    """Marshmallow field for :class:`~money_warp.money.Money`.
+
+    Args:
+        representation: Controls serialization format.
+            ``"raw"`` (default) -- full-precision ``raw_amount`` as string.
+            ``"real"`` -- rounded ``real_amount`` as string.
+            ``"cents"`` -- integer cents.
+    """
+
+    default_error_messages = {
+        "invalid": "Not a valid monetary amount.",
+    }
+
+    def __init__(self, representation: str = "raw", **kwargs) -> None:
+        super().__init__(**kwargs)
+        if representation not in _VALID_MONEY_REPRESENTATIONS:
+            raise ValueError(
+                f"Invalid representation: '{representation}'. Expected one of {_VALID_MONEY_REPRESENTATIONS}"
+            )
+        self.representation = representation
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if not isinstance(value, Money):
+            raise self.make_error("invalid")
+
+        if self.representation == "raw":
+            return str(value.raw_amount)
+        if self.representation == "real":
+            return str(value.real_amount)
+        return value.cents
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            result = Money.from_cents(int(value)) if self.representation == "cents" else Money(value)
+        except Exception as exc:
+            raise self.make_error("invalid") from exc
+        else:
+            return result
+
+
+class RateField(fields.Field):
+    """Marshmallow field for :class:`~money_warp.rate.Rate`.
+
+    Args:
+        representation: Controls serialization format.
+            ``"string"`` (default) -- human-readable string like ``"5.250% monthly"``.
+            ``"dict"`` -- dict with all params needed to reconstruct the Rate.
+        year_size: Default year-size convention for string deserialization.
+        precision: Default precision for string deserialization.
+        rounding: Default rounding mode for string deserialization.
+        str_style: Default str_style for string deserialization.
+    """
+
+    RATE_CLASS = Rate
+
+    default_error_messages = {
+        "invalid": "Not a valid rate.",
+        "invalid_dict": "Expected a dict with at least 'rate' and 'period' keys.",
+    }
+
+    def __init__(
+        self,
+        representation: str = "string",
+        year_size: YearSize = YearSize.commercial,
+        precision: int | None = None,
+        rounding: str = "ROUND_HALF_UP",
+        str_style: str = "long",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        if representation not in _VALID_RATE_REPRESENTATIONS:
+            raise ValueError(
+                f"Invalid representation: '{representation}'. Expected one of {_VALID_RATE_REPRESENTATIONS}"
+            )
+        self.representation = representation
+        self.rate_year_size = year_size
+        self.rate_precision = precision
+        self.rate_rounding = rounding
+        self.rate_str_style = str_style
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if not isinstance(value, Rate):
+            raise self.make_error("invalid")
+
+        if self.representation == "string":
+            return str(value)
+
+        return {
+            "rate": str(value.as_decimal),
+            "period": value.period.name.lower(),
+            "year_size": value.year_size.value,
+            "precision": value._precision,
+            "rounding": value._rounding,
+            "str_style": value._str_style,
+        }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+
+        if self.representation == "string":
+            return self._deserialize_string(value)
+        return self._deserialize_dict(value)
+
+    def _deserialize_string(self, value):
+        try:
+            result = self.RATE_CLASS(
+                value,
+                year_size=self.rate_year_size,
+                precision=self.rate_precision,
+                rounding=self.rate_rounding,
+                str_style=self.rate_str_style,
+            )
+        except Exception as exc:
+            raise self.make_error("invalid") from exc
+        else:
+            return result
+
+    def _deserialize_dict(self, value):
+        if not isinstance(value, dict):
+            raise self.make_error("invalid_dict")
+
+        try:
+            rate = Decimal(str(value["rate"]))
+            period = CompoundingFrequency[value["period"].upper()]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise self.make_error("invalid_dict") from exc
+
+        try:
+            year_size = YearSize(value["year_size"]) if "year_size" in value else self.rate_year_size
+            precision = value.get("precision", self.rate_precision)
+            rounding = value.get("rounding", self.rate_rounding)
+            str_style = value.get("str_style", self.rate_str_style)
+
+            result = self.RATE_CLASS(
+                rate,
+                period=period,
+                year_size=year_size,
+                precision=precision,
+                rounding=rounding,
+                str_style=str_style,
+            )
+        except Exception as exc:
+            raise self.make_error("invalid") from exc
+        else:
+            return result
+
+
+class InterestRateField(RateField):
+    """Marshmallow field for :class:`~money_warp.interest_rate.InterestRate`.
+
+    Identical to :class:`RateField` but constructs ``InterestRate`` instances,
+    which reject negative values.
+    """
+
+    RATE_CLASS = InterestRate
+
+    default_error_messages = {
+        **RateField.default_error_messages,
+        "invalid": "Not a valid interest rate.",
+    }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1591,6 +1591,27 @@ files = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "3.26.2"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73"},
+    {file = "marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57"},
+]
+markers = {main = "extra == \"marshmallow\""}
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+docs = ["autodocsumm (==0.2.14)", "furo (==2024.8.6)", "sphinx (==8.1.3)", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "sphinxext-opengraph (==0.9.1)"]
+tests = ["pytest", "simplejson"]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.1.7"
 description = "Inline Matplotlib backend for Jupyter"
@@ -2020,11 +2041,12 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "notebook"]
+groups = ["main", "dev", "docs", "notebook"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
+markers = {main = "extra == \"marshmallow\""}
 
 [[package]]
 name = "paginate"
@@ -3476,7 +3498,10 @@ files = [
     {file = "widgetsnbextension-4.0.14.tar.gz", hash = "sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af"},
 ]
 
+[extras]
+marshmallow = ["marshmallow"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "21936ac9279c55db141ea60bcd3f48e2fd26ed517412484c624bbb85b23b7f79"
+content-hash = "8f1b4552082e5bd7b5b32d7212e433e2903ac3c372282c145f739ef29bed93ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ packages = [
 python = ">=3.10,<4.0"
 scipy = "^1.10.0"
 python-dateutil = "^2.8.0"
+marshmallow = {version = "^3.20.0", optional = true}
+
+[tool.poetry.extras]
+marshmallow = ["marshmallow"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
@@ -36,6 +40,7 @@ deptry = "^0.6.4"
 pre-commit = "^2.20.0"
 tox = "^3.25.1"
 hypothesis = {version = "^6.151.9", python = ">=3.10"}
+marshmallow = "^3.20.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"

--- a/tests/ext/test_marshmallow.py
+++ b/tests/ext/test_marshmallow.py
@@ -1,0 +1,470 @@
+"""Tests for Marshmallow extension fields."""
+
+from decimal import Decimal
+
+import pytest
+from marshmallow import Schema, ValidationError
+
+from money_warp.ext.marshmallow import InterestRateField, MoneyField, RateField
+from money_warp.interest_rate import InterestRate
+from money_warp.money import Money
+from money_warp.rate import CompoundingFrequency, Rate, YearSize
+
+# ---------------------------------------------------------------------------
+# Helper schemas
+# ---------------------------------------------------------------------------
+
+
+class RawMoneySchema(Schema):
+    amount = MoneyField(representation="raw")
+
+
+class RealMoneySchema(Schema):
+    amount = MoneyField(representation="real")
+
+
+class CentsMoneySchema(Schema):
+    amount = MoneyField(representation="cents")
+
+
+class StringRateSchema(Schema):
+    rate = RateField(representation="string")
+
+
+class DictRateSchema(Schema):
+    rate = RateField(representation="dict")
+
+
+class StringInterestRateSchema(Schema):
+    rate = InterestRateField(representation="string")
+
+
+class DictInterestRateSchema(Schema):
+    rate = InterestRateField(representation="dict")
+
+
+# ===========================================================================
+# MoneyField — construction
+# ===========================================================================
+
+
+def test_money_field_invalid_representation_raises():
+    with pytest.raises(ValueError, match="Invalid representation"):
+        MoneyField(representation="unknown")
+
+
+@pytest.mark.parametrize("representation", ["raw", "real", "cents"])
+def test_money_field_valid_representation_accepted(representation):
+    field = MoneyField(representation=representation)
+    assert field.representation == representation
+
+
+# ===========================================================================
+# MoneyField — serialization
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "amount_str,expected",
+    [
+        ("100.50", "100.50"),
+        ("0", "0"),
+        ("999999999.123456789", "999999999.123456789"),
+        ("-50.25", "-50.25"),
+    ],
+)
+def test_money_field_serialize_raw(amount_str, expected):
+    result = RawMoneySchema().dump({"amount": Money(amount_str)})
+    assert result["amount"] == expected
+
+
+@pytest.mark.parametrize(
+    "amount_str,expected",
+    [
+        ("100.50", "100.50"),
+        ("100.125", "100.13"),
+        ("0.001", "0.00"),
+        ("-50.255", "-50.26"),
+    ],
+)
+def test_money_field_serialize_real(amount_str, expected):
+    result = RealMoneySchema().dump({"amount": Money(amount_str)})
+    assert result["amount"] == expected
+
+
+@pytest.mark.parametrize(
+    "amount_str,expected_cents",
+    [
+        ("100.50", 10050),
+        ("0", 0),
+        ("0.01", 1),
+        ("-25.99", -2599),
+    ],
+)
+def test_money_field_serialize_cents(amount_str, expected_cents):
+    result = CentsMoneySchema().dump({"amount": Money(amount_str)})
+    assert result["amount"] == expected_cents
+
+
+def test_money_field_serialize_none_returns_none():
+    result = RawMoneySchema().dump({"amount": None})
+    assert result["amount"] is None
+
+
+# ===========================================================================
+# MoneyField — deserialization
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "input_val,expected_raw",
+    [
+        ("100.50", Decimal("100.50")),
+        ("0", Decimal("0")),
+        ("999999999.123456789", Decimal("999999999.123456789")),
+    ],
+)
+def test_money_field_deserialize_raw(input_val, expected_raw):
+    result = RawMoneySchema().load({"amount": input_val})
+    assert result["amount"].raw_amount == expected_raw
+
+
+def test_money_field_deserialize_real():
+    result = RealMoneySchema().load({"amount": "100.50"})
+    assert result["amount"].raw_amount == Decimal("100.50")
+
+
+@pytest.mark.parametrize(
+    "cents_input,expected_real",
+    [
+        (10050, Decimal("100.50")),
+        (0, Decimal("0.00")),
+        (1, Decimal("0.01")),
+    ],
+)
+def test_money_field_deserialize_cents(cents_input, expected_real):
+    result = CentsMoneySchema().load({"amount": cents_input})
+    assert result["amount"].real_amount == expected_real
+
+
+def test_money_field_deserialize_invalid_raises():
+    with pytest.raises(ValidationError):
+        RawMoneySchema().load({"amount": "not-a-number"})
+
+
+# ===========================================================================
+# MoneyField — round-trips
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    ["100.50", "0", "999999999.123456789", "-50.25"],
+)
+def test_money_field_roundtrip_raw(amount_str):
+    original = Money(amount_str)
+    serialized = RawMoneySchema().dump({"amount": original})
+    loaded = RawMoneySchema().load(serialized)
+    assert loaded["amount"].raw_amount == original.raw_amount
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    ["100.50", "100.125", "0.001"],
+)
+def test_money_field_roundtrip_real(amount_str):
+    original = Money(amount_str)
+    serialized = RealMoneySchema().dump({"amount": original})
+    loaded = RealMoneySchema().load(serialized)
+    assert loaded["amount"].real_amount == original.real_amount
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    ["100.50", "0.01", "0"],
+)
+def test_money_field_roundtrip_cents(amount_str):
+    original = Money(amount_str)
+    serialized = CentsMoneySchema().dump({"amount": original})
+    loaded = CentsMoneySchema().load(serialized)
+    assert loaded["amount"].real_amount == original.real_amount
+
+
+# ===========================================================================
+# MoneyField — edge cases
+# ===========================================================================
+
+
+def test_money_field_zero_money():
+    result = RawMoneySchema().dump({"amount": Money.zero()})
+    assert result["amount"] == "0"
+
+
+def test_money_field_very_large_amount():
+    big = Money("99999999999.99")
+    loaded = RawMoneySchema().load(RawMoneySchema().dump({"amount": big}))
+    assert loaded["amount"].raw_amount == big.raw_amount
+
+
+# ===========================================================================
+# RateField — construction
+# ===========================================================================
+
+
+def test_rate_field_invalid_representation_raises():
+    with pytest.raises(ValueError, match="Invalid representation"):
+        RateField(representation="unknown")
+
+
+@pytest.mark.parametrize("representation", ["string", "dict"])
+def test_rate_field_valid_representation_accepted(representation):
+    field = RateField(representation=representation)
+    assert field.representation == representation
+
+
+# ===========================================================================
+# RateField — serialization (string)
+# ===========================================================================
+
+
+def test_rate_field_serialize_string():
+    rate = Rate("5.25% a")
+    result = StringRateSchema().dump({"rate": rate})
+    assert result["rate"] == "5.250% annual"
+
+
+def test_rate_field_serialize_string_monthly():
+    rate = Rate("1.5% m")
+    result = StringRateSchema().dump({"rate": rate})
+    assert result["rate"] == "1.500% monthly"
+
+
+def test_rate_field_serialize_string_negative():
+    rate = Rate("-2.5% a")
+    result = StringRateSchema().dump({"rate": rate})
+    assert result["rate"] == "-2.500% annual"
+
+
+def test_rate_field_serialize_none_returns_none():
+    result = StringRateSchema().dump({"rate": None})
+    assert result["rate"] is None
+
+
+# ===========================================================================
+# RateField — serialization (dict)
+# ===========================================================================
+
+
+def test_rate_field_serialize_dict_rate_value():
+    rate = Rate(Decimal("0.0525"), CompoundingFrequency.ANNUALLY)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["rate"] == "0.0525"
+
+
+def test_rate_field_serialize_dict_period():
+    rate = Rate(Decimal("0.015"), CompoundingFrequency.MONTHLY)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["period"] == "monthly"
+
+
+def test_rate_field_serialize_dict_year_size():
+    rate = Rate(Decimal("0.05"), CompoundingFrequency.ANNUALLY, year_size=YearSize.banker)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["year_size"] == 360
+
+
+def test_rate_field_serialize_dict_precision():
+    rate = Rate(Decimal("0.05"), CompoundingFrequency.ANNUALLY, precision=4)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["precision"] == 4
+
+
+def test_rate_field_serialize_dict_str_style():
+    rate = Rate("5.25% a.a.")
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["str_style"] == "abbrev"
+
+
+# ===========================================================================
+# RateField — deserialization (string)
+# ===========================================================================
+
+
+def test_rate_field_deserialize_string_annually():
+    result = StringRateSchema().load({"rate": "5.25% a"})
+    assert result["rate"].as_decimal == Decimal("0.0525")
+
+
+def test_rate_field_deserialize_string_monthly():
+    result = StringRateSchema().load({"rate": "1.5% monthly"})
+    assert result["rate"].period == CompoundingFrequency.MONTHLY
+
+
+def test_rate_field_deserialize_string_negative():
+    result = StringRateSchema().load({"rate": "-2.5% a"})
+    assert result["rate"].as_decimal == Decimal("-0.025")
+
+
+def test_rate_field_deserialize_string_invalid_raises():
+    with pytest.raises(ValidationError):
+        StringRateSchema().load({"rate": "not-a-rate"})
+
+
+def test_rate_field_deserialize_string_uses_field_year_size():
+    schema_class = type(
+        "S",
+        (Schema,),
+        {"rate": RateField(representation="string", year_size=YearSize.banker)},
+    )
+    result = schema_class().load({"rate": "5% a"})
+    assert result["rate"].year_size == YearSize.banker
+
+
+# ===========================================================================
+# RateField — deserialization (dict)
+# ===========================================================================
+
+
+def test_rate_field_deserialize_dict_basic():
+    data = {"rate": {"rate": "0.0525", "period": "annually"}}
+    result = DictRateSchema().load(data)
+    assert result["rate"].as_decimal == Decimal("0.0525")
+
+
+def test_rate_field_deserialize_dict_with_year_size():
+    data = {"rate": {"rate": "0.05", "period": "annually", "year_size": 360}}
+    result = DictRateSchema().load(data)
+    assert result["rate"].year_size == YearSize.banker
+
+
+def test_rate_field_deserialize_dict_with_precision():
+    data = {"rate": {"rate": "0.05", "period": "annually", "precision": 4}}
+    result = DictRateSchema().load(data)
+    assert result["rate"]._precision == 4
+
+
+def test_rate_field_deserialize_dict_with_str_style():
+    data = {"rate": {"rate": "0.05", "period": "annually", "str_style": "abbrev"}}
+    result = DictRateSchema().load(data)
+    assert str(result["rate"]) == "5.000% a.a."
+
+
+def test_rate_field_deserialize_dict_missing_rate_raises():
+    with pytest.raises(ValidationError, match="'rate' and 'period'"):
+        DictRateSchema().load({"rate": {"period": "annually"}})
+
+
+def test_rate_field_deserialize_dict_missing_period_raises():
+    with pytest.raises(ValidationError, match="'rate' and 'period'"):
+        DictRateSchema().load({"rate": {"rate": "0.05"}})
+
+
+def test_rate_field_deserialize_dict_not_dict_raises():
+    with pytest.raises(ValidationError, match="'rate' and 'period'"):
+        DictRateSchema().load({"rate": "not-a-dict"})
+
+
+def test_rate_field_deserialize_dict_invalid_period_raises():
+    with pytest.raises(ValidationError, match="'rate' and 'period'"):
+        DictRateSchema().load({"rate": {"rate": "0.05", "period": "biweekly"}})
+
+
+# ===========================================================================
+# RateField — round-trips
+# ===========================================================================
+
+
+def test_rate_field_roundtrip_string():
+    original = Rate("5.25% a")
+    serialized = StringRateSchema().dump({"rate": original})
+    loaded = StringRateSchema().load(serialized)
+    assert loaded["rate"] == original
+
+
+def test_rate_field_roundtrip_dict():
+    original = Rate(Decimal("0.0525"), CompoundingFrequency.ANNUALLY)
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert loaded["rate"] == original
+
+
+def test_rate_field_roundtrip_dict_with_all_params():
+    original = Rate(
+        Decimal("0.015"),
+        CompoundingFrequency.MONTHLY,
+        precision=6,
+        year_size=YearSize.banker,
+        str_style="abbrev",
+    )
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert loaded["rate"] == original
+
+
+def test_rate_field_roundtrip_dict_negative():
+    original = Rate(Decimal("-0.025"), CompoundingFrequency.ANNUALLY)
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert loaded["rate"] == original
+
+
+# ===========================================================================
+# InterestRateField — serialization
+# ===========================================================================
+
+
+def test_interest_rate_field_serialize_string():
+    rate = InterestRate("5.25% a")
+    result = StringInterestRateSchema().dump({"rate": rate})
+    assert result["rate"] == "5.250% annual"
+
+
+def test_interest_rate_field_serialize_dict_rate_value():
+    rate = InterestRate(Decimal("0.0525"), CompoundingFrequency.ANNUALLY)
+    result = DictInterestRateSchema().dump({"rate": rate})
+    assert result["rate"]["rate"] == "0.0525"
+
+
+# ===========================================================================
+# InterestRateField — deserialization
+# ===========================================================================
+
+
+def test_interest_rate_field_deserialize_string():
+    result = StringInterestRateSchema().load({"rate": "5.25% a"})
+    assert isinstance(result["rate"], InterestRate)
+
+
+def test_interest_rate_field_deserialize_dict():
+    data = {"rate": {"rate": "0.0525", "period": "annually"}}
+    result = DictInterestRateSchema().load(data)
+    assert isinstance(result["rate"], InterestRate)
+
+
+def test_interest_rate_field_deserialize_string_negative_raises():
+    with pytest.raises(ValidationError):
+        StringInterestRateSchema().load({"rate": "-2.5% a"})
+
+
+def test_interest_rate_field_deserialize_dict_negative_raises():
+    with pytest.raises(ValidationError):
+        DictInterestRateSchema().load({"rate": {"rate": "-0.025", "period": "annually"}})
+
+
+# ===========================================================================
+# InterestRateField — round-trips
+# ===========================================================================
+
+
+def test_interest_rate_field_roundtrip_string():
+    original = InterestRate("5.25% a")
+    serialized = StringInterestRateSchema().dump({"rate": original})
+    loaded = StringInterestRateSchema().load(serialized)
+    assert loaded["rate"] == original
+
+
+def test_interest_rate_field_roundtrip_dict():
+    original = InterestRate(Decimal("0.0525"), CompoundingFrequency.ANNUALLY)
+    serialized = DictInterestRateSchema().dump({"rate": original})
+    loaded = DictInterestRateSchema().load(serialized)
+    assert loaded["rate"] == original


### PR DESCRIPTION
## Summary
- Add `money_warp/ext/marshmallow.py` with custom Marshmallow fields (`MoneyField`, `RateField`, `InterestRateField`) for serializing/deserializing money-warp types
- Marshmallow is an optional dependency installable via `pip install money-warp[marshmallow]`
- Each field supports configurable representations (e.g. raw/real/cents for Money, string/dict for Rate)

## Changes
- `pyproject.toml`: marshmallow added as optional main dependency with `[marshmallow]` extras group, plus dev dependency for testing
- `money_warp/ext/__init__.py`: new package for third-party integrations
- `money_warp/ext/marshmallow.py`: `MoneyField` (raw/real/cents), `RateField` (string/dict), `InterestRateField` (inherits RateField, rejects negatives)
- `tests/ext/test_marshmallow.py`: 74 tests covering serialization, deserialization, round-trips, edge cases, and error handling
- `knowledge/ext.md`: AI-facing documentation for the extension
- `README.md`: feature bullet, install instructions, usage example

## Test plan
- [x] All 998 existing tests pass (`poetry run pytest`)
- [x] 74 new tests for marshmallow fields pass
- [ ] Verify `pip install money-warp[marshmallow]` installs marshmallow
- [ ] Verify `from money_warp.ext.marshmallow import MoneyField` works with marshmallow installed
- [ ] Verify importing without marshmallow installed raises clear `ImportError`

## Docs
- `README.md` updated with install instructions and usage example
- `knowledge/ext.md` created with design decisions and API surface


Made with [Cursor](https://cursor.com)