### PR TITLE
docs: align test rules across quality.mdc, QA skill, and development.mdc

### DIFF
--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -148,7 +148,7 @@ pip install package_name
 ### Test Quality
 - **Test coverage**: Aim for >90% coverage
 - **Test types**: Unit tests, integration tests, end-to-end tests
-- **Mock external dependencies**: Use `unittest.mock` or `pytest-mock`
+- **Avoid mocks unless absolutely necessary**: Prefer real objects. See `quality.mdc` for details.
 - **Test data**: Use fixtures for reusable test data
 
 ### Prefer Fixtures Over Helper Functions ⭐

--- a/.cursor/rules/quality.mdc
+++ b/.cursor/rules/quality.mdc
@@ -14,11 +14,13 @@ This document defines the testing patterns and rules for the **money-warp** proj
 - **Use**: Individual test functions with descriptive names
 - **Reason**: Tests are deterministic and don't need object-oriented structure
 
-### 2. Single Assert Per Test ⭐
-**Each test function should have exactly ONE assert statement.**
+### 2. Single Concept Per Test ⭐
+**Each test function should test exactly ONE concept.**
 
-- **Good**: `def test_money_addition_basic(): assert money1 + money2 == expected`
-- **Bad**: Multiple asserts testing different aspects in one function
+Multiple asserts on the same result object are acceptable when they verify different facets of the same logical outcome (e.g., asserting each field of an allocation). Avoid combining unrelated assertions in a single test.
+
+- **Good**: Several asserts verifying fields of a single settlement allocation
+- **Bad**: One test that checks money creation *and* money arithmetic
 - **Reason**: Clear failure identification and focused test purpose
 
 ### 3. Parametrized Tests for Multiple Cases ⭐
@@ -114,6 +116,22 @@ def test_money_multiplication_by_integer():
 def test_money_equality_same_amounts():
 def test_money_less_than_comparison():
 ```
+
+### 8. No Mocks Unless Absolutely Necessary ⭐
+**Test with real objects and real behavior. Avoid mocks.**
+
+Only reach for `unittest.mock` or `pytest-mock` when the dependency is truly external (network, filesystem, third-party service) and cannot be replaced with a simpler in-memory alternative. Never mock domain objects like `Money`, `Loan`, or `InterestRate`.
+
+- **Bad**: `mock_loan = Mock(spec=Loan)` — hides real behavior
+- **Good**: `loan = Loan(...)` — test the actual object
+- **Reason**: Mocks couple tests to implementation details and hide bugs in the mocked layer
+
+### 9. Prefer Fixtures Over Helper Functions ⭐
+**When test setup logic is reused across multiple tests, express it as a `@pytest.fixture` — not a plain helper function.**
+
+- **Bad**: `def _build_thing(): ...` called directly in each test
+- **Good**: `@pytest.fixture def thing(): ...` injected by pytest
+- **Reason**: Fixtures are composable, cacheable (via `scope`), and visible to pytest introspection. Helper functions hide dependencies and bypass fixture teardown.
 
 ## Testing Patterns
 
@@ -233,14 +251,14 @@ class TestMoney:
         pass
 ```
 
-### 2. ❌ Multiple Asserts
+### 2. ❌ Unrelated Assertions in One Test
 ```python
-# DON'T DO THIS
-def test_money_properties():
+# DON'T DO THIS — tests two unrelated concepts
+def test_money_properties_and_arithmetic():
     money = Money("100.50")
-    assert money.real_amount == Decimal("100.50")  # Multiple asserts
-    assert money.cents == 10050
-    assert money.is_positive()
+    assert money.real_amount == Decimal("100.50")  # Concept 1: creation
+    result = money + Money("50.00")
+    assert result.real_amount == Decimal("150.50")  # Concept 2: addition
 ```
 
 ### 3. ❌ Conditional Logic

--- a/.cursor/skills/quality-assurance/SKILL.md
+++ b/.cursor/skills/quality-assurance/SKILL.md
@@ -31,9 +31,8 @@ These rules apply regardless of the chosen mode:
 - `scipy.optimize` for root-finding and numerical solving (never hand-rolled loops)
 - Type hints on all functions and classes
 - Code formatting: Black, isort, Ruff
-- Test patterns from `test-patterns.mdc`: function-based tests, single assert, parametrize, exact values
+- Test patterns from `quality.mdc`: function-based tests, single concept per test, parametrize, exact values, no mocks, fixtures over helpers
 - No imports inside functions or methods
-- No mocks unless absolutely necessary
 - Docstrings on public API
 
 ### Workflow-Only (skipped in quick mode)
@@ -100,13 +99,15 @@ If you wrote any root-finding or convergence logic, verify it uses `scipy.optimi
 
 ### C6. Test quality
 
-If you wrote or modified tests, verify they follow `test-patterns.mdc`:
+If you wrote or modified tests, verify they follow `quality.mdc`:
 - Function-based (no class-based test cases)
-- Single assert per test function
+- Single concept per test (multiple asserts on the same result are fine)
 - Parametrized for multiple input/output combinations
 - Assert exact literal values, not computed results
 - No conditional logic or loops inside tests
 - Descriptive names: `test_[component]_[action]_[scenario]`
+- No mocks unless absolutely necessary
+- Prefer fixtures over helper functions
 
 ### C7. Knowledge and docs (full workflow mode only)
 
@@ -131,10 +132,12 @@ When reviewing code changes (your own or when the user asks for a review), check
 ### D2. Test quality
 
 - No class-based test cases (`class TestX:` is forbidden)
-- One assert per test function
+- Single concept per test (multiple asserts on the same result are fine)
 - `pytest.mark.parametrize` for multiple scenarios
 - Exact literal values in assertions (no calculations in tests)
-- No mocks unless truly necessary
+- No conditional logic or loops inside tests
+- Descriptive names: `test_[component]_[action]_[scenario]`
+- No mocks unless absolutely necessary
 - Fixtures for reusable setup (not helper functions)
 
 ### D3. Common mistakes to catch


### PR DESCRIPTION
## Summary
- Resolve contradictions between `quality.mdc` (formerly `test-patterns.mdc`), `quality-assurance/SKILL.md`, and `development.mdc` so all three documents tell a consistent story about test rules.

## Changes
- Relax "single assert per test" to "single concept per test" — multiple asserts on the same result are explicitly allowed
- Add two new rules to `quality.mdc`: "no mocks unless absolutely necessary" and "prefer fixtures over helpers"
- Fix `development.mdc` mock contradiction (was encouraging mocks, now aligned with "avoid mocks" stance)
- Update QA skill checklists (C6, D2, Always Enforced) to mirror the full rule set in `quality.mdc`
- Remove redundant standalone "no mocks" bullet in QA skill (already covered by test-patterns summary)
- Rename `test-patterns.mdc` to `quality.mdc`

## Test plan
- [ ] No code changes — documentation only, no tests affected
- [ ] Verify all cross-references resolve (`quality.mdc` mentioned in `development.mdc` and `SKILL.md`)

## Docs
- `quality.mdc`, `development.mdc`, and `quality-assurance/SKILL.md` updated as described above

Made with [Cursor](https://cursor.com)