### PR TITLE
Data-driven rate SQL bridge with string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoneyWarp 💰⏰
+# MoneyWarp
 
 **Bend time. Model cash.**
 
@@ -7,658 +7,107 @@
 [![codecov](https://codecov.io/gh/tomascorrea/money-warp/branch/main/graph/badge.svg)](https://codecov.io/gh/tomascorrea/money-warp)
 [![License](https://img.shields.io/github/license/tomascorrea/money-warp)](https://img.shields.io/github/license/tomascorrea/money-warp)
 
-> **⚠️ Development Stage Notice**
-> 
-> MoneyWarp is currently in active development and should be considered **alpha/pre-release software**. While the core functionality is implemented and tested, the API may change between versions. Use in production environments at your own risk.
->
-> - ✅ Core classes (`Money`, `InterestRate`, `CashFlow`, `Loan`) are stable
-> - ✅ Comprehensive test suite with 830+ tests
-> - ⚠️ API may evolve based on user feedback
-> - ✅ Published to PyPI
-> - 🚧 Additional features and schedulers in development
+> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 1200+ tests, but the API may evolve.
 
-MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as simple cash flows through time — and gives you the tools to warp them back and forth between present, future, and everything in between.
+MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as cash flows through time -- and gives you the tools to warp them back and forth between present, future, and everything in between.
 
-## 🚀 Features
+## Features
 
-- 🕰️ **Time Machine (Warp)** - Travel to any date and see loan state as of that moment
-- 🔢 **Calculate PMT, NPV, IRR, MIRR** and other core finance functions with scipy
-- ⏳ **Track loans and repayments** as evolving cash-flow streams  
-- 🌀 **Explore "what if" timelines** by bending payments across time
-- 💰 **High-precision calculations** using Decimal arithmetic
-- 📊 **Progressive Price Schedules** (French amortization system)
-- 📈 **Inverted Price Schedules** (Constant Amortization System - SAC)
-- 🎯 **Flexible payment scheduling** with irregular due dates
-- 📅 **Easy date generation** with smart month-end handling via python-dateutil
-- 🔒 **Type-safe interest rates** with explicit percentage handling
-- 🧮 **Robust numerics** powered by scipy for IRR and financial calculations
-- ⚖️ **Fine engine** with fines, mora interest, and configurable grace periods
-- 🍭 **Sugar payment methods** — `pay_installment()` and `anticipate_payment()` for natural workflows
-- 📋 **Installments & Settlements** — first-class views of the repayment plan and payment allocation
-- 🇧🇷 **Tax module** — Brazilian IOF with pluggable tax strategy, grossup, and preset rates
-- 🌐 **Timezone-aware** — all datetimes are UTC by default, configurable globally
-- 🔌 **Marshmallow extension** — custom fields for `Money`, `Rate`, and `InterestRate` serialization
-- 🗄️ **SQLAlchemy extension** — column types for `Money`, `Rate`, `InterestRate` + loan/settlement bridge decorators
+- **Time Machine (Warp)** -- travel to any date and see loan state as of that moment
+- **PMT, NPV, IRR, MIRR** -- core finance functions powered by scipy
+- **Loan tracking** -- payments, fines, mora interest, grace periods
+- **High-precision Money** -- Decimal arithmetic, never floats
+- **Amortization schedules** -- French (Price) and SAC (Inverted Price)
+- **Flexible dates** -- irregular due dates, smart month-end handling
+- **Type-safe interest rates** -- explicit percentage handling, frequency conversions
+- **Installments and Settlements** -- first-class repayment plan and payment allocation
+- **Tax module** -- Brazilian IOF, grossup, pluggable tax strategy
+- **Timezone-aware** -- UTC by default, configurable globally
+- **Marshmallow extension** -- custom fields for serialization
+- **SQLAlchemy extension** -- column types + loan/settlement bridge with SQL-queryable balance
 
-## 📦 Installation
+## Installation
 
 ```bash
 pip install money-warp
 ```
 
-Or with Poetry:
+With optional extensions:
 
 ```bash
-poetry add money-warp
+pip install money-warp[marshmallow]   # Marshmallow fields
+pip install money-warp[sa]            # SQLAlchemy types + bridge
 ```
 
-### Marshmallow Extension
-
-To use the Marshmallow custom fields for `Money`, `Rate`, and `InterestRate`:
-
-```bash
-pip install money-warp[marshmallow]
-```
-
-### SQLAlchemy Extension
-
-To use the SQLAlchemy column types and bridge decorators:
-
-```bash
-pip install money-warp[sa]
-```
-
-## 🎯 Quick Start
-
-### Basic Loan Analysis
+## Quick Start
 
 ```python
 from datetime import datetime, timezone
 from money_warp import Money, InterestRate, Loan, generate_monthly_dates
 
-# Create a $10,000 loan at 5% annual interest
 principal = Money("10000.00")
 rate = InterestRate("5% a")  # 5% annually
 
-# Generate monthly payment dates easily
-# Naive datetimes work too — they're silently coerced to the configured timezone (UTC)
 start_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
 due_dates = generate_monthly_dates(start_date, 12)
 
-# Generate the loan
 loan = Loan(principal, rate, due_dates)
 
-# Get the payment schedule
 schedule = loan.get_amortization_schedule()
 print(f"Monthly payment: {schedule[0].payment_amount}")
 print(f"Total interest: {schedule.total_interest}")
 
-# Track actual payments
 loan.record_payment(Money("856.07"), datetime(2024, 2, 1, tzinfo=timezone.utc))
 print(f"Remaining balance: {loan.current_balance}")
 ```
 
-### Installments & Settlements
+## Time Machine
 
-```python
-from money_warp import Loan, Money, InterestRate, generate_monthly_dates
-from datetime import datetime
-
-loan = Loan(
-    Money("10000"),
-    InterestRate("6% a"),
-    generate_monthly_dates(datetime(2025, 2, 1), 3),
-    disbursement_date=datetime(2025, 1, 1),
-)
-
-# Installments are the repayment plan — a consequence of the loan
-for inst in loan.installments:
-    print(f"#{inst.number} due {inst.due_date.date()}: "
-          f"{inst.expected_payment} (principal: {inst.expected_principal}, "
-          f"interest: {inst.expected_interest}) — paid: {inst.is_fully_paid}")
-
-# Payments return a Settlement showing how money was allocated
-schedule = loan.get_original_schedule()
-settlement = loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
-print(f"Principal paid: {settlement.principal_paid}")
-print(f"Interest paid: {settlement.interest_paid}")
-print(f"Remaining balance: {settlement.remaining_balance}")
-
-# Settlements show per-installment detail
-for alloc in settlement.allocations:
-    print(f"  Installment #{alloc.installment_number}: "
-          f"principal={alloc.principal_allocated}, covered={alloc.is_fully_covered}")
-
-# After payment, installments reflect what happened
-inst = loan.installments[0]
-print(f"Installment #1 paid: {inst.is_fully_paid}, principal_paid: {inst.principal_paid}")
-```
-
-### Cash Flow Analysis
-
-```python
-from money_warp import CashFlow, CashFlowItem, Money
-from datetime import datetime
-
-# Create cash flow items
-items = [
-    CashFlowItem(Money("1000.00"), datetime(2024, 1, 1), "Initial deposit", "deposit"),
-    CashFlowItem(Money("-50.00"), datetime(2024, 2, 1), "Monthly fee", "fee"),
-    CashFlowItem(Money("200.00"), datetime(2024, 3, 1), "Interest payment", "interest"),
-]
-
-# Analyze the cash flow
-cash_flow = CashFlow(items)
-print(f"Net cash flow: {cash_flow.net_present_value()}")
-print(f"Total deposits: {cash_flow.query.filter_by(category='deposit').sum_amounts()}")
-
-# Filter by date range
-recent = cash_flow.query.filter_by(datetime__gte=datetime(2024, 2, 1))
-print(f"Recent activity: {recent.sum_amounts()}")
-```
-
-### High-Precision Money Handling
-
-```python
-from money_warp import Money
-from decimal import Decimal
-
-# Create money with high internal precision
-money = Money("100.123456789")
-print(f"Internal precision: {money.raw_amount}")      # 100.123456789
-print(f"Real money (2 decimals): {money.real_amount}") # 100.12
-print(f"Display: {money}")                            # 100.12
-
-# Arithmetic maintains precision internally
-result = money * 3 / 7
-print(f"Calculation result: {result}")  # Precise to 2 decimals for display
-```
-
-### Time Machine - Warp to Any Date 🕰️
-
-**Core Philosophy:** *The loan is always time sensitive... it always filters based on present date regardless if it is warped or not... the warp just changes the present date.*
+Travel to any date and see the loan exactly as it was -- payments, interest, fines, everything filtered to that moment:
 
 ```python
 from money_warp import Warp, Loan, Money, InterestRate
 from datetime import datetime
 
-# Create a loan and make some payments
 loan = Loan(Money("10000"), InterestRate("5% a"), [datetime(2024, 1, 15)])
-loan.record_payment(Money("500"), datetime(2024, 1, 10), "Payment 1")
-loan.record_payment(Money("600"), datetime(2024, 2, 10), "Payment 2") 
-loan.record_payment(Money("700"), datetime(2024, 3, 10), "Payment 3")
+loan.record_payment(Money("500"), datetime(2024, 1, 10))
+loan.record_payment(Money("600"), datetime(2024, 2, 10))
+loan.record_payment(Money("700"), datetime(2024, 3, 10))
 
-print(f"Current balance: {loan.current_balance}")  # All payments applied
-
-# Warp to the past - only see payments made by that date
+# Warp to the past -- only payments made by that date are visible
 with Warp(loan, datetime(2024, 1, 20)) as past_loan:
-    print(f"Balance on Jan 20: {past_loan.current_balance}")  # Only first payment
-    print(f"Payments made: {len(past_loan._actual_payments)}")  # 2 items (interest + principal)
+    print(f"Balance on Jan 20: {past_loan.current_balance}")
 
-# Warp to the future - see all payments up to that date  
+# Warp to the future
 with Warp(loan, datetime(2025, 1, 1)) as future_loan:
-    print(f"Balance in future: {future_loan.current_balance}")  # All payments applied
-    print(f"Days since last payment: {future_loan.days_since_last_payment()}")  # From warped date
+    print(f"Balance in 2025: {future_loan.current_balance}")
 
-# Original loan unchanged
-print(f"Back to present: {loan.current_balance}")
+# Original loan is unchanged
+print(f"Present balance: {loan.current_balance}")
 ```
 
-**Key Features:**
-- 🕰️ **Natural time filtering**: Loans automatically show state as of any date
-- 🔄 **Safe cloning**: Original loan never modified during time travel
-- 📅 **Flexible date formats**: Accepts strings, datetime objects, or date objects
-- 🚫 **No nested warps**: Prevents dangerous time paradoxes
-- ⚡ **Instant calculations**: Balance and payment history update automatically
-
-### Interest Rate Conversions
-
-```python
-from money_warp import InterestRate, CompoundingFrequency, YearSize
-
-# Create rates with explicit formats
-annual_rate = InterestRate("5.25% a")     # 5.25% annually  
-monthly_rate = InterestRate("0.4167% m")  # 0.4167% monthly
-daily_rate = InterestRate("3% d")         # 3% daily (extreme example)
-
-# Convert between frequencies
-print(f"Annual: {annual_rate}")
-print(f"As monthly: {annual_rate.to_monthly()}")
-print(f"As daily: {annual_rate.to_daily()}")
-
-# Safe decimal/percentage handling
-print(f"As decimal: {annual_rate.as_decimal}")      # 0.0525
-print(f"As percentage: {annual_rate.as_percentage}") # 5.25
-
-# Abbreviated notation (Brazilian/LatAm convention)
-rate = InterestRate("5.25% a.a.")   # parsed as 5.25% annually
-print(rate)                         # "5.250% a.a." — round-trips automatically
-
-# Or set the style explicitly on numeric rates
-rate = InterestRate(1.5, CompoundingFrequency.MONTHLY, as_percentage=True, str_style="abbrev")
-print(rate)                         # "1.500% a.m."
-
-# Day-count convention: commercial (365 days, default) or banker (360 days)
-commercial = InterestRate("10% a", year_size=YearSize.commercial)
-banker = InterestRate("10% a", year_size=YearSize.banker)
-print(f"Commercial daily: {commercial.to_daily()}")  # 365-day year
-print(f"Banker daily: {banker.to_daily()}")          # 360-day year — slightly higher
-```
-
-### Marshmallow Extension 🔌
-
-```python
-from marshmallow import Schema
-from money_warp import Money, InterestRate
-from money_warp.ext.marshmallow import MoneyField, InterestRateField
-
-class LoanSchema(Schema):
-    principal = MoneyField(representation="raw")     # "10000.00"
-    rate = InterestRateField(representation="string") # "5.250% annual"
-
-schema = LoanSchema()
-
-# Serialize
-data = schema.dump({"principal": Money("10000"), "rate": InterestRate("5.25% a")})
-# {"principal": "10000", "rate": "5.250% annual"}
-
-# Deserialize
-result = schema.load(data)
-# {"principal": Money(10000), "rate": InterestRate(5.25% annually)}
-```
-
-**Available fields:**
-- **MoneyField**: representations `"raw"` (default), `"real"`, `"cents"`
-- **RateField**: representations `"string"` (default), `"dict"`
-- **InterestRateField**: same as RateField, but rejects negative rates
-
-### SQLAlchemy Extension 🗄️
-
-```python
-from datetime import datetime
-from decimal import Decimal
-from sqlalchemy import Column, Integer, DateTime, JSON, ForeignKey, create_engine, select
-from sqlalchemy.orm import DeclarativeBase, Session, relationship
-from money_warp import Money, InterestRate
-from money_warp.ext.sa import MoneyType, InterestRateType, settlement_bridge, loan_bridge
-
-class Base(DeclarativeBase):
-    pass
-
-# Mark settlement model with column metadata
-@settlement_bridge()
-class SettlementRecord(Base):
-    __tablename__ = "settlements"
-    id = Column(Integer, primary_key=True)
-    loan_id = Column(Integer, ForeignKey("loans.id"))
-    amount = Column(MoneyType())                  # stores raw_amount as Numeric
-    payment_date = Column(DateTime)
-    remaining_balance = Column(MoneyType())        # balance after this settlement
-
-# Add SQL-queryable balance hybrid_property
-@loan_bridge(principal="principal", settlements="settlements")
-class LoanRecord(Base):
-    __tablename__ = "loans"
-    id = Column(Integer, primary_key=True)
-    principal = Column(MoneyType())
-    interest_rate = Column(InterestRateType(representation="json"))
-    disbursement_date = Column(DateTime)
-    due_dates = Column(JSON)
-    settlements = relationship("SettlementRecord", order_by="SettlementRecord.payment_date")
-
-# Instance access returns Money
-loan = session.get(LoanRecord, 1)
-loan.balance  # -> Money("8500.00") from last settlement
-
-# SQL queries work too
-high_balance = session.execute(
-    select(LoanRecord).where(LoanRecord.balance > Decimal("5000"))
-).scalars().all()
-```
-
-**Available types:**
-- **MoneyType**: representations `"raw"` (default), `"real"`, `"cents"`
-- **RateType**: representations `"string"` (default), `"json"`
-- **InterestRateType**: same as RateType, but rejects negative rates
-
-**Bridge decorators:**
-- **@settlement_bridge()**: marks settlement model with column metadata (defaults: `balance="remaining_balance"`, `date="payment_date"`, `amount="amount"`)
-- **@loan_bridge(principal=, settlements=)**: adds `balance` hybrid_property — Python side returns `Money`, SQL side uses a correlated subquery
-
-### Easy Date Generation 📅
-
-**Simplified with python-dateutil for robust date handling:**
-
-```python
-from datetime import datetime
-from money_warp import (
-    generate_monthly_dates,
-    generate_biweekly_dates,
-    generate_weekly_dates,
-    generate_quarterly_dates,
-    generate_annual_dates,
-    generate_custom_interval_dates,
-)
-
-# Monthly payments (handles end-of-month intelligently)
-monthly_dates = generate_monthly_dates(datetime(2024, 1, 31), 12)
-print(f"Jan 31 → Feb 29 → Mar 31...")  # Anchors to original day (31st)
-
-# Bi-weekly payments (every 14 days)
-biweekly_dates = generate_biweekly_dates(datetime(2024, 1, 1), 26)
-print(f"26 payments over ~1 year")
-
-# Weekly payments
-weekly_dates = generate_weekly_dates(datetime(2024, 1, 1), 52)
-
-# Quarterly payments
-quarterly_dates = generate_quarterly_dates(datetime(2024, 1, 15), 4)
-
-# Annual payments
-annual_dates = generate_annual_dates(datetime(2024, 1, 1), 30)  # 30-year loan
-
-# Custom intervals (every N days)
-custom_dates = generate_custom_interval_dates(datetime(2024, 1, 1), 10, 45)  # Every 45 days
-
-# Use with loans immediately
-loan = Loan(
-    principal=Money("50000"),
-    interest_rate=InterestRate("3.5% annual"),
-    due_dates=monthly_dates  # Just plug in the generated dates!
-)
-```
-
-**Key Features:**
-- 🗓️ **Smart date handling**: Uses `python-dateutil` for robust month arithmetic
-- 📅 **End-of-month intelligence**: Jan 31 → Feb 29 → Mar 31 (anchors to original day)
-- 🎯 **Simple API**: Just `datetime` and `int` parameters, no complex options
-- ⚡ **Instant integration**: Generated dates work directly with `Loan` objects
-- 🔒 **Type-safe**: Full type annotations and validation
-```
-
-### Timezone-Aware Datetimes 🌐
-
-All datetimes inside MoneyWarp are timezone-aware. By default, UTC is used. Naive datetimes passed to any API are silently treated as UTC (or whatever timezone you configure).
-
-```python
-from money_warp import get_tz, set_tz, now
-
-# Check the default
-print(get_tz())  # datetime.timezone.utc
-
-# Get the current time (always aware)
-print(now())  # e.g. 2024-06-15 14:30:00+00:00
-
-# Change the default timezone
-set_tz("America/Sao_Paulo")
-print(now())  # e.g. 2024-06-15 11:30:00-03:00
-
-# You can also use a tzinfo object
-from datetime import timezone, timedelta
-set_tz(timezone(timedelta(hours=-3)))
-
-# Reset back to UTC
-set_tz("UTC")
-```
-
-Naive datetimes are accepted everywhere for convenience — the library converts them automatically:
-
-```python
-from datetime import datetime
-from money_warp import Loan, Money, InterestRate
-
-# These naive datetimes are silently coerced to UTC
-loan = Loan(
-    Money("10000"),
-    InterestRate("5% a"),
-    [datetime(2024, 2, 1), datetime(2024, 3, 1)],
-    disbursement_date=datetime(2024, 1, 1),
-)
-print(loan.disbursement_date)  # 2024-01-01 00:00:00+00:00
-```
-
-### Present Value and IRR Analysis 🧮
-
-**Powered by scipy for robust numerical calculations:**
-
-```python
-from money_warp import CashFlow, CashFlowItem, Money, InterestRate
-from money_warp import present_value, irr, modified_internal_rate_of_return
-from datetime import datetime
-
-# Create an investment cash flow
-items = [
-    CashFlowItem(Money("-10000"), datetime(2024, 1, 1), "Initial investment", "investment"),
-    CashFlowItem(Money("3000"), datetime(2024, 12, 31), "Year 1 return", "return"),
-    CashFlowItem(Money("4000"), datetime(2025, 12, 31), "Year 2 return", "return"),
-    CashFlowItem(Money("5000"), datetime(2026, 12, 31), "Year 3 return", "return"),
-]
-cash_flow = CashFlow(items)
-
-# Calculate Present Value at 8% discount rate
-discount_rate = InterestRate("8% annual")
-pv = present_value(cash_flow, discount_rate)
-print(f"Present Value at 8%: {pv}")
-
-# Calculate Internal Rate of Return
-investment_irr = irr(cash_flow)
-print(f"IRR: {investment_irr}")  # Should be ~9.7%
-
-# IRR with banker's year (360 days) for day-count convention
-from money_warp import YearSize
-banker_irr = irr(cash_flow, year_size=YearSize.banker)
-print(f"IRR (360-day year): {banker_irr}")
-
-# Calculate Modified IRR with different reinvestment assumptions
-finance_rate = InterestRate("10% annual")      # Cost of capital
-reinvestment_rate = InterestRate("6% annual")  # Reinvestment rate
-mirr = modified_internal_rate_of_return(cash_flow, finance_rate, reinvestment_rate)
-print(f"MIRR: {mirr}")
-
-# Loan IRR (borrower's perspective)
-loan = Loan(Money("10000"), InterestRate("5% annual"), [datetime(2024, 12, 31)])
-loan_irr = loan.irr()  # Sugar syntax — uses the loan's own year_size
-print(f"Loan IRR: {loan_irr}")  # Should be ~5% (loan's own rate)
-
-# Present Value of loan using different discount rate
-loan_pv = loan.present_value(InterestRate("8% annual"))
-print(f"Loan PV at 8%: {loan_pv}")  # Negative from borrower's perspective
-```
-
-**Key Features:**
-- 🔬 **Scipy-powered**: Uses `scipy.optimize.brentq` for robust root finding
-- 📊 **Automatic bracketing**: Finds IRR solutions reliably across complex cash flows
-- 🕰️ **Time Machine integration**: Use `Warp` to calculate IRR from any date
-- 🍭 **Sugar syntax**: `loan.irr()` and `loan.present_value()` convenience methods
-- 💰 **High precision**: Maintains decimal precision throughout calculations
-- 📅 **Day-count conventions**: `YearSize.commercial` (365) or `YearSize.banker` (360) for IRR and MIRR
-```
-
-### Tax & Grossup (Brazilian IOF) 🇧🇷
-
-**Pluggable tax system with built-in IOF support and grossup for financed taxes:**
-
-```python
-from datetime import datetime
-from money_warp import (
-    Money, InterestRate, Loan, IndividualIOF, CorporateIOF,
-    grossup_loan, PriceScheduler, generate_monthly_dates,
-)
-
-# Use preset rates for individual borrowers (PF)
-iof = IndividualIOF()  # daily=0.0082%, additional=0.38%
-
-# Or for corporate borrowers (PJ)
-iof_pj = CorporateIOF()  # daily=0.0041%, additional=0.38%
-
-# Attach tax to a loan for reporting
-due_dates = generate_monthly_dates(datetime(2024, 2, 1), 12)
-loan = Loan(
-    Money("10000"), InterestRate("1% m"), due_dates,
-    disbursement_date=datetime(2024, 1, 1),
-    taxes=[iof],
-)
-print(f"Total IOF: {loan.total_tax}")
-print(f"Net disbursement: {loan.net_disbursement}")  # principal - tax
-
-# Grossup: borrower wants to receive exactly 10,000 after tax
-grossed_loan = grossup_loan(
-    requested_amount=Money("10000"),
-    interest_rate=InterestRate("1% m"),
-    due_dates=due_dates,
-    disbursement_date=datetime(2024, 1, 1),
-    scheduler=PriceScheduler,
-    taxes=[iof],
-)
-print(f"Grossed-up principal: {grossed_loan.principal}")    # > 10,000
-print(f"Net to borrower: {grossed_loan.net_disbursement}")  # ~= 10,000
-```
-
-**Key Features:**
-- 🔌 **Pluggable taxes**: Implement `BaseTax` for any tax type
-- 🇧🇷 **IOF built-in**: Brazilian IOF with daily + additional rate components
-- 👤 **Presets**: `IndividualIOF()` and `CorporateIOF()` with standard rates (overridable)
-- 🔄 **Grossup**: Scipy-powered solver finds the principal so `principal - tax = requested_amount`
-- 📊 **Rounding modes**: `PRECISE` (default) or `PER_COMPONENT` to match external systems
-
-## 🏗️ Architecture
-
-MoneyWarp is built around six core concepts:
-
-### 💰 Money
-High-precision monetary amounts using Python's `Decimal` for accuracy:
-- **Internal precision**: Stores full decimal precision
-- **Display precision**: Shows 2 decimal places for "real money"
-- **Arithmetic safety**: No floating-point errors
-
-### 📈 InterestRate  
-Type-safe interest rate handling with explicit conversions:
-- **Clear representation**: Eliminates 0.05 vs 5% confusion
-- **Frequency conversion**: Annual ↔ Monthly ↔ Daily ↔ Quarterly
-- **String parsing**: `"5.25% annual"` or `"0.004167 monthly"`
-- **Abbreviated notation**: `"5.25% a.a."`, `"1.5% a.m."` (Brazilian/LatAm convention)
-- **Day-count convention**: `YearSize.commercial` (365) or `YearSize.banker` (360)
-
-### 💸 CashFlow
-Container for cash flow analysis with SQLAlchemy-style querying:
-- **CashFlowItem**: Individual transactions with amount, date, description, category
-- **CashFlow**: Collection with filtering, summing, and analysis methods
-- **Query interface**: `cashflow.query.filter_by(category='interest').sum_amounts()`
-
-### 🏦 Loan
-State machine for loan analysis with configurable schedulers:
-- **Expected vs Actual**: Compare planned payments with reality
-- **Payment allocation**: Fines → Interest → Principal priority
-- **Fine engine**: Automatic fines and mora interest for overdue payments
-- **Sugar methods**: `pay_installment()` and `anticipate_payment()` for natural workflows
-- **Installments**: Repayment plan as first-class objects derived from loan terms
-- **Settlements**: Payment allocation results with per-installment detail
-- **Flexible scheduling**: Any list of due dates, not just monthly
-- **Multiple schedulers**: PMT-based, fixed payment, custom algorithms
-
-### 🌐 Timezone (tz)
-Global timezone configuration with automatic coercion:
-- **UTC by default**: All datetimes are timezone-aware out of the box
-- **Configurable**: `set_tz("America/Sao_Paulo")` changes the default globally
-- **Silent coercion**: Naive datetimes passed to any API are automatically coerced
-- **`@tz_aware` decorator**: Applied to API boundaries — no manual conversion needed
-
-### 🇧🇷 Tax
-Pluggable tax strategy with Brazilian IOF and grossup:
-- **BaseTax interface**: Implement `calculate()` for any tax type
-- **IOF**: Daily rate + additional rate components with configurable rounding
-- **Presets**: `IndividualIOF` (PF) and `CorporateIOF` (PJ) with standard rates
-- **Grossup**: Scipy-powered solver for financed tax calculations
-
-## 📊 Supported Calculations
-
-### Loan Schedules
-- **Progressive Price Schedule** (French amortization system)
-- **Inverted Price Schedule** (Constant Amortization System - SAC)
-- **Fixed payment amounts** with interest/principal allocation
-- **Irregular payment dates** with daily compounding
-- **Bullet loans** (single payment at maturity)
-
-### Time Value of Money Functions
-- **Present Value (PV)**: Discount future cash flows to present value
-- **Net Present Value (NPV)**: Sum of discounted cash flows
-- **Internal Rate of Return (IRR)**: Rate where NPV equals zero, with configurable day-count convention
-- **Modified IRR (MIRR)**: IRR with different financing/reinvestment rates, with configurable day-count convention
-- **Present Value of Annuities**: Regular payment streams
-- **Present Value of Perpetuities**: Infinite payment streams
-- **Discount Factors**: Time value calculations
-
-### Financial Functions
-- **PMT**: Payment calculation for loans and annuities
-- **Daily compounding**: Precise interest calculations
-- **Amortization schedules**: Complete payment breakdowns
-- **Balance tracking**: Outstanding principal over time
-- **Robust numerics**: Scipy-powered calculations for complex scenarios
-
-### Tax Calculations
-- **IOF (Brazilian)**: Daily + additional rate on each installment's principal
-- **Grossup**: Find the principal so borrower receives the exact requested amount
-- **Per-installment breakdown**: Tax detail for every installment in the schedule
-- **Rounding modes**: Precise (sum-then-round) or per-component (round-then-sum)
-- **Custom taxes**: Extend `BaseTax` for any jurisdiction or tax type
-
-## 🧪 Testing & Validation
-
-MoneyWarp includes comprehensive test coverage with validation against established financial libraries:
-
-- **830+ total tests** with 100% core functionality coverage
-- **Reference validation** against [cartaorobbin/loan-calculator](https://github.com/cartaorobbin/loan-calculator)
-- **External IOF validation** against a production Brazilian lending platform
-- **Edge case handling**: Zero interest, irregular schedules, high precision
-- **Property-based testing**: Parametrized tests across various scenarios
-
-## 🎯 Use Cases
-
-### Personal Finance
-- **Mortgage analysis**: Compare different loan terms and rates
-- **Payment tracking**: Monitor actual vs expected payments
-- **Refinancing decisions**: Calculate savings from rate changes
-
-### Investment Analysis  
-- **Cash flow modeling**: Track investment returns over time
-- **Scenario analysis**: "What if" calculations with different assumptions
-- **Performance measurement**: Calculate actual returns vs projections
-
-### Financial Planning
-- **Loan comparison**: Evaluate different lending options
-- **Payment scheduling**: Optimize payment timing for cash flow
-- **Interest calculation**: Precise daily compounding for any scenario
-
-## 🔮 Roadmap
-
-- ✅ **Time Machine (Warp)**: Travel to any date and analyze loan state - *COMPLETED*
-- ✅ **Inverted Price Scheduler**: Constant Amortization System (SAC) - *COMPLETED*
-- ✅ **Present Value Functions**: PV, NPV, annuities, perpetuities - *COMPLETED*
-- ✅ **IRR Functions**: IRR, MIRR with scipy-powered numerics - *COMPLETED*
-- ✅ **Date Generation Utilities**: Smart payment scheduling - *COMPLETED*
-- ✅ **Fine Engine**: Fines, mora interest, grace periods - *COMPLETED*
-- ✅ **Payment Sugar Methods**: `pay_installment()`, `anticipate_payment()` - *COMPLETED*
-- ✅ **Tax Module**: Brazilian IOF, grossup, pluggable tax strategy - *COMPLETED*
-- ✅ **Installments & Settlements**: First-class repayment plan and payment allocation views - *COMPLETED*
-- ✅ **Timezone-Aware Datetimes**: UTC by default with configurable global timezone - *COMPLETED*
-- **Additional Schedulers**: Custom schedules, balloon payments
-- **Performance optimization**: Vectorized calculations for large datasets
-- **Advanced TVM**: Bond pricing, option valuation
-
-## 🤝 Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.rst) for details.
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- Inspired by the time value of money concepts and validated against [cartaorobbin/loan-calculator](https://github.com/cartaorobbin/loan-calculator)
-- Built with modern Python practices using Poetry, pytest, and pre-commit hooks
-- Follows the Zen of Python: "Beautiful is better than ugly. Explicit is better than implicit."
-
----
-
-**MoneyWarp** - Because time is money, and money should bend to your will. 💰⏰
+## Documentation
+
+Full guides, examples, and API reference at **[tomascorrea.github.io/money-warp](https://tomascorrea.github.io/money-warp)**.
+
+- [Quick Start](https://tomascorrea.github.io/money-warp/examples/quickstart/)
+- [Money and Precision](https://tomascorrea.github.io/money-warp/examples/money/)
+- [Interest Rates](https://tomascorrea.github.io/money-warp/examples/interest_rates/)
+- [Cash Flow Analysis](https://tomascorrea.github.io/money-warp/examples/cash_flow/)
+- [Date Generation](https://tomascorrea.github.io/money-warp/examples/date_generation/)
+- [Time Machine](https://tomascorrea.github.io/money-warp/examples/time_machine/)
+- [Present Value and IRR](https://tomascorrea.github.io/money-warp/examples/present_value_irr/)
+- [Fines and Mora Interest](https://tomascorrea.github.io/money-warp/examples/fines/)
+- [Tax and IOF](https://tomascorrea.github.io/money-warp/examples/tax/)
+- [Timezone Handling](https://tomascorrea.github.io/money-warp/examples/timezone/)
+- [Marshmallow Extension](https://tomascorrea.github.io/money-warp/examples/marshmallow/)
+- [SQLAlchemy Extension](https://tomascorrea.github.io/money-warp/examples/sqlalchemy/)
+- [API Reference](https://tomascorrea.github.io/money-warp/modules/)
+
+## Contributing
+
+Contributions are welcome! See the [Contributing Guide](CONTRIBUTING.rst) for details.
+
+## License
+
+MIT -- see [LICENSE](LICENSE).

--- a/docs/examples/marshmallow.md
+++ b/docs/examples/marshmallow.md
@@ -1,0 +1,108 @@
+# Marshmallow Extension
+
+Custom Marshmallow fields for serializing and deserializing `Money`, `Rate`, and `InterestRate` objects.
+
+## Installation
+
+```bash
+pip install money-warp[marshmallow]
+```
+
+## Fields
+
+### MoneyField
+
+Serializes `Money` instances. The `representation` parameter controls the format:
+
+| Representation | Serialized type | Serialize logic | Deserialize logic |
+|---|---|---|---|
+| `"raw"` (default) | `str` | `str(money.raw_amount)` | `Money(value)` |
+| `"real"` | `str` | `str(money.real_amount)` | `Money(value)` |
+| `"cents"` | `int` | `money.cents` | `Money.from_cents(value)` |
+
+### RateField
+
+Serializes `Rate` instances. The `representation` parameter controls the format:
+
+| Representation | Serialized type | Example output |
+|---|---|---|
+| `"string"` (default) | `str` | `"5.250% annual"` |
+| `"dict"` | `dict` | `{"rate": "0.0525", "period": "annually", ...}` |
+
+**String mode** outputs a parseable format that feeds directly back into `Rate(...)`. Field-level defaults (`year_size`, `precision`, `rounding`, `str_style`) are applied on deserialization.
+
+**Dict mode** captures all constructor params (`rate`, `period`, `year_size`, `precision`, `rounding`, `str_style`) for lossless reconstruction.
+
+### InterestRateField
+
+Inherits from `RateField` with `RATE_CLASS = InterestRate`. Same representations, but constructs `InterestRate` on deserialization (rejects negative values).
+
+## Usage
+
+```python
+from marshmallow import Schema
+from money_warp import Money, InterestRate
+from money_warp.ext.marshmallow import MoneyField, InterestRateField
+
+class LoanSchema(Schema):
+    principal = MoneyField(representation="raw")
+    rate = InterestRateField(representation="string")
+
+schema = LoanSchema()
+
+# Serialize
+data = schema.dump({"principal": Money("10000"), "rate": InterestRate("5.25% a")})
+# {"principal": "10000", "rate": "5.250% annual"}
+
+# Deserialize
+result = schema.load(data)
+# {"principal": Money(10000), "rate": InterestRate(5.25% annually)}
+```
+
+### Dict representation for lossless round-trips
+
+```python
+from money_warp.ext.marshmallow import RateField
+from money_warp import Rate, CompoundingFrequency, YearSize
+
+class DetailedSchema(Schema):
+    rate = RateField(representation="dict")
+
+schema = DetailedSchema()
+rate = Rate(0.0525, CompoundingFrequency.ANNUALLY, year_size=YearSize.banker)
+
+data = schema.dump({"rate": rate})
+# {
+#     "rate": {
+#         "rate": "0.0525",
+#         "period": "annually",
+#         "year_size": 360,
+#         "precision": None,
+#         "rounding": "ROUND_HALF_UP",
+#         "str_style": "long"
+#     }
+# }
+
+restored = schema.load(data)
+# Rate is fully reconstructed with all original parameters
+```
+
+### Cents representation for integer storage
+
+```python
+class PaymentSchema(Schema):
+    amount = MoneyField(representation="cents")
+
+schema = PaymentSchema()
+data = schema.dump({"amount": Money("123.45")})
+# {"amount": 12345}
+
+result = schema.load(data)
+# {"amount": Money("123.45")}
+```
+
+## Notes
+
+- All fields pass `None` through in both directions.
+- String round-trips lose some precision: the percentage rate is formatted with 3 decimal places. Use dict representation for rates with more than 3 decimal digits in percentage form.
+- `InterestRateField` raises a validation error for negative rates.

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -6,20 +6,21 @@ Welcome to MoneyWarp! This guide will get you up and running with the core conce
 
 ## Installation
 
-> **Note:** MoneyWarp is not yet published to PyPI. For now, install from source:
-
 ```bash
-git clone https://github.com/tomas_correa/money-warp.git
-cd money-warp
-pip install -e .
+pip install money-warp
 ```
 
-Or using Poetry (recommended for development):
+Or with Poetry:
 
 ```bash
-git clone https://github.com/tomas_correa/money-warp.git
-cd money-warp
-poetry install
+poetry add money-warp
+```
+
+With optional extensions:
+
+```bash
+pip install money-warp[marshmallow]   # Marshmallow fields
+pip install money-warp[sa]            # SQLAlchemy types + bridge
 ```
 
 ## Basic Loan Analysis

--- a/docs/examples/sqlalchemy.md
+++ b/docs/examples/sqlalchemy.md
@@ -1,0 +1,190 @@
+# SQLAlchemy Extension
+
+Custom SQLAlchemy column types for `Money`, `Rate`, and `InterestRate`, plus bridge decorators that add SQL-queryable `balance_at(date)` to loan models.
+
+## Installation
+
+```bash
+pip install money-warp[sa]
+```
+
+## Column Types
+
+### MoneyType
+
+Stores `Money` instances. The `representation` parameter controls the column type and conversion:
+
+| Representation | Column type | Bind (Money -> DB) | Result (DB -> Money) |
+|---|---|---|---|
+| `"raw"` (default) | `Numeric(20,10)` | `money.raw_amount` | `Money(value)` |
+| `"real"` | `Numeric(20,10)` | `money.real_amount` | `Money(value)` |
+| `"cents"` | `Integer` | `money.cents` | `Money.from_cents(value)` |
+
+`process_bind_param` also accepts raw `Decimal`/`int`/`float` values (passthrough) so that SQL comparisons like `LoanRecord.balance > Decimal("1000")` work without wrapping in `Money`.
+
+### RateType
+
+Stores `Rate` instances. The `representation` parameter controls the column type and conversion:
+
+| Representation | Column type | Example stored value |
+|---|---|---|
+| `"string"` (default) | `String` | `"5.250% annual"` |
+| `"json"` | `JSON` | `{"rate": "0.0525", "period": "annually", ...}` |
+
+Additional constructor parameters (`year_size`, `precision`, `rounding`, `str_style`) control defaults for string deserialization.
+
+### InterestRateType
+
+Subclass of `RateType` with `RATE_CLASS = InterestRate`. Same representations, but constructs `InterestRate` on load (rejects negative values).
+
+## Bridge Decorators
+
+The bridge system connects SQLAlchemy models to money-warp's Loan engine, providing both Python-side and SQL-side balance calculations.
+
+### @settlement_bridge
+
+Marks a settlement model with column metadata so that `@loan_bridge` can discover which columns hold the remaining balance, payment date, and amount:
+
+```python
+from money_warp.ext.sa import settlement_bridge, MoneyType
+
+@settlement_bridge()
+class SettlementRecord(Base):
+    __tablename__ = "settlements"
+    id = Column(Integer, primary_key=True)
+    loan_id = Column(Integer, ForeignKey("loans.id"))
+    amount = Column(MoneyType())
+    payment_date = Column(DateTime)
+    remaining_balance = Column(MoneyType())
+    interest_date = Column(DateTime, nullable=True)
+    processing_date = Column(DateTime, nullable=True)
+```
+
+All parameters have sensible defaults. `@settlement_bridge()` with no arguments works if your columns follow the naming convention.
+
+### @loan_bridge
+
+Adds `balance_at(date)` hybrid method and `balance` hybrid property to a loan model:
+
+```python
+from money_warp.ext.sa import loan_bridge, MoneyType, InterestRateType
+
+@loan_bridge()
+class LoanRecord(Base):
+    __tablename__ = "loans"
+    id = Column(Integer, primary_key=True)
+    principal = Column(MoneyType())
+    interest_rate = Column(InterestRateType(representation="json"))
+    disbursement_date = Column(DateTime)
+    due_dates = Column(JSON)
+    fine_rate = Column(Numeric(), nullable=True)
+    grace_period_days = Column(Integer(), nullable=True)
+    mora_interest_rate = Column(InterestRateType(representation="json"), nullable=True)
+    mora_strategy = Column(String(), nullable=True)
+    settlements = relationship("SettlementRecord", order_by="SettlementRecord.payment_date")
+```
+
+All parameter names default to conventional column names. `@loan_bridge()` with no arguments works if you follow the naming convention.
+
+## balance_at(date)
+
+The hybrid method works differently on instances vs queries:
+
+**Python side** -- reconstructs a full `Loan` from the model's stored fields, replays settlements, and uses `Warp(loan, as_of)` to return the exact balance including accrued interest, fines, and mora:
+
+```python
+loan = session.get(LoanRecord, 1)
+balance = loan.balance_at(some_date)  # Returns Money
+```
+
+**SQL side** -- generates a CTE-based expression that computes `principal_balance + regular_interest + mora_interest + fines` entirely in SQL:
+
+```python
+from sqlalchemy import select
+from decimal import Decimal
+
+high_balance_loans = session.execute(
+    select(LoanRecord).where(LoanRecord.balance_at(some_date) > Decimal("5000"))
+).scalars().all()
+```
+
+The `balance` property is a shortcut for `balance_at(now())`.
+
+## Rate Representation Support
+
+Both `"json"` and `"string"` representations are fully supported in the SQL balance expression. The bridge introspects the column's `InterestRateType` at expression-build time to determine the storage format and generates the correct SQL accordingly.
+
+### JSON representation
+
+Stores the full rate object with `rate`, `period`, `year_size`, and metadata. The SQL expression extracts these fields with `json_extract` and performs the conversion:
+
+```python
+interest_rate = Column(InterestRateType(representation="json"))
+# Stored as: {"rate": "0.05", "period": "annually", "year_size": 365, ...}
+```
+
+### String representation
+
+Stores a parseable string like `"5.000% annual"`. The SQL expression parses this with `SUBSTR`/`INSTR` and uses the column type's `rate_year_size` default:
+
+```python
+interest_rate = Column(InterestRateType(representation="string"))
+# Stored as: "5.000% annual"
+```
+
+!!! note "String format limitations"
+    The string format does not embed `year_size`. The SQL helpers use the `rate_year_size` from the column's `InterestRateType` definition. If different rates on the same column need different year sizes, use JSON representation instead. `CompoundingFrequency.CONTINUOUS` cannot be serialized as a string.
+
+## Full Example
+
+```python
+from datetime import datetime
+from decimal import Decimal
+from sqlalchemy import Column, Integer, DateTime, JSON, Numeric, String, ForeignKey
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import DeclarativeBase, Session, relationship
+from money_warp import Money, InterestRate
+from money_warp.ext.sa import MoneyType, InterestRateType, settlement_bridge, loan_bridge
+
+class Base(DeclarativeBase):
+    pass
+
+@settlement_bridge()
+class Settlement(Base):
+    __tablename__ = "settlements"
+    id = Column(Integer, primary_key=True)
+    loan_id = Column(Integer, ForeignKey("loans.id"))
+    amount = Column(MoneyType())
+    payment_date = Column(DateTime)
+    remaining_balance = Column(MoneyType())
+
+@loan_bridge()
+class Loan(Base):
+    __tablename__ = "loans"
+    id = Column(Integer, primary_key=True)
+    principal = Column(MoneyType())
+    interest_rate = Column(InterestRateType(representation="json"))
+    disbursement_date = Column(DateTime)
+    due_dates = Column(JSON)
+    settlements = relationship("Settlement", order_by="Settlement.payment_date")
+
+engine = create_engine("sqlite:///:memory:")
+Base.metadata.create_all(engine)
+
+with Session(engine) as session:
+    # Instance access returns Money
+    loan = session.get(Loan, 1)
+    print(loan.balance)  # Money("8500.00")
+
+    # SQL queries work too
+    overdue = session.execute(
+        select(Loan).where(Loan.balance > Decimal("5000"))
+    ).scalars().all()
+```
+
+## Notes
+
+- All type fields pass `None` through in both directions.
+- SQLite stores `Numeric` as floating-point internally. Very high-precision amounts may lose precision; use PostgreSQL or MySQL for production.
+- The SQL expression returns raw `Numeric`, not `Money`. Filter comparisons use `Decimal`: `LoanRecord.balance > Decimal("1000")`.
+- SQL arithmetic uses float64 while Python uses `Decimal`. Use approximate matching (`pytest.approx`) when comparing SQL results against Python in tests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,45 +1,32 @@
-# MoneyWarp 💰⏰
+# MoneyWarp
 
 **Bend time. Model cash.**
 
-[![Release](https://img.shields.io/github/v/release/tomas_correa/money-warp)](https://img.shields.io/github/v/release/tomas_correa/money-warp)
-[![Build status](https://img.shields.io/github/actions/workflow/status/tomas_correa/money-warp/main.yml?branch=main)](https://github.com/tomas_correa/money-warp/actions/workflows/main.yml?query=branch%3Amain)
-[![codecov](https://codecov.io/gh/tomas_correa/money-warp/branch/main/graph/badge.svg)](https://codecov.io/gh/tomas_correa/money-warp)
-[![License](https://img.shields.io/github/license/tomas_correa/money-warp)](https://img.shields.io/github/license/tomas_correa/money-warp)
+[![Release](https://img.shields.io/github/v/release/tomascorrea/money-warp)](https://img.shields.io/github/v/release/tomascorrea/money-warp)
+[![Build status](https://img.shields.io/github/actions/workflow/status/tomascorrea/money-warp/on-release-main.yml?branch=main)](https://github.com/tomascorrea/money-warp/actions/workflows/on-release-main.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/tomascorrea/money-warp/branch/main/graph/badge.svg)](https://codecov.io/gh/tomascorrea/money-warp)
+[![License](https://img.shields.io/github/license/tomascorrea/money-warp)](https://img.shields.io/github/license/tomascorrea/money-warp)
 
-> **⚠️ Development Stage Notice**
-> 
-> MoneyWarp is currently in active development and should be considered **alpha/pre-release software**. While the core functionality is implemented and tested, the API may change between versions. Use in production environments at your own risk.
->
-> - ✅ Core classes (`Money`, `InterestRate`, `CashFlow`, `Loan`) are stable
-> - ✅ Comprehensive test suite with 830+ tests
-> - ✅ Time Machine, Present Value, and IRR functions complete
-> - ⚠️ API may evolve based on user feedback
-> - ⚠️ Not yet published to PyPI
-> - 🚧 Additional features and schedulers in development
+> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 1200+ tests, but the API may evolve.
 
-MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as simple cash flows through time — and gives you the tools to warp them back and forth between present, future, and everything in between.
+MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as cash flows through time -- and gives you the tools to warp them back and forth between present, future, and everything in between.
 
-## 🚀 Key Features
+## Key Features
 
-- 🕰️ **Time Machine (Warp)** - Travel to any date and see loan state as of that moment
-- 🔢 **Calculate PMT, NPV, IRR, MIRR** and other core finance functions with scipy
-- ⏳ **Track loans and repayments** as evolving cash-flow streams  
-- 🌀 **Explore "what if" timelines** by bending payments across time
-- 💰 **High-precision calculations** using Decimal arithmetic
-- 📊 **Progressive Price Schedules** (French amortization system)
-- 📈 **Inverted Price Schedules** (Constant Amortization System - SAC)
-- 🎯 **Flexible payment scheduling** with irregular due dates
-- 📅 **Easy date generation** with smart month-end handling via python-dateutil
-- 🔒 **Type-safe interest rates** with explicit percentage handling
-- 🧮 **Robust numerics** powered by scipy for IRR and financial calculations
-- ⚖️ **Fine engine** with fines, mora interest, and configurable grace periods
-- 🍭 **Sugar payment methods** — `pay_installment()` and `anticipate_payment()`
-- 📋 **Installments & Settlements** — first-class views of the repayment plan and payment allocation
-- 🇧🇷 **Tax module** — Brazilian IOF with pluggable tax strategy, grossup, and preset rates
-- 🌐 **Timezone-aware** — all datetimes are UTC by default, configurable globally
+- **Time Machine (Warp)** -- travel to any date and see loan state as of that moment
+- **PMT, NPV, IRR, MIRR** -- core finance functions powered by scipy
+- **Loan tracking** -- payments, fines, mora interest, grace periods
+- **High-precision Money** -- Decimal arithmetic, never floats
+- **Amortization schedules** -- French (Price) and SAC (Inverted Price)
+- **Flexible dates** -- irregular due dates, smart month-end handling
+- **Type-safe interest rates** -- explicit percentage handling, frequency conversions
+- **Installments and Settlements** -- first-class repayment plan and payment allocation
+- **Tax module** -- Brazilian IOF, grossup, pluggable tax strategy
+- **Timezone-aware** -- UTC by default, configurable globally
+- **Marshmallow extension** -- custom fields for serialization
+- **SQLAlchemy extension** -- column types + loan/settlement bridge with SQL-queryable balance
 
-## 🧮 Time Value of Money Functions
+## Time Value of Money Functions
 
 MoneyWarp provides comprehensive TVM functions powered by scipy:
 
@@ -63,38 +50,40 @@ MoneyWarp provides comprehensive TVM functions powered by scipy:
 - **Type safety**: Full type annotations and mypy compatibility
 - **Error handling**: Clear messages and edge case handling
 
-## 📖 Documentation
+## Documentation
 
 Explore the comprehensive examples and API reference:
 
-- **[Quick Start](examples/quickstart.md)** - Get up and running quickly
-- **[Money](examples/money.md)** - High-precision monetary amounts
-- **[Interest Rates](examples/interest_rates.md)** - Type-safe rate handling and conversions
-- **[Date Generation](examples/date_generation.md)** - Smart payment date utilities
-- **[Present Value & IRR](examples/present_value_irr.md)** - TVM functions and analysis
-- **[Time Machine](examples/time_machine.md)** - Travel through time with loans
-- **[Cash Flow Analysis](examples/cash_flow.md)** - Work with cash flow streams
-- **[Fines & Payments](examples/fines.md)** - Fines, mora interest, installments, settlements, and payment methods
-- **[Tax & IOF](examples/tax.md)** - Brazilian IOF, grossup, and pluggable taxes
-- **[Timezone Handling](examples/timezone.md)** - UTC default, global configuration, silent coercion
-- **[API Reference](modules.md)** - Complete function documentation
+- **[Quick Start](examples/quickstart.md)** -- get up and running quickly
+- **[Money](examples/money.md)** -- high-precision monetary amounts
+- **[Interest Rates](examples/interest_rates.md)** -- type-safe rate handling and conversions
+- **[Date Generation](examples/date_generation.md)** -- smart payment date utilities
+- **[Present Value & IRR](examples/present_value_irr.md)** -- TVM functions and analysis
+- **[Time Machine](examples/time_machine.md)** -- travel through time with loans
+- **[Cash Flow Analysis](examples/cash_flow.md)** -- work with cash flow streams
+- **[Fines & Payments](examples/fines.md)** -- fines, mora interest, installments, settlements, and payment methods
+- **[Tax & IOF](examples/tax.md)** -- Brazilian IOF, grossup, and pluggable taxes
+- **[Timezone Handling](examples/timezone.md)** -- UTC default, global configuration, silent coercion
+- **[Marshmallow Extension](examples/marshmallow.md)** -- custom Marshmallow fields for Money, Rate, InterestRate
+- **[SQLAlchemy Extension](examples/sqlalchemy.md)** -- column types, bridge decorators, SQL-queryable balance
+- **[API Reference](modules.md)** -- complete function documentation
 
-## 🏗️ Architecture
+## Architecture
 
 MoneyWarp is built around core financial concepts:
 
-- **💰 Money**: High-precision monetary amounts using Decimal
-- **📈 InterestRate**: Type-safe rates with frequency conversions, abbreviated notation, and day-count conventions
-- **💸 CashFlow**: Collections with SQLAlchemy-style querying
-- **🏦 Loan**: State machines for loan analysis and tracking
-- **📋 Installment & Settlement**: Derived views of repayment plans and payment allocations
-- **🇧🇷 Tax**: Pluggable tax strategy with IOF, grossup, and presets
-- **🌐 tz**: Timezone configuration — UTC default, global `set_tz()`, silent coercion
-- **🕰️ Warp**: Time Machine for temporal financial analysis
+- **Money**: High-precision monetary amounts using Decimal
+- **InterestRate**: Type-safe rates with frequency conversions, abbreviated notation, and day-count conventions
+- **CashFlow**: Collections with SQLAlchemy-style querying
+- **Loan**: State machines for loan analysis and tracking
+- **Installment & Settlement**: Derived views of repayment plans and payment allocations
+- **Tax**: Pluggable tax strategy with IOF, grossup, and presets
+- **tz**: Timezone configuration -- UTC default, global `set_tz()`, silent coercion
+- **Warp**: Time Machine for temporal financial analysis
 
-## 🧪 Quality & Testing
+## Quality & Testing
 
-- **830+ comprehensive tests** with 100% core functionality coverage
+- **1200+ comprehensive tests** with 100% core functionality coverage
 - **Type safety**: Full mypy compatibility with zero type errors
 - **Code quality**: Passes ruff linting and black formatting
 - **Robust numerics**: Scipy-powered calculations for reliability

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -133,23 +133,30 @@ The SQL side of `balance_at` uses nested CTEs (`nesting=True`) inside a single s
 | CTE | Purpose |
 |-----|---------|
 | `loan_state` | `COALESCE(last_remaining_balance, principal)` and `COALESCE(last_payment_date, disbursement_date)`. Uses scalar subqueries so it always returns 1 row even with no settlements. |
-| `daily_rates` | Converts rates of any period to daily via `_daily_rate_expr`. Handles all `CompoundingFrequency` values (annual, monthly, quarterly, semi-annual, daily, continuous). NULL mora rate coalesces to 0. |
+| `daily_rates` | Converts rates of any period to daily via `_daily_rate_expr`. Handles all `CompoundingFrequency` values for both JSON and string column representations. NULL mora rate coalesces to 0. |
 | `time_split` | Computes `total_days` and finds `next_due` date after last payment via `json_each(due_dates)`. |
 | `day_split` | Splits total days into `regular_days` and `mora_days` at the next-due boundary. |
 | `accrued` | `regular_interest` (compound on principal) and `mora_interest` (COMPOUND or SIMPLE branching via `mora_strategy`). |
 | `late_fines` | Counts late installments (`past_grace_count - settlement_count`), estimates PMT, applies fine rate. |
 | Final SELECT | `principal_balance + regular_interest + mora_interest + fines`. |
 
-NULL guard: `CASE WHEN json_extract(interest_rate, '$.rate') IS NULL` falls back to the simple `COALESCE(remaining_balance, principal)` since SQL cannot raise exceptions.
+NULL guard: Falls back to `COALESCE(remaining_balance, principal)` when no rate is present. The check depends on representation: JSON uses `json_extract(interest_rate, '$.rate') IS NULL`; string uses `interest_rate IS NULL`.
 
 ### Rate conversion helpers
 
-Two private helpers in `bridge.py` convert JSON-stored rates to daily rates in SQL, mirroring `Rate._to_effective_annual()` and `Rate.to_daily()`:
+Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirroring `Rate._to_effective_annual()` and `Rate.to_daily()`. They support both JSON and string column representations.
 
-- **`_effective_annual_expr(rate_col)`**: Extracts `$.rate`, `$.period`, and `$.year_size` from the JSON column. Returns a SQL `CASE` expression that converts the stored rate to an effective annual rate based on the period (`annually`, `monthly`, `quarterly`, `semi_annually`, `daily`, `continuous`). Falls back to treating the rate as annual for unknown period values.
-- **`_daily_rate_expr(rate_col)`**: Returns the stored rate directly when period is `daily`; otherwise converts through the effective annual rate: `pow(1 + eff_annual, 1/year_size) - 1`.
+**Column introspection:** `_get_rate_col_info(cls, attr_name)` reads the `InterestRateType` from the model's column to determine `representation` ("json" or "string") and `default_year_size`. This happens once at expression-build time — no SQL-side format detection.
 
-Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` which requires the SQLite math extension (available in Python 3.11+ / SQLite 3.35+).
+**Param extraction:** `_extract_rate_params(rate_col, representation, default_year_size)` returns `(decimal_rate, period, year_size)` as SQL expressions:
+- JSON: uses `json_extract` for all three values.
+- String: parses `"5.250% annual"` via `SUBSTR`/`INSTR`, divides the percentage by 100; uses the column type's `default_year_size` since the string format does not embed year size.
+
+**Period mapping:** `_periods_per_year_expr(period, year_size, representation)` builds a SQL `CASE` generated from `CompoundingFrequency` — no hardcoded magic numbers. Period names differ by representation (JSON: `"annually"`, `"semi_annually"`; string: `"annual"`, `"semi-annual"` via `_FREQUENCY_TOKEN`). `CONTINUOUS` is excluded (handled separately via `exp()`). `DAILY` uses `year_size` instead of a fixed value.
+
+**Conversion:** `_effective_annual_expr(rate_col, representation, default_year_size)` and `_daily_rate_expr(rate_col, representation, default_year_size)` combine the above. Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` which requires the SQLite math extension (available in Python 3.11+ / SQLite 3.35+).
+
+**NULL guard:** `_has_rate(rate_col, representation)` returns a SQL expression that is NULL when no parseable rate is present. For JSON: checks `json_extract(rate_col, '$.rate')`; for string: checks the column itself.
 
 ## Design Decisions
 
@@ -175,6 +182,8 @@ Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_ra
 - **SQLite precision:** SQLite stores `Numeric` as floating-point internally. Very high-precision raw amounts (> ~10 significant digits) may lose precision. Use PostgreSQL or MySQL for production.
 - **SQL expression type asymmetry:** The `balance` hybrid_property returns `Money` on instances but raw `Numeric` in SQL expressions. Filter comparisons use `Decimal`, not `Money`: `LoanRecord.balance > Decimal("1000")`.
 - **SQL vs Python precision:** The SQL CTE expression uses float64 arithmetic while Python uses `Decimal`. For exact comparisons in tests, use approximate matching (e.g., `pytest.approx`) when comparing SQL results against Python `balance_at`.
-- **JSON NULL vs SQL NULL:** SQLAlchemy's `JSON` type stores Python `None` as the string `'null'` rather than SQL `NULL`. The NULL guard checks `json_extract(interest_rate, '$.rate') IS NULL` which correctly handles both cases since `json_extract('null', '$.rate')` returns NULL.
-- **Mora rate NULL handling:** When `mora_interest_rate` is NULL, `json_extract(NULL, '$.rate')` cascades NULL through `pow()`. The `daily_rates` CTE coalesces the mora daily rate to 0.0 to prevent this from nullifying the entire expression.
-- **Period-aware SQL rate conversion:** The SQL CTE handles all `CompoundingFrequency` periods (annual, monthly, quarterly, semi-annual, daily, continuous). This only applies to the `json` representation. The `string` representation triggers the NULL-rate fallback (simple balance) since `json_extract` on a plain string returns NULL for `$.rate`.
+- **JSON NULL vs SQL NULL:** SQLAlchemy's `JSON` type stores Python `None` as the string `'null'` rather than SQL `NULL`. For JSON representation, the NULL guard checks `json_extract(interest_rate, '$.rate') IS NULL` which correctly handles both cases since `json_extract('null', '$.rate')` returns NULL.
+- **Mora rate NULL handling:** When `mora_interest_rate` is NULL, the helper functions cascade NULL through `pow()`. The `daily_rates` CTE coalesces the mora daily rate to 0.0 to prevent this from nullifying the entire expression.
+- **Data-driven period mapping:** The SQL `CASE` branches in `_periods_per_year_expr` are generated from the `CompoundingFrequency` enum and `_FREQUENCY_TOKEN` mapping. Adding a new `CompoundingFrequency` member and its token automatically extends both JSON and string SQL support.
+- **String representation year_size limitation:** The string format (e.g., `"5.250% annual"`) does not embed `year_size`. The SQL helpers use the `rate_year_size` default from the column's `InterestRateType` definition. If different rates on the same column need different year sizes, use JSON representation instead.
+- **Continuous compounding in string format:** `CompoundingFrequency.CONTINUOUS` is not in `_FREQUENCY_TOKEN` and cannot be serialized as a string. Use JSON representation for continuous rates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,11 @@ nav:
     - Time Machine (Warp): examples/time_machine.md
     - Present Value & IRR: examples/present_value_irr.md
     - Fines & Mora Interest: examples/fines.md
+    - Tax & IOF: examples/tax.md
+    - Timezone Handling: examples/timezone.md
+  - Extensions:
+    - Marshmallow: examples/marshmallow.md
+    - SQLAlchemy: examples/sqlalchemy.md
   - API Reference: modules.md
 
 plugins:

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -11,7 +11,9 @@ from typing import List
 from sqlalchemy import Float, String, case, cast, column, func, literal, select
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
+from money_warp.ext.sa.types import _FREQUENCY_TOKEN
 from money_warp.loan import Loan, MoraStrategy
+from money_warp.rate import CompoundingFrequency
 from money_warp.tz import ensure_aware, now
 from money_warp.warp import Warp, WarpedTime
 
@@ -182,43 +184,101 @@ def _load_money_warp_loan_impl(self):
 # SQL helpers — rate conversion
 # ---------------------------------------------------------------------------
 
+# Period-name lookups derived from CompoundingFrequency, keyed by representation.
+# JSON uses freq.name.lower(); string uses the tokens from types._FREQUENCY_TOKEN.
+_PERIOD_NAMES: dict[str, dict[CompoundingFrequency, str]] = {
+    "json": {freq: freq.name.lower() for freq in CompoundingFrequency},
+    "string": {freq: token for freq, token in _FREQUENCY_TOKEN.items()},
+}
 
-def _effective_annual_expr(rate_col):
-    """SQL CASE converting any stored JSON rate to an effective annual rate.
 
-    Mirrors :meth:`Rate._to_effective_annual` for all
-    :class:`CompoundingFrequency` values stored in the JSON ``period`` field.
+def _get_rate_col_info(cls, attr_name):
+    """Introspect a rate column's type to get ``(representation, default_year_size)``."""
+    col_type = getattr(cls, attr_name).property.columns[0].type
+    representation = getattr(col_type, "representation", "json")
+    year_size = getattr(col_type, "rate_year_size", None)
+    default_year_size = float(year_size.value) if year_size is not None else 365.0
+    return representation, default_year_size
+
+
+def _extract_rate_params(rate_col, representation, default_year_size):
+    """Extract ``(decimal_rate, period, year_size)`` as SQL expressions.
+
+    For JSON: reads ``$.rate``, ``$.period``, ``$.year_size`` via ``json_extract``.
+    For string: parses ``"5.250% annual"`` via ``SUBSTR``/``INSTR``; uses
+    *default_year_size* since the string format does not embed year size.
     """
-    rate = cast(func.json_extract(rate_col, "$.rate"), Float)
-    period = func.json_extract(rate_col, "$.period")
-    year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
+    if representation == "json":
+        rate = cast(func.json_extract(rate_col, "$.rate"), Float)
+        period = func.json_extract(rate_col, "$.period")
+        year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
+    else:
+        pct_pos = func.instr(rate_col, "%")
+        rate = cast(func.substr(rate_col, 1, pct_pos - 1), Float) / 100.0
+        period = func.trim(func.substr(rate_col, pct_pos + 1))
+        year_size = default_year_size
+    return rate, period, year_size
 
+
+def _periods_per_year_expr(period, year_size, representation):
+    """Map a period name to its periods-per-year value in SQL.
+
+    Generated from :class:`CompoundingFrequency` — no hardcoded magic numbers.
+    ``CONTINUOUS`` is excluded (handled separately via ``exp()``).
+    """
+    names = _PERIOD_NAMES[representation]
+    branches = []
+    for freq in CompoundingFrequency:
+        if freq == CompoundingFrequency.CONTINUOUS:
+            continue
+        name = names.get(freq)
+        if name is None:
+            continue
+        n = year_size if freq == CompoundingFrequency.DAILY else float(freq.value)
+        branches.append((period == name, n))
+    return case(*branches, else_=1.0)
+
+
+def _effective_annual_from_params(rate, period, n):
+    """Apply the effective-annual formula to pre-extracted SQL params.
+
+    Mirrors :meth:`Rate._to_effective_annual`.
+    """
     return case(
-        (period == "annually", rate),
-        (period == "monthly", func.pow(1.0 + rate, 12.0) - 1.0),
-        (period == "quarterly", func.pow(1.0 + rate, 4.0) - 1.0),
-        (period == "semi_annually", func.pow(1.0 + rate, 2.0) - 1.0),
-        (period == "daily", func.pow(1.0 + rate, year_size) - 1.0),
         (period == "continuous", func.exp(rate) - 1.0),
-        else_=rate,
+        else_=func.pow(1.0 + rate, n) - 1.0,
     )
 
 
-def _daily_rate_expr(rate_col):
-    """SQL expression for the daily rate derived from a JSON-stored rate.
+def _effective_annual_expr(rate_col, representation, default_year_size):
+    """SQL expression converting any stored rate to effective annual."""
+    rate, period, year_size = _extract_rate_params(rate_col, representation, default_year_size)
+    n = _periods_per_year_expr(period, year_size, representation)
+    return _effective_annual_from_params(rate, period, n)
+
+
+def _daily_rate_expr(rate_col, representation, default_year_size):
+    """SQL expression for the daily rate from a stored rate column.
 
     Returns the stored rate directly when the period is already daily;
     otherwise converts through the effective annual rate.
+    Mirrors :meth:`Rate.to_daily`.
     """
-    rate = cast(func.json_extract(rate_col, "$.rate"), Float)
-    period = func.json_extract(rate_col, "$.period")
-    year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
-    eff_annual = _effective_annual_expr(rate_col)
+    rate, period, year_size = _extract_rate_params(rate_col, representation, default_year_size)
+    n = _periods_per_year_expr(period, year_size, representation)
+    eff_annual = _effective_annual_from_params(rate, period, n)
 
     return case(
         (period == "daily", rate),
         else_=func.pow(1.0 + eff_annual, 1.0 / year_size) - 1.0,
     )
+
+
+def _has_rate(rate_col, representation):
+    """SQL expression that is NULL when no parseable rate is present."""
+    if representation == "json":
+        return cast(func.json_extract(rate_col, "$.rate"), Float)
+    return rate_col
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +292,7 @@ def _build_sql_balance_expression(cls, as_of, meta):
     Uses nested CTEs (``nesting=True``) inside a single scalar subquery
     so that each computation step is named and readable.  Falls back to
     ``COALESCE(remaining_balance, principal)`` when the interest rate
-    JSON is NULL (defensive guard for data that was stored without full
+    is NULL (defensive guard for data that was stored without full
     loan parameters).
     """
     info = _resolve_settlement_info(cls, meta["settlements"])
@@ -244,6 +304,9 @@ def _build_sql_balance_expression(cls, as_of, meta):
     gp_col = getattr(cls, meta["grace_period_days"])
     mir_col = getattr(cls, meta["mora_interest_rate"])
     ms_col = getattr(cls, meta["mora_strategy"])
+
+    ir_repr, ir_ys = _get_rate_col_info(cls, meta["interest_rate"])
+    mir_repr, mir_ys = _get_rate_col_info(cls, meta["mora_interest_rate"])
 
     # -- CTE 1: loan_state -------------------------------------------------
     # Uses scalar subqueries so this always returns exactly 1 row even
@@ -278,8 +341,8 @@ def _build_sql_balance_expression(cls, as_of, meta):
     # -- CTE 3: daily_rates ------------------------------------------------
     daily_rates = (
         select(
-            _daily_rate_expr(ir_col).label("daily_rate"),
-            func.coalesce(_daily_rate_expr(mir_col), 0.0).label("mora_daily_rate"),
+            _daily_rate_expr(ir_col, ir_repr, ir_ys).label("daily_rate"),
+            func.coalesce(_daily_rate_expr(mir_col, mir_repr, mir_ys), 0.0).label("mora_daily_rate"),
         )
         .correlate(cls)
         .cte("daily_rates", nesting=True)
@@ -410,10 +473,10 @@ def _build_sql_balance_expression(cls, as_of, meta):
         .scalar_subquery()
     )
 
-    # -- Simple fallback (defensive: rate JSON is NULL) --------------------
+    # -- Simple fallback (defensive: rate is NULL) -------------------------
     simple_balance = func.coalesce(last_balance_sq, pr_col)
 
-    rate_present = cast(func.json_extract(ir_col, "$.rate"), Float)
+    rate_present = _has_rate(ir_col, ir_repr)
     return case(
         (rate_present.is_(None), simple_balance),
         else_=full_balance_sq,

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -99,6 +99,36 @@ class LoanRecord(Base):
     settlements = relationship("SettlementRecord", order_by="SettlementRecord.payment_date")
 
 
+@settlement_bridge()
+class StringSettlementRecord(Base):
+    __tablename__ = "string_settlements"
+    id = Column(Integer, primary_key=True)
+    loan_id = Column(Integer, ForeignKey("string_loans.id"))
+    amount = Column(MoneyType())
+    payment_date = Column(DateTime)
+    remaining_balance = Column(MoneyType())
+    interest_date = Column(DateTime, nullable=True)
+    processing_date = Column(DateTime, nullable=True)
+
+
+@loan_bridge()
+class StringLoanRecord(Base):
+    __tablename__ = "string_loans"
+    id = Column(Integer, primary_key=True)
+    principal = Column(MoneyType())
+    interest_rate = Column(InterestRateType(representation="string"), nullable=True)
+    disbursement_date = Column(DateTime, nullable=True)
+    due_dates = Column(JSON, nullable=True)
+    fine_rate = Column(Numeric(), nullable=True)
+    grace_period_days = Column(Integer(), nullable=True)
+    mora_interest_rate = Column(InterestRateType(representation="string"), nullable=True)
+    mora_strategy = Column(String(), nullable=True)
+    settlements = relationship(
+        "StringSettlementRecord",
+        order_by="StringSettlementRecord.payment_date",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -116,6 +146,8 @@ def session(engine):
     with Session(engine) as s:
         LoanRecordFactory._meta.sqlalchemy_session = s
         SettlementRecordFactory._meta.sqlalchemy_session = s
+        StringLoanRecordFactory._meta.sqlalchemy_session = s
+        StringSettlementRecordFactory._meta.sqlalchemy_session = s
         yield s
 
 
@@ -211,6 +243,33 @@ class LoanRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
 class SettlementRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = SettlementRecord
+        sqlalchemy_session_persistence = "flush"
+
+    amount = factory.LazyFunction(lambda: Money("3000"))
+    payment_date = factory.LazyFunction(lambda: datetime(2024, 2, 1, tzinfo=timezone.utc))
+    remaining_balance = factory.LazyFunction(lambda: Money("7000"))
+    interest_date = None
+    processing_date = None
+
+
+class StringLoanRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = StringLoanRecord
+        sqlalchemy_session_persistence = "flush"
+
+    principal = factory.LazyFunction(lambda: Money("10000"))
+    interest_rate = factory.LazyFunction(lambda: InterestRate("10% a"))
+    disbursement_date = factory.LazyFunction(lambda: datetime(2024, 1, 1, tzinfo=timezone.utc))
+    due_dates = factory.LazyFunction(lambda: ["2024-02-01T00:00:00+00:00", "2024-03-01T00:00:00+00:00"])
+    fine_rate = None
+    grace_period_days = None
+    mora_interest_rate = None
+    mora_strategy = None
+
+
+class StringSettlementRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = StringSettlementRecord
         sqlalchemy_session_persistence = "flush"
 
     amount = factory.LazyFunction(lambda: Money("3000"))

--- a/tests/ext/sa/test_sa_integration.py
+++ b/tests/ext/sa/test_sa_integration.py
@@ -19,6 +19,8 @@ from .conftest import (
     _LATE_PAYMENT_DUE_DATES,
     LoanRecord,
     LoanRecordFactory,
+    StringLoanRecord,
+    StringLoanRecordFactory,
 )
 
 _LOAN_PRINCIPAL = Money("10000")
@@ -219,5 +221,70 @@ def test_balance_at_sql_matches_python_various_mora_rate_periods(session, mora_r
     expected = float(loaded.balance_at(as_of).raw_amount)
 
     sql_result = session.execute(select(LoanRecord.balance_at(as_of)).where(LoanRecord.id == sa_loan.id)).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+# ===========================================================================
+# balance_at(date) — string representation SQL side
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rate_str",
+    [
+        "10% a",
+        "1% m",
+        "3% q",
+        "5% s",
+        "0.03% d",
+    ],
+    ids=["annual", "monthly", "quarterly", "semi_annual", "daily"],
+)
+def test_string_repr_balance_at_sql_matches_python(session, rate_str):
+    """SQL CTE with string-representation rates matches Python balance."""
+    sa_loan = StringLoanRecordFactory(interest_rate=InterestRate(rate_str))
+    session.expire_all()
+    loaded = session.get(StringLoanRecord, sa_loan.id)
+
+    as_of = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(
+        select(StringLoanRecord.balance_at(as_of)).where(StringLoanRecord.id == sa_loan.id)
+    ).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "mora_rate_str",
+    [
+        "12% a",
+        "1% m",
+        "3% q",
+    ],
+    ids=["annual", "monthly", "quarterly"],
+)
+def test_string_repr_balance_at_sql_matches_python_mora(session, mora_rate_str):
+    """SQL CTE with string-representation mora rates matches Python balance."""
+    sa_loan = StringLoanRecordFactory(
+        interest_rate=InterestRate("6% a"),
+        mora_interest_rate=InterestRate(mora_rate_str),
+        mora_strategy="COMPOUND",
+        fine_rate=Decimal("0.02"),
+        grace_period_days=0,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        due_dates=[d.isoformat() for d in _LATE_PAYMENT_DUE_DATES],
+    )
+    session.expire_all()
+    loaded = session.get(StringLoanRecord, sa_loan.id)
+
+    as_of = datetime(2025, 3, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(
+        select(StringLoanRecord.balance_at(as_of)).where(StringLoanRecord.id == sa_loan.id)
+    ).scalar()
 
     assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)


### PR DESCRIPTION
## Summary

- **Data-driven rate SQL bridge**: Replace hardcoded CASE branches in `_effective_annual_expr` with mapping generated from `CompoundingFrequency` enum. Add `_extract_rate_params`, `_periods_per_year_expr`, and `_has_rate` helpers that branch on the column's representation (json/string). Introspect `InterestRateType` at expression-build time to determine format and default year_size -- no SQL-side format detection.
- **String representation support**: The SQL `balance_at` expression now works with both `InterestRateType(representation="json")` and `InterestRateType(representation="string")` columns. String rates like `"5.000% annual"` are parsed in SQL via `SUBSTR`/`INSTR`.
- **Simplified README**: Slimmed from ~660 to ~110 lines, keeping only Quick Start and Time Machine examples. Everything else links to the docs site.
- **New docs pages**: Added `docs/examples/marshmallow.md` and `docs/examples/sqlalchemy.md` covering all column types, bridge decorators, and string support.
- **Fixed stale docs**: Updated badges, test count (1200+), PyPI status, and mkdocs nav to include Tax, Timezone, and extension pages.

## Test plan

- [x] All 1277 existing tests pass (including 76 SA integration tests)
- [x] 8 new parametrized tests verify string-format SQL balance matches Python for interest rates (annual, monthly, quarterly, semi-annual, daily) and mora rates (annual, monthly, quarterly)
- [x] JSON-format tests unchanged and passing


Made with [Cursor](https://cursor.com)