### PR TITLE
feat: add __float__ dunder method to Money

### DIFF
--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -42,7 +42,7 @@ money_warp/
 
 ### Dual-Precision Money
 
-`Money` stores a `raw_amount: Decimal` at full precision for intermediate calculations and exposes a `real_amount: Decimal` rounded to 2 decimal places for display and comparison. All arithmetic returns new `Money` instances (immutable value object). Comparisons (`==`, `<`, `<=`, `>`, `>=`) use `real_amount`, so two values that round to the same cents are considered equal. Both `Money` and `Decimal` are accepted on the right-hand side, so `Money("100.50") == Decimal("100.50")` works directly without extracting `.real_amount`.
+`Money` stores a `raw_amount: Decimal` at full precision for intermediate calculations and exposes a `real_amount: Decimal` rounded to 2 decimal places for display and comparison. All arithmetic returns new `Money` instances (immutable value object). Comparisons (`==`, `<`, `<=`, `>`, `>=`) use `real_amount`, so two values that round to the same cents are considered equal. Both `Money` and `Decimal` are accepted on the right-hand side, so `Money("100.50") == Decimal("100.50")` works directly without extracting `.real_amount`. `float(money)` returns `float(raw_amount)` — full internal precision, useful for interop with libraries that expect plain floats.
 
 ### Rate and InterestRate
 

--- a/money_warp/money.py
+++ b/money_warp/money.py
@@ -60,6 +60,10 @@ class Money:
         """Absolute value."""
         return Money(abs(self._amount))
 
+    def __float__(self) -> float:
+        """Float representation using full internal precision."""
+        return float(self._amount)
+
     def _compare_value(self, other: object) -> Union[Decimal, type(NotImplemented)]:
         """Extract the Decimal value to compare against, or NotImplemented."""
         if isinstance(other, Money):

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -257,6 +257,25 @@ def test_money_to_real_money_real_amount():
     assert real_money.real_amount == Decimal("100.12")
 
 
+# Float conversion tests
+@pytest.mark.parametrize(
+    "amount,expected",
+    [
+        ("100.50", 100.50),
+        ("0.00", 0.0),
+        ("-50.25", -50.25),
+        ("100.123456789", 100.123456789),
+    ],
+)
+def test_money_float_conversion(amount, expected):
+    assert float(Money(amount)) == expected
+
+
+def test_money_float_returns_float_type():
+    result = float(Money("100.50"))
+    assert type(result) is float
+
+
 # Display tests
 @pytest.mark.parametrize(
     "amount,expected",


### PR DESCRIPTION
## Summary
- Add `Money.__float__()` so `float(Money(...))` returns the full-precision `raw_amount` as a Python float, enabling easy interop with libraries that expect plain floats.

## Changes
- `money_warp/money.py`: added `__float__` method after `__abs__`
- `tests/test_money.py`: added parametrized test covering typical, zero, negative, and high-precision cases, plus a type-check test
- `knowledge/architecture.md`: documented `__float__` in the Dual-Precision Money section

## Test plan
- [x] All existing tests pass (`poetry run pytest` — 1312 passed)
- [x] New `test_money_float_conversion` parametrized test covers 4 cases
- [x] New `test_money_float_returns_float_type` verifies return type

## Docs
- Updated `knowledge/architecture.md` with `__float__` note

Made with [Cursor](https://cursor.com)