### PR TITLE
feat: support all rate periods in SQL balance_at expression

### DIFF
--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -133,7 +133,7 @@ The SQL side of `balance_at` uses nested CTEs (`nesting=True`) inside a single s
 | CTE | Purpose |
 |-----|---------|
 | `loan_state` | `COALESCE(last_remaining_balance, principal)` and `COALESCE(last_payment_date, disbursement_date)`. Uses scalar subqueries so it always returns 1 row even with no settlements. |
-| `daily_rates` | Converts annual rates to daily: `pow(1 + annual_rate, 1/year_size) - 1`. NULL mora rate coalesces to 0. |
+| `daily_rates` | Converts rates of any period to daily via `_daily_rate_expr`. Handles all `CompoundingFrequency` values (annual, monthly, quarterly, semi-annual, daily, continuous). NULL mora rate coalesces to 0. |
 | `time_split` | Computes `total_days` and finds `next_due` date after last payment via `json_each(due_dates)`. |
 | `day_split` | Splits total days into `regular_days` and `mora_days` at the next-due boundary. |
 | `accrued` | `regular_interest` (compound on principal) and `mora_interest` (COMPOUND or SIMPLE branching via `mora_strategy`). |
@@ -141,6 +141,15 @@ The SQL side of `balance_at` uses nested CTEs (`nesting=True`) inside a single s
 | Final SELECT | `principal_balance + regular_interest + mora_interest + fines`. |
 
 NULL guard: `CASE WHEN json_extract(interest_rate, '$.rate') IS NULL` falls back to the simple `COALESCE(remaining_balance, principal)` since SQL cannot raise exceptions.
+
+### Rate conversion helpers
+
+Two private helpers in `bridge.py` convert JSON-stored rates to daily rates in SQL, mirroring `Rate._to_effective_annual()` and `Rate.to_daily()`:
+
+- **`_effective_annual_expr(rate_col)`**: Extracts `$.rate`, `$.period`, and `$.year_size` from the JSON column. Returns a SQL `CASE` expression that converts the stored rate to an effective annual rate based on the period (`annually`, `monthly`, `quarterly`, `semi_annually`, `daily`, `continuous`). Falls back to treating the rate as annual for unknown period values.
+- **`_daily_rate_expr(rate_col)`**: Returns the stored rate directly when period is `daily`; otherwise converts through the effective annual rate: `pow(1 + eff_annual, 1/year_size) - 1`.
+
+Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` which requires the SQLite math extension (available in Python 3.11+ / SQLite 3.35+).
 
 ## Design Decisions
 
@@ -168,3 +177,4 @@ NULL guard: `CASE WHEN json_extract(interest_rate, '$.rate') IS NULL` falls back
 - **SQL vs Python precision:** The SQL CTE expression uses float64 arithmetic while Python uses `Decimal`. For exact comparisons in tests, use approximate matching (e.g., `pytest.approx`) when comparing SQL results against Python `balance_at`.
 - **JSON NULL vs SQL NULL:** SQLAlchemy's `JSON` type stores Python `None` as the string `'null'` rather than SQL `NULL`. The NULL guard checks `json_extract(interest_rate, '$.rate') IS NULL` which correctly handles both cases since `json_extract('null', '$.rate')` returns NULL.
 - **Mora rate NULL handling:** When `mora_interest_rate` is NULL, `json_extract(NULL, '$.rate')` cascades NULL through `pow()`. The `daily_rates` CTE coalesces the mora daily rate to 0.0 to prevent this from nullifying the entire expression.
+- **Period-aware SQL rate conversion:** The SQL CTE handles all `CompoundingFrequency` periods (annual, monthly, quarterly, semi-annual, daily, continuous). This only applies to the `json` representation. The `string` representation triggers the NULL-rate fallback (simple balance) since `json_extract` on a plain string returns NULL for `$.rate`.

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -179,6 +179,49 @@ def _load_money_warp_loan_impl(self):
 
 
 # ---------------------------------------------------------------------------
+# SQL helpers — rate conversion
+# ---------------------------------------------------------------------------
+
+
+def _effective_annual_expr(rate_col):
+    """SQL CASE converting any stored JSON rate to an effective annual rate.
+
+    Mirrors :meth:`Rate._to_effective_annual` for all
+    :class:`CompoundingFrequency` values stored in the JSON ``period`` field.
+    """
+    rate = cast(func.json_extract(rate_col, "$.rate"), Float)
+    period = func.json_extract(rate_col, "$.period")
+    year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
+
+    return case(
+        (period == "annually", rate),
+        (period == "monthly", func.pow(1.0 + rate, 12.0) - 1.0),
+        (period == "quarterly", func.pow(1.0 + rate, 4.0) - 1.0),
+        (period == "semi_annually", func.pow(1.0 + rate, 2.0) - 1.0),
+        (period == "daily", func.pow(1.0 + rate, year_size) - 1.0),
+        (period == "continuous", func.exp(rate) - 1.0),
+        else_=rate,
+    )
+
+
+def _daily_rate_expr(rate_col):
+    """SQL expression for the daily rate derived from a JSON-stored rate.
+
+    Returns the stored rate directly when the period is already daily;
+    otherwise converts through the effective annual rate.
+    """
+    rate = cast(func.json_extract(rate_col, "$.rate"), Float)
+    period = func.json_extract(rate_col, "$.period")
+    year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
+    eff_annual = _effective_annual_expr(rate_col)
+
+    return case(
+        (period == "daily", rate),
+        else_=func.pow(1.0 + eff_annual, 1.0 / year_size) - 1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
 # SQL expression (CTE-based)
 # ---------------------------------------------------------------------------
 
@@ -233,15 +276,10 @@ def _build_sql_balance_expression(cls, as_of, meta):
     )
 
     # -- CTE 3: daily_rates ------------------------------------------------
-    annual_rate = cast(func.json_extract(ir_col, "$.rate"), Float)
-    year_size = cast(func.json_extract(ir_col, "$.year_size"), Float)
-    mora_annual = cast(func.json_extract(mir_col, "$.rate"), Float)
-    mora_ys = cast(func.json_extract(mir_col, "$.year_size"), Float)
-
     daily_rates = (
         select(
-            (func.pow(1.0 + annual_rate, 1.0 / year_size) - 1.0).label("daily_rate"),
-            func.coalesce(func.pow(1.0 + mora_annual, 1.0 / mora_ys) - 1.0, 0.0).label("mora_daily_rate"),
+            _daily_rate_expr(ir_col).label("daily_rate"),
+            func.coalesce(_daily_rate_expr(mir_col), 0.0).label("mora_daily_rate"),
         )
         .correlate(cls)
         .cte("daily_rates", nesting=True)

--- a/tests/ext/sa/test_sa_integration.py
+++ b/tests/ext/sa/test_sa_integration.py
@@ -160,3 +160,64 @@ def test_balance_at_sql_matches_python(session, warp_to):
     sql_result = session.execute(select(LoanRecord.balance_at(warp_to)).where(LoanRecord.id == sa_loan.id)).scalar()
 
     assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+# ===========================================================================
+# balance_at(date) — SQL side with various rate periods
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rate_str",
+    [
+        "10% a",
+        "1% m",
+        "3% q",
+        "5% s",
+        "0.03% d",
+    ],
+    ids=["annual", "monthly", "quarterly", "semi_annual", "daily"],
+)
+def test_balance_at_sql_matches_python_various_interest_rate_periods(session, rate_str):
+    """SQL CTE correctly converts non-annual interest rates to daily."""
+    sa_loan = LoanRecordFactory(interest_rate=InterestRate(rate_str))
+    session.expire_all()
+    loaded = session.get(LoanRecord, sa_loan.id)
+
+    as_of = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(select(LoanRecord.balance_at(as_of)).where(LoanRecord.id == sa_loan.id)).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "mora_rate_str",
+    [
+        "12% a",
+        "1% m",
+        "3% q",
+    ],
+    ids=["annual", "monthly", "quarterly"],
+)
+def test_balance_at_sql_matches_python_various_mora_rate_periods(session, mora_rate_str):
+    """SQL CTE correctly converts non-annual mora interest rates to daily."""
+    sa_loan = LoanRecordFactory(
+        interest_rate=InterestRate("6% a"),
+        mora_interest_rate=InterestRate(mora_rate_str),
+        mora_strategy="COMPOUND",
+        fine_rate=Decimal("0.02"),
+        grace_period_days=0,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        due_dates=[d.isoformat() for d in _LATE_PAYMENT_DUE_DATES],
+    )
+    session.expire_all()
+    loaded = session.get(LoanRecord, sa_loan.id)
+
+    as_of = datetime(2025, 3, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(select(LoanRecord.balance_at(as_of)).where(LoanRecord.id == sa_loan.id)).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)


### PR DESCRIPTION
## Summary
- The SQL CTE in `bridge.py` previously assumed all stored rates were annual, ignoring the `$.period` field in the JSON column. Non-annual rates (monthly, quarterly, daily, semi-annual, continuous) produced incorrect daily rates in the SQL `balance_at` expression.
- Added `_effective_annual_expr` and `_daily_rate_expr` helpers that read `$.period` and apply the correct conversion formula for each `CompoundingFrequency` before computing the daily rate.
- Python-side `balance_at` was already correct (it reconstructs the full `InterestRate` object via `_from_dict`). Only the SQL CTE path was affected.

## Changes
- `money_warp/ext/sa/bridge.py`: Added `_effective_annual_expr(rate_col)` and `_daily_rate_expr(rate_col)` helper functions. Replaced hardcoded annual-rate extraction in CTE 3 with calls to these helpers for both `ir_col` and `mir_col`.
- `tests/ext/sa/test_sa_integration.py`: Added 8 parametrized tests verifying SQL `balance_at` matches Python `balance_at` for annual, monthly, quarterly, semi-annual, and daily interest rate periods, plus annual/monthly/quarterly mora rate periods.
- `knowledge/ext.md`: Documented rate conversion helpers and period-aware behavior.

## Test plan
- [x] All existing tests pass (`poetry run pytest` -- 1264 passed, 5 xfailed)
- [x] New tests cover annual, monthly, quarterly, semi-annual, and daily interest rate periods
- [x] New tests cover annual, monthly, and quarterly mora interest rate periods
- [x] SQL balance matches Python balance for all tested periods (within float precision)

## Docs
- Updated `knowledge/ext.md` with rate conversion helper documentation and period-aware gotcha

Made with [Cursor](https://cursor.com)