### PR TITLE
feat: add precision support to Rate accessors (as_decimal, as_percentage, as_float)

### DIFF
--- a/.cursor/skills/validate-loan/SKILL.md
+++ b/.cursor/skills/validate-loan/SKILL.md
@@ -369,7 +369,7 @@ getcontext().prec = 50
 
 principal = Decimal("PRINCIPAL")
 monthly_rate = Decimal("MONTHLY_RATE")
-fine_rate = Decimal("0.02")  # default 2% (InterestRate.as_decimal)
+fine_rate = Decimal("0.02")  # default 2% (InterestRate.as_decimal())
 num_installments = NUM_INSTALLMENTS
 
 annual_rate = (1 + monthly_rate) ** 12 - 1
@@ -467,7 +467,7 @@ print(json.dumps(results, indent=2))
 
 **Key conventions** (from `knowledge/loan.md`):
 - Allocation order: fines first, then interest, then mora, then principal.
-- Fine = `fine_rate.as_decimal * expected_payment` from the **original** schedule. One fine per missed due date, never duplicated.
+- Fine = `fine_rate.as_decimal() * expected_payment` from the **original** schedule. One fine per missed due date, never duplicated.
 - Mora strategy defaults to COMPOUND: mora rate is applied to `balance + regular_interest`.
 - If `mora_interest_rate` is not specified, it defaults to `interest_rate`.
 - Anticipation: `interest_date = payment_date` (discount for fewer days).

--- a/docs/examples/interest_rates.md
+++ b/docs/examples/interest_rates.md
@@ -71,8 +71,9 @@ Safe access to decimal and percentage representations:
 ```python
 rate = InterestRate("6.5% a")
 
-print(f"As percentage: {rate.as_percentage}")  # 6.5
-print(f"As decimal: {rate.as_decimal}")        # 0.065
+print(f"As percentage: {rate.as_percentage()}")  # 6.5
+print(f"As decimal: {rate.as_decimal()()}")        # 0.065
+print(f"As float: {rate.as_float(4)}")           # 0.065
 print(f"Frequency: {rate.period}")             # CompoundingFrequency.ANNUALLY
 print(f"Display: {rate}")                      # 6.500% annually
 ```
@@ -118,8 +119,8 @@ print(f"Nominal annual: {nominal}")
 print(f"Effective monthly: {monthly_effective}")
 
 # Verify: 12 months of monthly rate should equal annual
-annual_check = (1 + monthly_effective.as_decimal) ** 12 - 1
-print(f"Verification: {annual_check:.6f} ≈ {nominal.as_decimal:.6f}")
+annual_check = (1 + monthly_effective.as_decimal()) ** 12 - 1
+print(f"Verification: {annual_check:.6f} ≈ {nominal.as_decimal():.6f}")
 ```
 
 **Output:**
@@ -152,7 +153,7 @@ def analyze_credit_card(balance, apr_string, monthly_payment):
     print()
     
     # Calculate monthly interest (30 days)
-    monthly_interest = balance * (daily_rate.as_decimal * 30)
+    monthly_interest = balance * (daily_rate.as_decimal() * 30)
     principal_payment = monthly_payment - monthly_interest
     
     print(f"Monthly breakdown:")
@@ -168,7 +169,7 @@ def analyze_credit_card(balance, apr_string, monthly_payment):
     current_balance = balance
     
     while current_balance > Money.zero() and months < 600:  # Max 50 years
-        interest = current_balance * (daily_rate.as_decimal * 30)
+        interest = current_balance * (daily_rate.as_decimal() * 30)
         principal = monthly_payment - interest
         
         if principal <= Money.zero():
@@ -277,7 +278,7 @@ def calculate_compound_returns(principal, daily_rate_pct, days):
     print()
     
     # Calculate compound growth
-    growth_factor = (1 + daily_rate.as_decimal) ** days
+    growth_factor = (1 + daily_rate.as_decimal()) ** days
     final_amount = principal * growth_factor
     total_return = final_amount - principal
     
@@ -420,8 +421,8 @@ from money_warp import InterestRate, YearSize, Money
 rate_365 = InterestRate("10% a", year_size=YearSize.commercial)
 rate_360 = InterestRate("10% a", year_size=YearSize.banker)
 
-print(f"Commercial daily: {rate_365.to_daily().as_decimal:.10f}")  # ~0.0002611578
-print(f"Banker daily:     {rate_360.to_daily().as_decimal:.10f}")  # ~0.0002651568
+print(f"Commercial daily: {rate_365.to_daily().as_decimal():.10f}")  # ~0.0002611578
+print(f"Banker daily:     {rate_360.to_daily().as_decimal():.10f}")  # ~0.0002651568
 
 # This difference compounds when accruing interest
 principal = Money("100000")
@@ -484,7 +485,7 @@ for name, rate in annual_rates.items():
     print(f"{name}: {rate}")
 
 # Finding the best rate
-best_savings = max(rates['savings'], rates['checking'], key=lambda r: r.as_decimal)
+best_savings = max(rates['savings'], rates['checking'], key=lambda r: r.as_decimal())
 print(f"Best savings rate: {best_savings}")
 ```
 

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -178,8 +178,9 @@ print(f"As monthly: {annual.to_monthly()}")
 print(f"As daily: {annual.to_daily()}")
 
 # Safe decimal access
-print(f"As decimal: {annual.as_decimal}")      # 0.065
-print(f"As percentage: {annual.as_percentage}") # 6.5
+print(f"As decimal: {annual.as_decimal()}")      # 0.065
+print(f"As percentage: {annual.as_percentage()}") # 6.5
+print(f"As float: {annual.as_float(4)}")        # 0.065
 ```
 
 ## Next Steps

--- a/knowledge/credit_card.md
+++ b/knowledge/credit_card.md
@@ -57,7 +57,7 @@ All validate positive amounts. `purchase` also checks `credit_limit` if set. `da
 
 1. Compute the **carried balance**: `max(0, previous_closing_balance - payments_in_period - refunds_in_period)`.
 2. If carried balance is positive, compute interest via `interest_rate.accrue(carried, days)` and materialise as a `CashFlowItem` with category `"interest_charge"`.
-3. For cycles after the first: check if the previous cycle's minimum payment was met (payments between previous close and previous due date). If not, materialise a fine = `fine_rate.as_decimal * minimum_payment.raw_amount` (wrapped in `Money`).
+3. For cycles after the first: check if the previous cycle's minimum payment was met (payments between previous close and previous due date). If not, materialise a fine = `fine_rate.as_decimal() * minimum_payment.raw_amount` (wrapped in `Money`).
 4. Update `_last_closing_balance` with the new closing balance.
 
 Tracked by `_cycles_closed` counter to guarantee idempotency.

--- a/knowledge/rate.md
+++ b/knowledge/rate.md
@@ -21,11 +21,22 @@ MoneyWarp distinguishes between two rate types based on domain semantics.
 Both types share the same conversion, comparison, and display logic (inherited from `Rate`):
 
 - **String parsing:** `"5.25% a"`, `"0.5% a.m."`, `"-2.5% annual"` (negatives only valid for `Rate`)
+- **Accessors:** `as_decimal(precision=None)`, `as_percentage(precision=None)`, `as_float(precision=None)` — all are methods (not properties). When `precision` is given, the result is quantized/rounded to that many decimal places.
 - **Conversions:** `to_daily()`, `to_monthly()`, `to_annual()`, `to_periodic_rate(n)`
 - **Comparisons:** `==`, `<`, `<=`, `>`, `>=` (via effective annual rate)
 - **Year size:** `YearSize.commercial` (365, default) or `YearSize.banker` (360)
 
 Conversion methods use `self.__class__(...)` so `InterestRate.to_monthly()` returns an `InterestRate` and `Rate.to_monthly()` returns a `Rate`.
+
+### Accessor Details
+
+| Method | Return type | No precision | With precision |
+|---|---|---|---|
+| `as_decimal()` | `Decimal` | Raw stored rate (e.g. `Decimal("0.0525")`) | Quantized via `ROUND_HALF_UP` (or the rate's configured rounding) |
+| `as_percentage()` | `Decimal` | Raw percentage (e.g. `Decimal("5.25")`) | Same quantization behaviour |
+| `as_float()` | `float` | `float(raw_rate)` | `round(float_value, precision)` |
+
+`as_float(precision)` is a convenience that replaces the verbose `round(float(rate.as_decimal()), n)` pattern commonly needed for JSON serialization and API responses.
 
 ## Cross-Type Compatibility
 

--- a/money_warp/credit_card/credit_card.py
+++ b/money_warp/credit_card/credit_card.py
@@ -316,7 +316,7 @@ class CreditCard:
         payments_by_due = self._sum_category_between("payment", prev_closing, prev_due)
 
         if payments_by_due < minimum:
-            fine = Money(minimum.raw_amount * self.fine_rate.as_decimal)
+            fine = Money(minimum.raw_amount * self.fine_rate.as_decimal())
             if fine.is_positive():
                 self.cash_flow.add_item(
                     CashFlowItem(

--- a/money_warp/ext/marshmallow.py
+++ b/money_warp/ext/marshmallow.py
@@ -124,10 +124,10 @@ class RateField(fields.Field):
 
         if self.representation == "string":
             token = _FREQUENCY_TOKEN[value.period]
-            return f"{value.as_percentage:.3f}% {token}"
+            return f"{value.as_percentage():.3f}% {token}"
 
         return {
-            "rate": str(value.as_decimal),
+            "rate": str(value.as_decimal()),
             "period": value.period.name.lower(),
             "year_size": value.year_size.value,
             "precision": value._precision,

--- a/money_warp/ext/sa/types.py
+++ b/money_warp/ext/sa/types.py
@@ -127,10 +127,10 @@ class RateType(TypeDecorator):
         if self.representation == "string":
             is_abbrev = getattr(value, "_str_style", "long") == "abbrev"
             token = _ABBREV_MAP[value.period] if is_abbrev else _FREQUENCY_TOKEN[value.period]
-            return f"{value.as_percentage:.3f}% {token}"
+            return f"{value.as_percentage():.3f}% {token}"
 
         return {
-            "rate": str(value.as_decimal),
+            "rate": str(value.as_decimal()),
             "period": value.period.name.lower(),
             "year_size": value.year_size.value,
             "precision": value._precision,

--- a/money_warp/interest_rate.py
+++ b/money_warp/interest_rate.py
@@ -102,6 +102,6 @@ class InterestRate(Rate):
         Returns:
             The accrued interest (not including the principal).
         """
-        daily_rate = self.to_daily().as_decimal
+        daily_rate = self.to_daily().as_decimal()
         accrued = principal.raw_amount * ((1 + daily_rate) ** Decimal(str(days)) - 1)
         return Money(accrued)

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -360,7 +360,7 @@ class Loan:
             if not payment_made:
                 # Apply fine: percentage of expected payment amount
                 expected_payment = self.get_expected_payment_amount(due_date)
-                fine_amount = Money(expected_payment.raw_amount * self.fine_rate.as_decimal)
+                fine_amount = Money(expected_payment.raw_amount * self.fine_rate.as_decimal())
 
                 # Record the fine
                 self.fines_applied[due_date] = fine_amount

--- a/money_warp/present_value.py
+++ b/money_warp/present_value.py
@@ -61,7 +61,7 @@ def present_value(cash_flow: CashFlow, discount_rate: Rate, valuation_date: Opti
         raise ValueError("Cannot calculate present value: no cash flows or invalid valuation date")
 
     # Convert discount rate to daily rate for precise calculations
-    daily_rate = discount_rate.to_daily().as_decimal
+    daily_rate = discount_rate.to_daily().as_decimal()
 
     total_pv = Money.zero()
 
@@ -128,7 +128,7 @@ def present_value_of_annuity(
         return Money.zero()
 
     # Get the periodic interest rate as decimal
-    periodic_rate = interest_rate.as_decimal
+    periodic_rate = interest_rate.as_decimal()
 
     if periodic_rate == 0:
         # Special case: zero interest rate
@@ -178,7 +178,7 @@ def present_value_of_perpetuity(payment_amount: Money, interest_rate: InterestRa
     if payment_amount.is_zero():
         return Money.zero()
 
-    periodic_rate = interest_rate.as_decimal
+    periodic_rate = interest_rate.as_decimal()
 
     if periodic_rate <= 0:
         raise ValueError("Interest rate must be positive for perpetuity calculations")
@@ -210,7 +210,7 @@ def discount_factor(interest_rate: Rate, periods: Union[int, Decimal]) -> Decima
     if periods == 0:
         return Decimal("1")
 
-    rate = interest_rate.as_decimal
+    rate = interest_rate.as_decimal()
     return Decimal("1") / ((Decimal("1") + rate) ** Decimal(str(periods)))
 
 
@@ -323,7 +323,7 @@ def internal_rate_of_return(
         raise ValueError("Cannot calculate IRR: no cash flows")
 
     # Use 10% as default initial guess
-    initial_guess = 0.10 if guess is None else float(guess.as_decimal)
+    initial_guess = 0.10 if guess is None else guess.as_float()
 
     # Create NPV function
     npv_function = _npv_function_factory(cash_flow, valuation_date, year_size)
@@ -422,7 +422,7 @@ def _calculate_mirr_components(
     for item in positive_flows:
         periods_to_end = (latest_date - item.datetime).days / days_per_year
         if periods_to_end >= 0:
-            annual_rate = reinvestment_rate.as_decimal
+            annual_rate = reinvestment_rate.as_decimal()
             compound_factor = (Decimal("1") + annual_rate) ** periods_to_end
             fv_positive += Money(item.amount.raw_amount * compound_factor)
         else:
@@ -433,7 +433,7 @@ def _calculate_mirr_components(
     for item in negative_flows:
         periods_from_start = (item.datetime - valuation_date).days / days_per_year
         if periods_from_start >= 0:
-            annual_rate = finance_rate.as_decimal
+            annual_rate = finance_rate.as_decimal()
             discount_factor = (Decimal("1") + annual_rate) ** periods_from_start
             pv_negative += Money(item.amount.raw_amount / discount_factor)
         else:

--- a/money_warp/rate.py
+++ b/money_warp/rate.py
@@ -183,15 +183,46 @@ class Rate:
             "period": frequency,
         }
 
-    @property
-    def as_decimal(self) -> Decimal:
-        """Get as decimal (0.05 = 5%)."""
-        return self._decimal_rate
+    def as_decimal(self, precision: Optional[int] = None) -> Decimal:
+        """Get as decimal (0.05 = 5%).
 
-    @property
-    def as_percentage(self) -> Decimal:
-        """Get as percentage (5.0 = 5%)."""
-        return self._percentage_rate
+        Args:
+            precision: Number of decimal places. None returns the raw value.
+
+        Returns:
+            The rate as a Decimal, optionally quantized.
+        """
+        if precision is None:
+            return self._decimal_rate
+        return self._decimal_rate.quantize(Decimal(10) ** -precision, rounding=self._rounding)
+
+    def as_percentage(self, precision: Optional[int] = None) -> Decimal:
+        """Get as percentage (5.0 = 5%).
+
+        Args:
+            precision: Number of decimal places. None returns the raw value.
+
+        Returns:
+            The rate as a percentage Decimal, optionally quantized.
+        """
+        if precision is None:
+            return self._percentage_rate
+        return self._percentage_rate.quantize(Decimal(10) ** -precision, rounding=self._rounding)
+
+    def as_float(self, precision: Optional[int] = None) -> float:
+        """Get as a float (0.05 = 5%).
+
+        Args:
+            precision: Number of decimal places to round to. None returns
+                       the unrounded float conversion.
+
+        Returns:
+            The rate as a float, optionally rounded.
+        """
+        value = float(self._decimal_rate)
+        if precision is None:
+            return value
+        return round(value, precision)
 
     @property
     def year_size(self) -> YearSize:

--- a/money_warp/scheduler/inverted_price_scheduler.py
+++ b/money_warp/scheduler/inverted_price_scheduler.py
@@ -48,7 +48,7 @@ class InvertedPriceScheduler(BaseScheduler):
         fixed_principal_payment = principal.raw_amount / Decimal(str(len(due_dates)))
 
         # Get daily interest rate
-        daily_rate = interest_rate.to_daily().as_decimal
+        daily_rate = interest_rate.to_daily().as_decimal()
 
         # Generate schedule entries
         entries = []

--- a/money_warp/scheduler/price_scheduler.py
+++ b/money_warp/scheduler/price_scheduler.py
@@ -57,7 +57,7 @@ class PriceScheduler(BaseScheduler):
         return_days = [(due_date - disbursement_date).days for due_date in due_dates]
 
         # Calculate PMT using the reference formula
-        daily_rate = interest_rate.to_daily().as_decimal
+        daily_rate = interest_rate.to_daily().as_decimal()
 
         # Create an instance with the loan parameters
         scheduler = cls(principal.raw_amount, daily_rate, return_days, disbursement_date)

--- a/tests/ext/test_marshmallow.py
+++ b/tests/ext/test_marshmallow.py
@@ -292,7 +292,7 @@ def test_rate_field_serialize_dict_str_style():
 
 def test_rate_field_deserialize_string_annually():
     result = StringRateSchema().load({"rate": "5.25% a"})
-    assert result["rate"].as_decimal == Decimal("0.0525")
+    assert result["rate"].as_decimal() == Decimal("0.0525")
 
 
 def test_rate_field_deserialize_string_monthly():
@@ -302,7 +302,7 @@ def test_rate_field_deserialize_string_monthly():
 
 def test_rate_field_deserialize_string_negative():
     result = StringRateSchema().load({"rate": "-2.5% a"})
-    assert result["rate"].as_decimal == Decimal("-0.025")
+    assert result["rate"].as_decimal() == Decimal("-0.025")
 
 
 def test_rate_field_deserialize_string_invalid_raises():
@@ -328,7 +328,7 @@ def test_rate_field_deserialize_string_uses_field_year_size():
 def test_rate_field_deserialize_dict_basic():
     data = {"rate": {"rate": "0.0525", "period": "annually"}}
     result = DictRateSchema().load(data)
-    assert result["rate"].as_decimal == Decimal("0.0525")
+    assert result["rate"].as_decimal() == Decimal("0.0525")
 
 
 def test_rate_field_deserialize_dict_with_year_size():

--- a/tests/loan/test_fines.py
+++ b/tests/loan/test_fines.py
@@ -449,7 +449,7 @@ def test_late_overpayment_total_interest_for_45_days():
         fine_rate=InterestRate("2% annual"),
     )
 
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_total = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -476,7 +476,7 @@ def test_late_overpayment_principal_is_remainder_after_fine_and_interest():
 
     scheduled_payment = loan.get_expected_payment_amount(datetime(2025, 2, 1, tzinfo=timezone.utc))
     fine = scheduled_payment.raw_amount * Decimal("0.02")
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
     expected_principal = Decimal("7000") - fine - interest
 
@@ -503,7 +503,7 @@ def test_late_overpayment_ending_balance_in_actual_entry():
 
     scheduled_payment = loan.get_expected_payment_amount(datetime(2025, 2, 1, tzinfo=timezone.utc))
     fine = scheduled_payment.raw_amount * Decimal("0.02")
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
     principal_paid = Decimal("7000") - fine - interest
     expected_ending = Decimal("10000") - principal_paid

--- a/tests/loan/test_loan_with_tax.py
+++ b/tests/loan/test_loan_with_tax.py
@@ -235,4 +235,4 @@ def test_grossup_loan_irr_not_inflated_by_double_counted_tax():
         taxes=[IOF(daily_rate="0.0082%", additional_rate="0.38%")],
     )
     irr = loan.irr()
-    assert abs(irr.as_decimal - Decimal("0.710526")) < Decimal("0.01")
+    assert abs(irr.as_decimal() - Decimal("0.710526")) < Decimal("0.01")

--- a/tests/loan/test_mora_interest.py
+++ b/tests/loan/test_mora_interest.py
@@ -35,7 +35,7 @@ def test_mora_interest_equals_difference_between_total_and_regular():
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     regular_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
     total_interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
     expected_mora = total_interest - regular_interest
@@ -82,7 +82,7 @@ def test_total_interest_on_late_payment_matches_manual_calculation(late_days):
     payment_date = due_date + timedelta(days=late_days)
     total_days = (payment_date - disbursement).days
 
-    daily_rate = rate.to_daily().as_decimal
+    daily_rate = rate.to_daily().as_decimal()
     expected_total = Decimal("10000") * ((1 + daily_rate) ** total_days - 1)
 
     with Warp(loan, payment_date) as warped:
@@ -137,7 +137,7 @@ def test_on_time_interest_unchanged():
     loan = Loan(principal, rate, [due_date], disbursement_date=disbursement)
     days_to_due = (due_date - disbursement).days
 
-    daily_rate = rate.to_daily().as_decimal
+    daily_rate = rate.to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** days_to_due - 1)
 
     with Warp(loan, due_date) as warped:
@@ -190,7 +190,7 @@ def test_on_time_payment_unaffected_by_custom_mora_rate():
         mora_interest_rate=mora_rate,
     )
 
-    daily_base = base_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
     days = (due_date - disbursement).days
     expected_interest = Decimal("10000") * ((1 + daily_base) ** days - 1)
 
@@ -224,8 +224,8 @@ def test_mora_with_custom_rate_compound_strategy():
     regular_days = (due_date - disbursement).days  # 31
     mora_days = (payment_date - due_date).days  # 14
 
-    daily_base = base_rate.to_daily().as_decimal
-    daily_mora = mora_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
+    daily_mora = mora_rate.to_daily().as_decimal()
 
     expected_regular = principal * ((1 + daily_base) ** regular_days - 1)
     accumulated = principal + expected_regular
@@ -257,7 +257,7 @@ def test_mora_with_custom_rate_simple_strategy():
     )
 
     mora_days = (payment_date - due_date).days  # 14
-    daily_mora = mora_rate.to_daily().as_decimal
+    daily_mora = mora_rate.to_daily().as_decimal()
     expected_mora = principal * ((1 + daily_mora) ** mora_days - 1)
 
     with Warp(loan, payment_date) as warped:
@@ -313,7 +313,7 @@ def test_regular_interest_unchanged_regardless_of_mora_rate():
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
     regular_days = (due_date - disbursement).days
-    daily_base = base_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
     expected_regular = Decimal("10000") * ((1 + daily_base) ** regular_days - 1)
 
     loan = Loan(
@@ -354,8 +354,8 @@ def test_total_interest_with_custom_mora_rate_matches_manual(mora_rate_str, stra
     regular_days = (due_date - disbursement).days
     mora_days = (payment_date - due_date).days
 
-    daily_base = base_rate.to_daily().as_decimal
-    daily_mora = mora_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
+    daily_mora = mora_rate.to_daily().as_decimal()
 
     expected_regular = principal * ((1 + daily_base) ** regular_days - 1)
     if strategy == MoraStrategy.COMPOUND:
@@ -398,8 +398,8 @@ def test_accrued_interest_uses_mora_rate_when_past_due():
     regular_days = (due_date - disbursement).days
     mora_days = (check_date - due_date).days
 
-    daily_base = base_rate.to_daily().as_decimal
-    daily_mora = mora_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
+    daily_mora = mora_rate.to_daily().as_decimal()
 
     regular = principal * ((1 + daily_base) ** regular_days - 1)
     mora = (principal + regular) * ((1 + daily_mora) ** mora_days - 1)
@@ -427,7 +427,7 @@ def test_accrued_interest_uses_base_rate_when_not_late():
     check_date = datetime(2025, 1, 20, tzinfo=timezone.utc)
 
     days = (check_date - disbursement).days
-    daily_base = base_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
     expected = principal * ((1 + daily_base) ** days - 1)
 
     loan = Loan(
@@ -454,8 +454,8 @@ def test_current_balance_reflects_mora_rate_when_past_due():
     regular_days = (due_date - disbursement).days
     mora_days = (check_date - due_date).days
 
-    daily_base = base_rate.to_daily().as_decimal
-    daily_mora = mora_rate.to_daily().as_decimal
+    daily_base = base_rate.to_daily().as_decimal()
+    daily_mora = mora_rate.to_daily().as_decimal()
 
     regular = principal * ((1 + daily_base) ** regular_days - 1)
     mora = (principal + regular) * ((1 + daily_mora) ** mora_days - 1)

--- a/tests/loan/test_payment_methods.py
+++ b/tests/loan/test_payment_methods.py
@@ -39,7 +39,7 @@ def test_pay_installment_charges_interest_to_due_date():
         interest_items = [p for p in warped._all_payments if p.category == "actual_interest"]
         assert len(interest_items) == 1
 
-        daily_rate = InterestRate("6% a").to_daily().as_decimal
+        daily_rate = InterestRate("6% a").to_daily().as_decimal()
         expected_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
         assert interest_items[0].amount == Money(expected_interest)
 
@@ -115,7 +115,7 @@ def test_anticipate_payment_charges_interest_only_for_elapsed_days():
         warped.anticipate_payment(Money("5000.00"))
         interest_items = [p for p in warped._all_payments if p.category == "actual_interest"]
 
-        daily_rate = InterestRate("6% a").to_daily().as_decimal
+        daily_rate = InterestRate("6% a").to_daily().as_decimal()
         expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
         assert interest_items[0].amount == Money(expected_interest)
 
@@ -194,7 +194,7 @@ def test_record_payment_with_explicit_interest_date():
     )
 
     interest_items = [p for p in loan._all_payments if p.category == "actual_interest"]
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
     assert interest_items[0].amount == Money(expected_interest)
 
@@ -210,7 +210,7 @@ def test_record_payment_interest_date_defaults_to_payment_date():
     loan.record_payment(Money("5000.00"), payment_date=datetime(2025, 1, 15, tzinfo=timezone.utc))
 
     interest_items = [p for p in loan._all_payments if p.category == "actual_interest"]
-    daily_rate = InterestRate("6% a").to_daily().as_decimal
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
     assert interest_items[0].amount == Money(expected_interest)
 

--- a/tests/loan/test_tvm.py
+++ b/tests/loan/test_tvm.py
@@ -135,7 +135,7 @@ def test_loan_irr_basic():
     assert isinstance(loan_irr, Rate)
     # IRR should be very close to the loan's interest rate (5%)
     # because that's the rate where NPV ≈ 0
-    actual_rate = float(loan_irr.as_decimal * 100)
+    actual_rate = float(loan_irr.as_decimal() * 100)
     assert abs(actual_rate - 5.0) < 0.1  # Should be very close to 5%
 
 
@@ -154,7 +154,7 @@ def test_loan_irr_with_time_machine_for_valuation():
 
     assert isinstance(loan_irr, Rate)
     # Should be close to the loan's interest rate (4%)
-    actual_rate = float(loan_irr.as_decimal * 100)
+    actual_rate = float(loan_irr.as_decimal() * 100)
     assert abs(actual_rate - 4.0) < 0.1  # Should be very close to 4%
 
 
@@ -171,7 +171,7 @@ def test_loan_irr_with_custom_guess():
 
     assert isinstance(loan_irr, Rate)
     # Should converge to loan's rate (6%) regardless of initial guess
-    actual_rate = float(loan_irr.as_decimal * 100)
+    actual_rate = float(loan_irr.as_decimal() * 100)
     assert abs(actual_rate - 6.0) < 0.1  # Should be very close to 6%
 
 
@@ -194,7 +194,7 @@ def test_loan_irr_with_time_machine():
     assert isinstance(warped_irr, Rate)
     # Both should be close to the loan's rate (7%)
     for test_irr in [normal_irr, warped_irr]:
-        actual_rate = float(test_irr.as_decimal * 100)
+        actual_rate = float(test_irr.as_decimal() * 100)
         assert abs(actual_rate - 7.0) < 0.1  # Should be very close to 7%
 
 
@@ -211,5 +211,5 @@ def test_loan_irr_multiple_payments():
 
     assert isinstance(loan_irr, Rate)
     # Should be very close to the loan's rate (5.5%)
-    actual_rate = float(loan_irr.as_decimal * 100)
+    actual_rate = float(loan_irr.as_decimal() * 100)
     assert abs(actual_rate - 5.5) < 0.1  # Should be very close to 5.5%

--- a/tests/test_interest_rate.py
+++ b/tests/test_interest_rate.py
@@ -40,12 +40,12 @@ from money_warp.money import Money
 )
 def test_interest_rate_string_parsing(rate_string, expected_decimal, expected_percentage, expected_frequency):
     rate = InterestRate(rate_string)
-    assert rate.as_decimal == expected_decimal
+    assert rate.as_decimal() == expected_decimal
 
 
 def test_interest_rate_string_parsing_stores_percentage():
     rate = InterestRate("5.25% a")
-    assert rate.as_percentage == Decimal("5.25")
+    assert rate.as_percentage() == Decimal("5.25")
 
 
 def test_interest_rate_string_parsing_stores_frequency():
@@ -56,12 +56,12 @@ def test_interest_rate_string_parsing_stores_frequency():
 # String parsing edge cases
 def test_interest_rate_string_parsing_with_extra_spaces():
     rate = InterestRate("  5.25%   a  ")
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")
 
 
 def test_interest_rate_string_parsing_case_insensitive():
     rate = InterestRate("5.25% ANNUAL")
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")
 
 
 def test_interest_rate_string_parsing_mixed_case():
@@ -97,12 +97,12 @@ def test_interest_rate_string_parsing_rejects_negative():
 # Numeric creation tests (backward compatibility)
 def test_interest_rate_numeric_creation_decimal():
     rate = InterestRate(0.0525, CompoundingFrequency.ANNUALLY)
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")
 
 
 def test_interest_rate_numeric_creation_percentage():
     rate = InterestRate(5.25, CompoundingFrequency.ANNUALLY, as_percentage=True)
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")
 
 
 def test_interest_rate_numeric_creation_stores_frequency():
@@ -119,7 +119,7 @@ def test_interest_rate_numeric_creation_missing_period_raises_error():
 def test_interest_rate_string_vs_numeric_equivalent():
     string_rate = InterestRate("5.25% a")
     numeric_rate = InterestRate(5.25, CompoundingFrequency.ANNUALLY, as_percentage=True)
-    assert string_rate.as_decimal == numeric_rate.as_decimal
+    assert string_rate.as_decimal() == numeric_rate.as_decimal()
     assert string_rate.period == numeric_rate.period
 
 
@@ -128,7 +128,7 @@ def test_interest_rate_to_monthly_from_annual():
     annual_rate = InterestRate("6% a")
     monthly_rate = annual_rate.to_monthly()
     # Should be approximately 0.4868% monthly
-    assert abs(monthly_rate.as_percentage - Decimal("0.4868")) < Decimal("0.001")
+    assert abs(monthly_rate.as_percentage() - Decimal("0.4868")) < Decimal("0.001")
 
 
 def test_interest_rate_to_monthly_returns_monthly_frequency():
@@ -141,7 +141,7 @@ def test_interest_rate_to_daily_from_annual():
     annual_rate = InterestRate("5% a")
     daily_rate = annual_rate.to_daily()
     # Should be approximately 0.0134% daily
-    assert abs(daily_rate.as_percentage - Decimal("0.0134")) < Decimal("0.001")
+    assert abs(daily_rate.as_percentage() - Decimal("0.0134")) < Decimal("0.001")
 
 
 def test_interest_rate_to_daily_returns_daily_frequency():
@@ -154,7 +154,7 @@ def test_interest_rate_to_annual_from_monthly():
     monthly_rate = InterestRate("0.5% m")
     annual_rate = monthly_rate.to_annual()
     # Should be approximately 6.17% annually (0.5% compounded 12 times)
-    assert abs(annual_rate.as_percentage - Decimal("6.17")) < Decimal("0.01")
+    assert abs(annual_rate.as_percentage() - Decimal("6.17")) < Decimal("0.01")
 
 
 def test_interest_rate_to_annual_returns_annual_frequency():
@@ -179,7 +179,7 @@ def test_interest_rate_to_periodic_rate_monthly():
 def test_interest_rate_to_periodic_rate_same_frequency():
     monthly_rate = InterestRate("0.5% m")
     periodic_rate = monthly_rate.to_periodic_rate(12)
-    assert periodic_rate == monthly_rate.as_decimal
+    assert periodic_rate == monthly_rate.as_decimal()
 
 
 # Comparison tests
@@ -245,12 +245,12 @@ def test_interest_rate_repr_representation():
 # Property tests
 def test_interest_rate_as_decimal_property():
     rate = InterestRate("5.25% a")
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")
 
 
 def test_interest_rate_as_percentage_property():
     rate = InterestRate("0.0525 a")
-    assert rate.as_percentage == Decimal("5.25")
+    assert rate.as_percentage() == Decimal("5.25")
 
 
 def test_interest_rate_period_property():
@@ -261,20 +261,20 @@ def test_interest_rate_period_property():
 # Edge case tests
 def test_interest_rate_zero_rate():
     rate = InterestRate("0% a")
-    assert rate.as_decimal == Decimal("0.0")
-    assert rate.as_percentage == Decimal("0.0")
+    assert rate.as_decimal() == Decimal("0.0")
+    assert rate.as_percentage() == Decimal("0.0")
 
 
 def test_interest_rate_very_high_rate():
     rate = InterestRate("50% a")
-    assert rate.as_decimal == Decimal("0.5")
-    assert rate.as_percentage == Decimal("50.0")
+    assert rate.as_decimal() == Decimal("0.5")
+    assert rate.as_percentage() == Decimal("50.0")
 
 
 def test_interest_rate_very_small_rate():
     rate = InterestRate("0.01% a")
-    assert rate.as_decimal == Decimal("0.0001")
-    assert rate.as_percentage == Decimal("0.01")
+    assert rate.as_decimal() == Decimal("0.0001")
+    assert rate.as_percentage() == Decimal("0.01")
 
 
 def test_interest_rate_daily_compounding():
@@ -287,7 +287,7 @@ def test_interest_rate_continuous_compounding():
     annual_rate = rate.to_annual()
     # For continuous compounding: e^r - 1
     # 5% continuous should be approximately 5.127% effective annual
-    assert abs(annual_rate.as_percentage - Decimal("5.127")) < Decimal("0.001")
+    assert abs(annual_rate.as_percentage() - Decimal("5.127")) < Decimal("0.001")
 
 
 # Conversion accuracy tests
@@ -296,7 +296,7 @@ def test_interest_rate_round_trip_conversion():
     monthly = original.to_monthly()
     back_to_annual = monthly.to_annual()
     # Should be very close to original (allowing for small rounding differences)
-    assert abs(original.as_percentage - back_to_annual.as_percentage) < Decimal("0.01")
+    assert abs(original.as_percentage() - back_to_annual.as_percentage()) < Decimal("0.01")
 
 
 def test_interest_rate_compound_frequency_enum_values():
@@ -329,7 +329,7 @@ def test_interest_rate_compound_frequency_enum_values():
 )
 def test_interest_rate_string_parsing_precision(rate_string, expected_decimal):
     rate = InterestRate(rate_string)
-    assert rate.as_decimal == expected_decimal
+    assert rate.as_decimal() == expected_decimal
 
 
 def test_interest_rate_string_parsing_all_frequencies():
@@ -380,7 +380,7 @@ def test_precision_propagates_to_daily_conversion():
     rate = InterestRate("1% m", precision=6)
     daily = rate.to_daily()
     expected_daily = (1 + Decimal("0.126825")) ** (Decimal(1) / Decimal(365)) - 1
-    assert daily.as_decimal == expected_daily
+    assert daily.as_decimal() == expected_daily
 
 
 def test_precision_propagates_to_monthly_conversion():
@@ -399,7 +399,7 @@ def test_rounding_mode_round_down():
 
 def test_precision_does_not_alter_stored_rate():
     rate = InterestRate("1% m", precision=6)
-    assert rate.as_decimal == Decimal("0.01")
+    assert rate.as_decimal() == Decimal("0.01")
 
 
 # --- str_style tests ---
@@ -422,12 +422,12 @@ def test_interest_rate_abbreviated_string_parsing(
     rate_string, expected_decimal, expected_percentage, expected_frequency
 ):
     rate = InterestRate(rate_string)
-    assert rate.as_decimal == expected_decimal
+    assert rate.as_decimal() == expected_decimal
 
 
 def test_interest_rate_abbreviated_parsing_stores_percentage():
     rate = InterestRate("5.25% a.a.")
-    assert rate.as_percentage == Decimal("5.25")
+    assert rate.as_percentage() == Decimal("5.25")
 
 
 def test_interest_rate_abbreviated_parsing_stores_frequency():
@@ -542,34 +542,34 @@ def test_year_size_banker_to_daily_uses_360():
     rate = InterestRate("10% a", year_size=YearSize.banker)
     daily = rate.to_daily()
     expected = (1 + Decimal("0.10")) ** (Decimal("1") / Decimal("360")) - 1
-    assert daily.as_decimal == expected
+    assert daily.as_decimal() == expected
 
 
 def test_year_size_commercial_to_daily_uses_365():
     rate = InterestRate("10% a", year_size=YearSize.commercial)
     daily = rate.to_daily()
     expected = (1 + Decimal("0.10")) ** (Decimal("1") / Decimal("365")) - 1
-    assert daily.as_decimal == expected
+    assert daily.as_decimal() == expected
 
 
 def test_year_size_banker_daily_rate_higher_than_commercial():
     banker = InterestRate("10% a", year_size=YearSize.banker).to_daily()
     commercial = InterestRate("10% a", year_size=YearSize.commercial).to_daily()
-    assert banker.as_decimal > commercial.as_decimal
+    assert banker.as_decimal() > commercial.as_decimal()
 
 
 def test_year_size_banker_daily_to_annual_round_trip():
     original = InterestRate("10% a", year_size=YearSize.banker)
     daily = original.to_daily()
     back = daily.to_annual()
-    assert abs(back.as_percentage - Decimal("10")) < Decimal("0.0001")
+    assert abs(back.as_percentage() - Decimal("10")) < Decimal("0.0001")
 
 
 def test_year_size_banker_effective_annual_from_daily():
     daily_rate = (1 + Decimal("0.10")) ** (Decimal("1") / Decimal("360")) - 1
     rate = InterestRate(daily_rate, CompoundingFrequency.DAILY, year_size=YearSize.banker)
     annual = rate.to_annual()
-    assert abs(annual.as_percentage - Decimal("10")) < Decimal("0.001")
+    assert abs(annual.as_percentage() - Decimal("10")) < Decimal("0.001")
 
 
 def test_year_size_propagates_to_daily():
@@ -641,4 +641,4 @@ def test_year_size_repr_omits_commercial():
 def test_year_size_string_parsing_with_banker():
     rate = InterestRate("5.25% a.a.", year_size=YearSize.banker)
     assert rate.year_size == YearSize.banker
-    assert rate.as_decimal == Decimal("0.0525")
+    assert rate.as_decimal() == Decimal("0.0525")

--- a/tests/test_irr.py
+++ b/tests/test_irr.py
@@ -46,7 +46,7 @@ def test_irr_simple_investment(simple_investment):
 
     # Should be approximately 10% (1100/1000 - 1 = 0.10)
     expected_rate = 10.0
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.1  # Within 0.1%
 
@@ -56,7 +56,7 @@ def test_internal_rate_of_return_simple_investment(simple_investment):
 
     # Should be approximately 10%
     expected_rate = 10.0
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.1
 
@@ -67,7 +67,7 @@ def test_irr_multi_period_investment(multi_period_investment):
     # Should return a valid InterestRate
     assert isinstance(calculated_irr, Rate)
     # Should be positive (profitable investment)
-    assert calculated_irr.as_decimal > 0
+    assert calculated_irr.as_decimal() > 0
 
 
 def test_irr_with_time_machine_for_specific_date(simple_investment):
@@ -100,7 +100,7 @@ def test_irr_with_custom_guess(simple_investment):
 
     # Should still converge to approximately 10%
     expected_rate = 10.0
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.1
 
@@ -149,7 +149,7 @@ def test_irr_zero_npv_case():
 
     # Should find a valid IRR
     assert isinstance(calculated_irr, Rate)
-    assert calculated_irr.as_decimal > 0
+    assert calculated_irr.as_decimal() > 0
 
 
 # Precision and convergence tests
@@ -167,7 +167,7 @@ def test_irr_high_precision():
 
     # Should be very close to 5.127%
     expected_rate = 5.127
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.001
 
@@ -184,7 +184,7 @@ def test_irr_scipy_convergence():
     calculated_irr = internal_rate_of_return(cf)
 
     expected_rate = 10.0
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.001  # Very precise with scipy
 
@@ -222,7 +222,7 @@ def test_mirr_basic():
     mirr = modified_internal_rate_of_return(cf, finance_rate, reinvestment_rate)
 
     assert isinstance(mirr, Rate)
-    assert mirr.as_decimal > 0  # Should be positive
+    assert mirr.as_decimal() > 0  # Should be positive
 
 
 def test_mirr_empty_cash_flow():
@@ -306,7 +306,7 @@ def test_irr_very_small_cash_flows():
 
     # Should still work with very small amounts
     expected_rate = 10.0  # 0.011/0.01 - 1 = 0.10
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 1.0  # Within 1% (precision may be lower for tiny amounts)
 
@@ -322,7 +322,7 @@ def test_irr_very_large_cash_flows():
 
     # Should work with large amounts
     expected_rate = 10.0
-    actual_rate = float(calculated_irr.as_decimal * 100)
+    actual_rate = float(calculated_irr.as_decimal() * 100)
 
     assert abs(actual_rate - expected_rate) < 0.1
 
@@ -344,7 +344,7 @@ def test_irr_result_string_representation():
     assert "annual" in irr_str.lower()
 
     # Should be convertible to float
-    rate_as_float = float(calculated_irr.as_decimal)
+    rate_as_float = float(calculated_irr.as_decimal())
     assert 0.05 < rate_as_float < 0.20  # Between 5% and 20% is reasonable
 
 
@@ -359,7 +359,7 @@ def test_irr_banker_year_differs_from_commercial():
     irr_commercial = irr(cf, year_size=YearSize.commercial)
     irr_banker = irr(cf, year_size=YearSize.banker)
 
-    assert irr_commercial.as_decimal != irr_banker.as_decimal
+    assert irr_commercial.as_decimal() != irr_banker.as_decimal()
 
 
 def test_irr_banker_year_returns_banker_year_size():
@@ -424,7 +424,7 @@ def test_internal_rate_of_return_with_banker_year():
     calculated_irr = internal_rate_of_return(cf, year_size=YearSize.banker)
 
     assert calculated_irr.year_size == YearSize.banker
-    assert calculated_irr.as_decimal > 0
+    assert calculated_irr.as_decimal() > 0
 
 
 def test_mirr_banker_year_differs_from_commercial():
@@ -442,7 +442,7 @@ def test_mirr_banker_year_differs_from_commercial():
     mirr_commercial = modified_internal_rate_of_return(cf, finance_rate, reinvestment_rate)
     mirr_banker = modified_internal_rate_of_return(cf, finance_rate, reinvestment_rate, year_size=YearSize.banker)
 
-    assert mirr_commercial.as_decimal != mirr_banker.as_decimal
+    assert mirr_commercial.as_decimal() != mirr_banker.as_decimal()
 
 
 def test_mirr_banker_year_returns_banker_year_size():

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -36,27 +36,27 @@ from money_warp.rate import CompoundingFrequency
 )
 def test_rate_creation_from_string(rate_str, expected_decimal):
     rate = Rate(rate_str)
-    assert rate.as_decimal == expected_decimal
+    assert rate.as_decimal() == expected_decimal
 
 
 def test_rate_creation_negative_numeric():
     rate = Rate(-0.05, CompoundingFrequency.ANNUALLY)
-    assert rate.as_decimal == Decimal("-0.05")
+    assert rate.as_decimal() == Decimal("-0.05")
 
 
 def test_rate_creation_negative_numeric_as_percentage():
     rate = Rate(-5, CompoundingFrequency.ANNUALLY, as_percentage=True)
-    assert rate.as_decimal == Decimal("-0.05")
+    assert rate.as_decimal() == Decimal("-0.05")
 
 
 def test_rate_creation_zero_numeric():
     rate = Rate(0, CompoundingFrequency.ANNUALLY)
-    assert rate.as_decimal == Decimal("0")
+    assert rate.as_decimal() == Decimal("0")
 
 
 def test_rate_creation_positive_numeric():
     rate = Rate(0.10, CompoundingFrequency.ANNUALLY)
-    assert rate.as_decimal == Decimal("0.1")
+    assert rate.as_decimal() == Decimal("0.1")
 
 
 # ---------------------------------------------------------------------------
@@ -66,17 +66,17 @@ def test_rate_creation_positive_numeric():
 
 def test_rate_negative_string_percentage():
     rate = Rate("-3.5% annual")
-    assert rate.as_percentage == Decimal("-3.5")
+    assert rate.as_percentage() == Decimal("-3.5")
 
 
 def test_rate_negative_string_decimal():
     rate = Rate("-0.035 annual")
-    assert rate.as_decimal == Decimal("-0.035")
+    assert rate.as_decimal() == Decimal("-0.035")
 
 
 def test_rate_negative_string_abbreviated():
     rate = Rate("-1.25% a.a.")
-    assert rate.as_percentage == Decimal("-1.25")
+    assert rate.as_percentage() == Decimal("-1.25")
     assert rate.period == CompoundingFrequency.ANNUALLY
 
 
@@ -113,21 +113,21 @@ def test_rate_negative_annual_to_monthly():
     rate = Rate("-12% annual")
     monthly = rate.to_monthly()
     assert monthly.period == CompoundingFrequency.MONTHLY
-    assert monthly.as_decimal < 0
+    assert monthly.as_decimal() < 0
 
 
 def test_rate_negative_annual_to_daily():
     rate = Rate("-5% annual")
     daily = rate.to_daily()
     assert daily.period == CompoundingFrequency.DAILY
-    assert daily.as_decimal < 0
+    assert daily.as_decimal() < 0
 
 
 def test_rate_negative_monthly_to_annual():
     rate = Rate("-1% monthly")
     annual = rate.to_annual()
     assert annual.period == CompoundingFrequency.ANNUALLY
-    assert annual.as_decimal < 0
+    assert annual.as_decimal() < 0
 
 
 def test_rate_conversion_preserves_class_for_rate():
@@ -230,7 +230,7 @@ def test_interest_rate_rejects_negative_percentage():
 
 def test_interest_rate_allows_zero():
     rate = InterestRate("0% annual")
-    assert rate.as_decimal == Decimal("0")
+    assert rate.as_decimal() == Decimal("0")
 
 
 # ---------------------------------------------------------------------------
@@ -285,7 +285,7 @@ def test_irr_negative_result_when_fees_erode_return():
     cf = CashFlow(items)
     result = irr(cf)
     assert isinstance(result, Rate)
-    assert result.as_decimal < 0
+    assert result.as_decimal() < 0
 
 
 # ---------------------------------------------------------------------------
@@ -302,3 +302,141 @@ def test_rate_year_size_propagates_through_conversion():
 def test_rate_year_size_default_is_commercial():
     rate = Rate("5% annual")
     assert rate.year_size == YearSize.commercial
+
+
+# ---------------------------------------------------------------------------
+# as_decimal(precision) tests
+# ---------------------------------------------------------------------------
+
+
+def test_rate_as_decimal_no_precision_returns_raw_value():
+    rate = Rate("5.25% annual")
+    assert rate.as_decimal() == Decimal("0.0525")
+
+
+def test_rate_as_decimal_with_precision_quantizes():
+    rate = Rate("5.25% annual")
+    assert rate.as_decimal(2) == Decimal("0.05")
+
+
+def test_rate_as_decimal_precision_four_places():
+    rate = Rate(Decimal("0.12345678"), CompoundingFrequency.MONTHLY)
+    assert rate.as_decimal(4) == Decimal("0.1235")
+
+
+def test_rate_as_decimal_precision_zero():
+    rate = Rate("5.25% annual")
+    assert rate.as_decimal(0) == Decimal("0")
+
+
+def test_rate_as_decimal_precision_high():
+    rate = Rate(Decimal("0.123456789012"), CompoundingFrequency.ANNUALLY)
+    assert rate.as_decimal(10) == Decimal("0.1234567890")
+
+
+@pytest.mark.parametrize(
+    "rate_value,precision,expected",
+    [
+        ("5.25% annual", None, Decimal("0.0525")),
+        ("5.25% annual", 1, Decimal("0.1")),
+        ("5.25% annual", 2, Decimal("0.05")),
+        ("5.25% annual", 4, Decimal("0.0525")),
+        ("5.25% annual", 6, Decimal("0.052500")),
+    ],
+)
+def test_rate_as_decimal_parametrized(rate_value, precision, expected):
+    rate = Rate(rate_value)
+    assert rate.as_decimal(precision) == expected
+
+
+# ---------------------------------------------------------------------------
+# as_percentage(precision) tests
+# ---------------------------------------------------------------------------
+
+
+def test_rate_as_percentage_no_precision_returns_raw_value():
+    rate = Rate("5.25% annual")
+    assert rate.as_percentage() == Decimal("5.25")
+
+
+def test_rate_as_percentage_with_precision_quantizes():
+    rate = Rate("5.256% annual")
+    assert rate.as_percentage(2) == Decimal("5.26")
+
+
+def test_rate_as_percentage_precision_zero():
+    rate = Rate("5.25% annual")
+    assert rate.as_percentage(0) == Decimal("5")
+
+
+@pytest.mark.parametrize(
+    "rate_value,precision,expected",
+    [
+        ("5.25% annual", None, Decimal("5.25")),
+        ("5.25% annual", 1, Decimal("5.3")),
+        ("5.25% annual", 2, Decimal("5.25")),
+        ("5.25% annual", 4, Decimal("5.2500")),
+    ],
+)
+def test_rate_as_percentage_parametrized(rate_value, precision, expected):
+    rate = Rate(rate_value)
+    assert rate.as_percentage(precision) == expected
+
+
+# ---------------------------------------------------------------------------
+# as_float(precision) tests
+# ---------------------------------------------------------------------------
+
+
+def test_rate_as_float_returns_float_type():
+    rate = Rate("5.25% annual")
+    assert isinstance(rate.as_float(), float)
+
+
+def test_rate_as_float_no_precision():
+    rate = Rate("5.25% annual")
+    assert rate.as_float() == 0.0525
+
+
+def test_rate_as_float_with_precision():
+    rate = Rate("5.25% annual")
+    assert rate.as_float(2) == 0.05
+
+
+def test_rate_as_float_precision_four():
+    rate = Rate(Decimal("0.12345678"), CompoundingFrequency.MONTHLY)
+    assert rate.as_float(4) == 0.1235
+
+
+def test_rate_as_float_precision_zero():
+    rate = Rate("5.25% annual")
+    assert rate.as_float(0) == 0.0
+
+
+@pytest.mark.parametrize(
+    "rate_value,precision,expected",
+    [
+        ("5.25% annual", None, 0.0525),
+        ("5.25% annual", 1, 0.1),
+        ("5.25% annual", 2, 0.05),
+        ("5.25% annual", 4, 0.0525),
+    ],
+)
+def test_rate_as_float_parametrized(rate_value, precision, expected):
+    rate = Rate(rate_value)
+    assert rate.as_float(precision) == expected
+
+
+def test_rate_as_float_negative_rate():
+    rate = Rate("-5.25% annual")
+    assert rate.as_float() == -0.0525
+
+
+def test_rate_as_float_negative_rate_with_precision():
+    rate = Rate("-5.25% annual")
+    assert rate.as_float(2) == -0.05
+
+
+def test_rate_as_float_zero_rate():
+    rate = Rate("0% annual")
+    assert rate.as_float() == 0.0


### PR DESCRIPTION
## Summary
- Convert `as_decimal` and `as_percentage` from properties to methods with an optional `precision` parameter for quantized/rounded output
- Add new `as_float(precision=None)` method for convenient float conversion with rounding
- Update all call sites (source, tests, docs, knowledge) for the property-to-method change

## Changes
- `Rate.as_decimal(precision=None)` — returns `Decimal`, quantized when precision is given
- `Rate.as_percentage(precision=None)` — same behaviour for the percentage representation
- `Rate.as_float(precision=None)` — returns `float`, rounded via `round()` when precision is given
- 23 files updated across source, tests, docs, and knowledge
- 28 new tests covering all three methods with and without precision

## Breaking change
`as_decimal` and `as_percentage` are no longer properties — all existing `.as_decimal` usages must become `.as_decimal()`. This was a deliberate choice to keep the API simple rather than introducing parallel `to_decimal()`/`to_percentage()` methods.

## Motivation
Replace the verbose pattern:
```python
round(float(financing.loan.interest_rate.to_monthly().as_decimal), 4)
```
With:
```python
financing.loan.interest_rate.to_monthly().as_float(4)
```

## Test plan
- [x] All 1343 existing tests pass (+ 5 xfailed)
- [x] 28 new tests for `as_decimal(precision)`, `as_percentage(precision)`, `as_float(precision)`
- [x] Pre-commit hooks (ruff, black) pass

## Docs
- Updated `docs/examples/quickstart.md` and `docs/examples/interest_rates.md`
- Updated `knowledge/rate.md` with accessor details table
- Updated `knowledge/credit_card.md` and `.cursor/skills/validate-loan/SKILL.md`


Made with [Cursor](https://cursor.com)