### PR TITLE
feat: support abbreviated frequency tokens in SA extension

### DIFF
--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -70,8 +70,10 @@ All public symbols are re-exported from `__init__.py`, so `from money_warp.ext.s
 
 | Representation | Column type | Example stored value |
 |----------------|-------------|--------------------------------------|
-| `"string"` (default) | `String` | `"5.250% annual"` |
+| `"string"` (default) | `String` | `"5.250% annual"` or `"5.250% a.a."` |
 | `"json"` | `JSON` | `{"rate": "0.0525", "period": "annually", ...}` |
+
+String serialization respects the Rate's `str_style`: rates with `str_style="abbrev"` are stored with abbreviated tokens (e.g., `"5.250% a.a."`), while `str_style="long"` (the default) uses long tokens (e.g., `"5.250% annual"`). Deserialization handles both formats transparently since `Rate(...)` parses both.
 
 Same deserialization knobs as the Marshmallow `RateField`: `year_size`, `precision`, `rounding`, `str_style`.
 
@@ -152,7 +154,7 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 - JSON: uses `json_extract` for all three values.
 - String: parses `"5.250% annual"` via `SUBSTR`/`INSTR`, divides the percentage by 100; uses the column type's `default_year_size` since the string format does not embed year size.
 
-**Period mapping:** `_periods_per_year_expr(period, year_size, representation)` builds a SQL `CASE` generated from `CompoundingFrequency` — no hardcoded magic numbers. Period names differ by representation (JSON: `"annually"`, `"semi_annually"`; string: `"annual"`, `"semi-annual"` via `_FREQUENCY_TOKEN`). `CONTINUOUS` is excluded (handled separately via `exp()`). `DAILY` uses `year_size` instead of a fixed value.
+**Period mapping:** `_periods_per_year_expr(period, year_size, representation)` builds a SQL `CASE` generated from `CompoundingFrequency` — no hardcoded magic numbers. Period names differ by representation (JSON: `"annually"`, `"semi_annually"`; string: both long tokens like `"annual"`, `"semi-annual"` and abbreviated tokens like `"a.a."`, `"a.s."` from `_ABBREV_MAP`). Each frequency generates CASE branches for all its recognized tokens. `CONTINUOUS` is excluded (handled separately via `exp()`). `DAILY` uses `year_size` instead of a fixed value.
 
 **Conversion:** `_effective_annual_expr(rate_col, representation, default_year_size)` and `_daily_rate_expr(rate_col, representation, default_year_size)` combine the above. Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` which requires the SQLite math extension (available in Python 3.11+ / SQLite 3.35+).
 
@@ -161,7 +163,7 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 ## Design Decisions
 
 - **`RATE_CLASS` pattern:** Both Marshmallow and SA extensions use `RATE_CLASS` on the Rate field/type. `InterestRateField`/`InterestRateType` override this to `InterestRate`, avoiding code duplication.
-- **Parseable string serialization:** String mode uses `_FREQUENCY_TOKEN` mapping instead of `str(rate)` because `Rate.__str__()` outputs `"annually"` / `"semi_annually"` which the Rate parser does not accept. The mapping outputs parser-compatible tokens like `"annual"` and `"semi-annual"`. Both extensions duplicate this mapping (each is self-contained).
+- **Parseable string serialization:** String mode uses `_FREQUENCY_TOKEN` (long tokens) or `_ABBREV_MAP` (abbreviated tokens) depending on the Rate's `str_style`. This avoids using `str(rate)` directly because `Rate.__str__()` outputs `"annually"` / `"semi_annually"` which the Rate parser does not accept. The mapping outputs parser-compatible tokens like `"annual"` / `"semi-annual"` or `"a.a."` / `"a.s."`. Both extensions duplicate the long-token mapping (each is self-contained); `_ABBREV_MAP` is imported from `money_warp.rate`.
 - **Private attribute access:** Dict/JSON serialization reads `value._precision`, `value._rounding`, `value._str_style` since there are no public getters. Acceptable because these are first-party extensions.
 - **Optional dependencies:** Each extension is declared optional in `pyproject.toml` under `[tool.poetry.extras]`. Importing without the dependency installed raises `ImportError`.
 - **Two-decorator bridge pattern:** `@settlement_bridge` stores metadata, `@loan_bridge` reads it. Both store `_money_warp_bridge_meta` (namespaced to avoid collisions). This keeps each model self-describing and avoids passing settlement column names through the loan decorator.
@@ -184,6 +186,6 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 - **SQL vs Python precision:** The SQL CTE expression uses float64 arithmetic while Python uses `Decimal`. For exact comparisons in tests, use approximate matching (e.g., `pytest.approx`) when comparing SQL results against Python `balance_at`.
 - **JSON NULL vs SQL NULL:** SQLAlchemy's `JSON` type stores Python `None` as the string `'null'` rather than SQL `NULL`. For JSON representation, the NULL guard checks `json_extract(interest_rate, '$.rate') IS NULL` which correctly handles both cases since `json_extract('null', '$.rate')` returns NULL.
 - **Mora rate NULL handling:** When `mora_interest_rate` is NULL, the helper functions cascade NULL through `pow()`. The `daily_rates` CTE coalesces the mora daily rate to 0.0 to prevent this from nullifying the entire expression.
-- **Data-driven period mapping:** The SQL `CASE` branches in `_periods_per_year_expr` are generated from the `CompoundingFrequency` enum and `_FREQUENCY_TOKEN` mapping. Adding a new `CompoundingFrequency` member and its token automatically extends both JSON and string SQL support.
+- **Data-driven period mapping:** The SQL `CASE` branches in `_periods_per_year_expr` are generated from the `CompoundingFrequency` enum, `_FREQUENCY_TOKEN`, and `_ABBREV_MAP`. Each frequency maps to a list of recognized tokens (long and abbreviated). Adding a new `CompoundingFrequency` member and its tokens automatically extends both JSON and string SQL support.
 - **String representation year_size limitation:** The string format (e.g., `"5.250% annual"`) does not embed `year_size`. The SQL helpers use the `rate_year_size` default from the column's `InterestRateType` definition. If different rates on the same column need different year sizes, use JSON representation instead.
 - **Continuous compounding in string format:** `CompoundingFrequency.CONTINUOUS` is not in `_FREQUENCY_TOKEN` and cannot be serialized as a string. Use JSON representation for continuous rates.

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
 from money_warp.ext.sa.types import _FREQUENCY_TOKEN
 from money_warp.loan import Loan, MoraStrategy
-from money_warp.rate import CompoundingFrequency
+from money_warp.rate import _ABBREV_MAP, CompoundingFrequency
 from money_warp.tz import ensure_aware, now
 from money_warp.warp import Warp, WarpedTime
 
@@ -185,10 +185,11 @@ def _load_money_warp_loan_impl(self):
 # ---------------------------------------------------------------------------
 
 # Period-name lookups derived from CompoundingFrequency, keyed by representation.
-# JSON uses freq.name.lower(); string uses the tokens from types._FREQUENCY_TOKEN.
-_PERIOD_NAMES: dict[str, dict[CompoundingFrequency, str]] = {
-    "json": {freq: freq.name.lower() for freq in CompoundingFrequency},
-    "string": {freq: token for freq, token in _FREQUENCY_TOKEN.items()},
+# JSON uses freq.name.lower(); string accepts both long tokens from
+# _FREQUENCY_TOKEN ("annual") and abbreviated tokens from _ABBREV_MAP ("a.a.").
+_PERIOD_NAMES: dict[str, dict[CompoundingFrequency, list[str]]] = {
+    "json": {freq: [freq.name.lower()] for freq in CompoundingFrequency},
+    "string": {freq: [_FREQUENCY_TOKEN[freq], _ABBREV_MAP[freq]] for freq in _FREQUENCY_TOKEN},
 }
 
 
@@ -225,27 +226,30 @@ def _periods_per_year_expr(period, year_size, representation):
 
     Generated from :class:`CompoundingFrequency` — no hardcoded magic numbers.
     ``CONTINUOUS`` is excluded (handled separately via ``exp()``).
+    Each frequency may have multiple recognized tokens (long and abbreviated).
     """
     names = _PERIOD_NAMES[representation]
     branches = []
     for freq in CompoundingFrequency:
         if freq == CompoundingFrequency.CONTINUOUS:
             continue
-        name = names.get(freq)
-        if name is None:
+        freq_names = names.get(freq)
+        if not freq_names:
             continue
         n = year_size if freq == CompoundingFrequency.DAILY else float(freq.value)
-        branches.append((period == name, n))
+        for name in freq_names:
+            branches.append((period == name, n))
     return case(*branches, else_=1.0)
 
 
-def _effective_annual_from_params(rate, period, n):
+def _effective_annual_from_params(rate, period, n, representation):
     """Apply the effective-annual formula to pre-extracted SQL params.
 
     Mirrors :meth:`Rate._to_effective_annual`.
     """
+    continuous_names = _PERIOD_NAMES[representation].get(CompoundingFrequency.CONTINUOUS, [])
     return case(
-        (period == "continuous", func.exp(rate) - 1.0),
+        (period.in_(continuous_names), func.exp(rate) - 1.0),
         else_=func.pow(1.0 + rate, n) - 1.0,
     )
 
@@ -254,7 +258,7 @@ def _effective_annual_expr(rate_col, representation, default_year_size):
     """SQL expression converting any stored rate to effective annual."""
     rate, period, year_size = _extract_rate_params(rate_col, representation, default_year_size)
     n = _periods_per_year_expr(period, year_size, representation)
-    return _effective_annual_from_params(rate, period, n)
+    return _effective_annual_from_params(rate, period, n, representation)
 
 
 def _daily_rate_expr(rate_col, representation, default_year_size):
@@ -266,10 +270,11 @@ def _daily_rate_expr(rate_col, representation, default_year_size):
     """
     rate, period, year_size = _extract_rate_params(rate_col, representation, default_year_size)
     n = _periods_per_year_expr(period, year_size, representation)
-    eff_annual = _effective_annual_from_params(rate, period, n)
+    eff_annual = _effective_annual_from_params(rate, period, n, representation)
 
+    daily_names = _PERIOD_NAMES[representation].get(CompoundingFrequency.DAILY, [])
     return case(
-        (period == "daily", rate),
+        (period.in_(daily_names), rate),
         else_=func.pow(1.0 + eff_annual, 1.0 / year_size) - 1.0,
     )
 

--- a/money_warp/ext/sa/types.py
+++ b/money_warp/ext/sa/types.py
@@ -8,7 +8,7 @@ from sqlalchemy.types import TypeDecorator
 
 from money_warp.interest_rate import InterestRate
 from money_warp.money import Money
-from money_warp.rate import CompoundingFrequency, Rate, YearSize
+from money_warp.rate import _ABBREV_MAP, CompoundingFrequency, Rate, YearSize
 
 _VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents")
 _VALID_RATE_REPRESENTATIONS = ("string", "json")
@@ -114,7 +114,8 @@ class RateType(TypeDecorator):
             return None
 
         if self.representation == "string":
-            token = _FREQUENCY_TOKEN[value.period]
+            is_abbrev = getattr(value, "_str_style", "long") == "abbrev"
+            token = _ABBREV_MAP[value.period] if is_abbrev else _FREQUENCY_TOKEN[value.period]
             return f"{value.as_percentage:.3f}% {token}"
 
         return {

--- a/tests/ext/sa/test_sa_integration.py
+++ b/tests/ext/sa/test_sa_integration.py
@@ -288,3 +288,68 @@ def test_string_repr_balance_at_sql_matches_python_mora(session, mora_rate_str):
     ).scalar()
 
     assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+# ===========================================================================
+# balance_at(date) — abbreviated string representation SQL side
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rate_str",
+    [
+        "10% a.a.",
+        "1% a.m.",
+        "3% a.t.",
+        "5% a.s.",
+        "0.03% a.d.",
+    ],
+    ids=["annual", "monthly", "quarterly", "semi_annual", "daily"],
+)
+def test_string_repr_abbrev_balance_at_sql_matches_python(session, rate_str):
+    """SQL CTE with abbreviated string-representation rates matches Python balance."""
+    sa_loan = StringLoanRecordFactory(interest_rate=InterestRate(rate_str))
+    session.expire_all()
+    loaded = session.get(StringLoanRecord, sa_loan.id)
+
+    as_of = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(
+        select(StringLoanRecord.balance_at(as_of)).where(StringLoanRecord.id == sa_loan.id)
+    ).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "mora_rate_str",
+    [
+        "12% a.a.",
+        "1% a.m.",
+        "3% a.t.",
+    ],
+    ids=["annual", "monthly", "quarterly"],
+)
+def test_string_repr_abbrev_balance_at_sql_matches_python_mora(session, mora_rate_str):
+    """SQL CTE with abbreviated string-representation mora rates matches Python balance."""
+    sa_loan = StringLoanRecordFactory(
+        interest_rate=InterestRate("6% a.a."),
+        mora_interest_rate=InterestRate(mora_rate_str),
+        mora_strategy="COMPOUND",
+        fine_rate=Decimal("0.02"),
+        grace_period_days=0,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        due_dates=[d.isoformat() for d in _LATE_PAYMENT_DUE_DATES],
+    )
+    session.expire_all()
+    loaded = session.get(StringLoanRecord, sa_loan.id)
+
+    as_of = datetime(2025, 3, 20, tzinfo=timezone.utc)
+    expected = float(loaded.balance_at(as_of).raw_amount)
+
+    sql_result = session.execute(
+        select(StringLoanRecord.balance_at(as_of)).where(StringLoanRecord.id == sa_loan.id)
+    ).scalar()
+
+    assert float(sql_result.raw_amount) == pytest.approx(expected, abs=1e-4)

--- a/tests/ext/sa/test_sa_rate_type.py
+++ b/tests/ext/sa/test_sa_rate_type.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import text
 
 from money_warp.ext.sa import RateType
 from money_warp.interest_rate import InterestRate
@@ -143,5 +144,57 @@ def test_interest_rate_type_roundtrip_json(session):
     session.flush()
     session.expire_all()
     loaded = session.get(InterestRateJsonModel, 1)
+    assert isinstance(loaded.rate, InterestRate)
+    assert loaded.rate == original
+
+
+# ===========================================================================
+# RateType — abbreviated string round-trips
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rate_string,expected_stored_token",
+    [
+        ("5.25% a.a.", "a.a."),
+        ("1.5% a.m.", "a.m."),
+        ("0.03% a.d.", "a.d."),
+        ("2.5% a.t.", "a.t."),
+        ("3.0% a.s.", "a.s."),
+    ],
+    ids=["annually", "monthly", "daily", "quarterly", "semi_annually"],
+)
+def test_rate_type_roundtrip_string_abbreviated(session, rate_string, expected_stored_token):
+    original = Rate(rate_string)
+    session.add(RateStringModel(id=1, rate=original))
+    session.flush()
+
+    raw = session.execute(text("SELECT rate FROM rate_string WHERE id = 1")).scalar()
+    assert raw.endswith(expected_stored_token)
+
+    session.expire_all()
+    loaded = session.get(RateStringModel, 1)
+    assert loaded.rate == original
+
+
+def test_rate_type_abbreviated_preserves_str_style(session):
+    original = Rate("5.25% a.a.")
+    session.add(RateStringModel(id=1, rate=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(RateStringModel, 1)
+    assert loaded.rate._str_style == "abbrev"
+
+
+def test_interest_rate_type_roundtrip_string_abbreviated(session):
+    original = InterestRate("5.25% a.a.")
+    session.add(InterestRateStringModel(id=1, rate=original))
+    session.flush()
+
+    raw = session.execute(text("SELECT rate FROM interest_rate_string WHERE id = 1")).scalar()
+    assert raw == "5.250% a.a."
+
+    session.expire_all()
+    loaded = session.get(InterestRateStringModel, 1)
     assert isinstance(loaded.rate, InterestRate)
     assert loaded.rate == original


### PR DESCRIPTION
## Summary
- `RateType.process_bind_param` now respects `str_style="abbrev"`, serializing rates with abbreviated tokens (e.g., `"5.250% a.a."`) instead of always using long tokens
- Bridge SQL expressions (`_periods_per_year_expr`, `_daily_rate_expr`, `_effective_annual_from_params`) now match both long and abbreviated frequency tokens, so `balance_at` works correctly regardless of which format is stored
- `_PERIOD_NAMES` restructured from `dict[str, dict[Freq, str]]` to `dict[str, dict[Freq, list[str]]]` to hold both token families per frequency

## Changes
- `types.py`: Import `_ABBREV_MAP` from `money_warp.rate`; pick token based on `value._str_style`
- `bridge.py`: Import `_ABBREV_MAP`; expand `_PERIOD_NAMES["string"]` to include both long and abbreviated tokens; update `_periods_per_year_expr` to iterate all names per frequency; update `_daily_rate_expr` and `_effective_annual_from_params` to use `period.in_(names)` instead of hardcoded string comparisons
- `knowledge/ext.md`: Updated to document abbreviated token support

## Test plan
- [x] All existing tests pass (1303 passed, 5 xfailed)
- [x] Round-trip tests for all 5 abbreviated frequencies through `RateType(representation="string")`
- [x] Verify stored DB string uses abbreviated tokens (`SELECT rate FROM ...`)
- [x] `str_style="abbrev"` preserved through round-trip
- [x] `InterestRateType` round-trip with abbreviated tokens
- [x] `balance_at` SQL matches Python for all 5 abbreviated interest rate periods
- [x] `balance_at` SQL matches Python for abbreviated mora rate periods

## Docs
- Updated `knowledge/ext.md` with abbreviated token support details

Made with [Cursor](https://cursor.com)