### PR TITLE
feat: make MoneyType precision and scale configurable

### DIFF
--- a/docs/examples/sqlalchemy.md
+++ b/docs/examples/sqlalchemy.md
@@ -12,12 +12,19 @@ pip install money-warp[sa]
 
 ### MoneyType
 
-Stores `Money` instances. The `representation` parameter controls the column type and conversion:
+Stores `Money` instances:
+
+```python
+MoneyType(representation="raw", precision=20, scale=10)
+```
+
+- `representation` controls the storage format (see table below).
+- `precision` and `scale` set the `Numeric` column dimensions. Ignored when `representation="cents"` (uses `Integer`).
 
 | Representation | Column type | Bind (Money -> DB) | Result (DB -> Money) |
 |---|---|---|---|
-| `"raw"` (default) | `Numeric(20,10)` | `money.raw_amount` | `Money(value)` |
-| `"real"` | `Numeric(20,10)` | `money.real_amount` | `Money(value)` |
+| `"raw"` (default) | `Numeric(precision, scale)` | `money.raw_amount` | `Money(value)` |
+| `"real"` | `Numeric(precision, scale)` | `money.real_amount` | `Money(value)` |
 | `"cents"` | `Integer` | `money.cents` | `Money.from_cents(value)` |
 
 `process_bind_param` also accepts raw `Decimal`/`int`/`float` values (passthrough) so that SQL comparisons like `LoanRecord.balance > Decimal("1000")` work without wrapping in `Money`.

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -54,12 +54,19 @@ All public symbols are re-exported from `__init__.py`, so `from money_warp.ext.s
 
 ### MoneyType
 
-`TypeDecorator` storing `Money` instances. Configurable `representation` parameter:
+`TypeDecorator` storing `Money` instances. Constructor signature:
+
+```python
+MoneyType(representation="raw", precision=20, scale=10)
+```
+
+- `representation` controls the storage format (see table below).
+- `precision` and `scale` set the `Numeric` column dimensions. Ignored when `representation="cents"` (uses `Integer`).
 
 | Representation | Column type | Bind (Money -> DB) | Result (DB -> Money) |
 |----------------|-------------|---------------------|----------------------|
-| `"raw"` (default) | `Numeric(20,10)` | `money.raw_amount` | `Money(value)` |
-| `"real"` | `Numeric(20,10)` | `money.real_amount` | `Money(value)` |
+| `"raw"` (default) | `Numeric(precision, scale)` | `money.raw_amount` | `Money(value)` |
+| `"real"` | `Numeric(precision, scale)` | `money.real_amount` | `Money(value)` |
 | `"cents"` | `Integer` | `money.cents` | `Money.from_cents(value)` |
 
 `process_bind_param` also accepts raw `Decimal`/`int`/`float` values (passthrough) so that SQL expression comparisons like `LoanRecord.balance > Decimal("1000")` work without wrapping in `Money`.

--- a/money_warp/ext/sa/types.py
+++ b/money_warp/ext/sa/types.py
@@ -30,23 +30,34 @@ class MoneyType(TypeDecorator):
             ``"raw"`` (default) -- ``Numeric`` column storing ``raw_amount``.
             ``"real"`` -- ``Numeric`` column storing ``real_amount``.
             ``"cents"`` -- ``Integer`` column storing cents.
+        precision: Total number of digits for the ``Numeric`` column
+            (ignored when *representation* is ``"cents"``).
+        scale: Number of fractional digits for the ``Numeric`` column
+            (ignored when *representation* is ``"cents"``).
     """
 
     impl = Numeric
     cache_ok = True
 
-    def __init__(self, representation: str = "raw") -> None:
+    def __init__(
+        self,
+        representation: str = "raw",
+        precision: int = 20,
+        scale: int = 10,
+    ) -> None:
         if representation not in _VALID_MONEY_REPRESENTATIONS:
             raise ValueError(
                 f"Invalid representation: '{representation}'. Expected one of {_VALID_MONEY_REPRESENTATIONS}"
             )
         self.representation = representation
+        self.precision = precision
+        self.scale = scale
         super().__init__()
 
     def load_dialect_impl(self, dialect):
         if self.representation == "cents":
             return dialect.type_descriptor(Integer())
-        return dialect.type_descriptor(Numeric(precision=20, scale=10))
+        return dialect.type_descriptor(Numeric(precision=self.precision, scale=self.scale))
 
     def process_bind_param(self, value, dialect) -> Any:
         if value is None:

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -48,6 +48,12 @@ class MoneyCentsModel(Base):
     amount = Column(MoneyType(representation="cents"))
 
 
+class MoneyCustomPrecisionModel(Base):
+    __tablename__ = "money_custom_precision"
+    id = Column(Integer, primary_key=True)
+    amount = Column(MoneyType(representation="raw", precision=10, scale=2))
+
+
 class RateStringModel(Base):
     __tablename__ = "rate_string"
     id = Column(Integer, primary_key=True)

--- a/tests/ext/sa/test_sa_money_type.py
+++ b/tests/ext/sa/test_sa_money_type.py
@@ -3,11 +3,12 @@
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import Integer
 
 from money_warp.ext.sa import MoneyType
 from money_warp.money import Money
 
-from .conftest import MoneyCentsModel, MoneyRawModel, MoneyRealModel
+from .conftest import MoneyCentsModel, MoneyCustomPrecisionModel, MoneyRawModel, MoneyRealModel
 
 # ===========================================================================
 # Construction
@@ -23,6 +24,40 @@ def test_money_type_invalid_representation_raises():
 def test_money_type_valid_representation_accepted(representation):
     col_type = MoneyType(representation=representation)
     assert col_type.representation == representation
+
+
+def test_money_type_default_precision_and_scale():
+    col_type = MoneyType()
+    assert col_type.precision == 20
+    assert col_type.scale == 10
+
+
+def test_money_type_custom_precision_and_scale():
+    col_type = MoneyType(precision=12, scale=4)
+    assert col_type.precision == 12
+    assert col_type.scale == 4
+
+
+def test_money_type_cents_ignores_precision_and_scale(session):
+    col_type = MoneyType(representation="cents", precision=8, scale=3)
+    assert col_type.precision == 8
+    assert col_type.scale == 3
+    dialect_impl = col_type.load_dialect_impl(session.bind.dialect)
+    assert isinstance(dialect_impl, Integer)
+
+
+# ===========================================================================
+# Round-trip with custom precision/scale
+# ===========================================================================
+
+
+def test_money_type_roundtrip_custom_precision(session):
+    original = Money("12345.67")
+    session.add(MoneyCustomPrecisionModel(id=1, amount=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(MoneyCustomPrecisionModel, 1)
+    assert loaded.amount.real_amount == Decimal("12345.67")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- `MoneyType` now accepts optional `precision` and `scale` parameters (default `20`/`10`) instead of hardcoding the `Numeric` column dimensions.
- Backward compatible -- existing code using `MoneyType()` or `MoneyType(representation="raw")` is unchanged.

## Changes
- Added `precision` and `scale` parameters to `MoneyType.__init__`
- `load_dialect_impl` uses `self.precision` / `self.scale` instead of hardcoded values
- `"cents"` representation continues to ignore these parameters and use `Integer`

## Test plan
- [x] All existing tests pass (`poetry run pytest` -- 1292 passed)
- [x] New tests verify default values, custom values, cents-ignores-precision, and round-trip with custom precision

## Docs
- Updated `docs/examples/sqlalchemy.md` with new constructor signature and parameter docs
- Updated `knowledge/ext.md` with new API surface

Made with [Cursor](https://cursor.com)