### PR TITLE
feat: configurable rate display formatting

### DIFF
--- a/docs/examples/interest_rates.md
+++ b/docs/examples/interest_rates.md
@@ -388,6 +388,70 @@ print(monthly)  # "0.487% a.m."
 print(daily)    # "0.016% a.d."
 ```
 
+## Configurable Display Formatting
+
+You can control the number of decimal places and the abbreviation labels used by `__str__`:
+
+### Decimal places (`str_decimals`)
+
+```python
+# Default: 3 decimal places
+rate = InterestRate("3.99% a.m.")
+print(rate)  # "3.990% a.m."
+
+# 2 decimal places
+rate = InterestRate("3.99% a.m.", str_decimals=2)
+print(rate)  # "3.99% a.m."
+
+# 0 decimal places
+rate = InterestRate("3.99% a.m.", str_decimals=0)
+print(rate)  # "4% a.m."
+```
+
+### Custom abbreviation labels (`abbrev_labels`)
+
+Override any subset of the default abbreviation map. Unspecified keys keep their defaults:
+
+```python
+from money_warp import InterestRate, CompoundingFrequency
+
+# Drop the trailing dot on monthly only
+rate = InterestRate(
+    "3.99% a.m.",
+    abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+)
+print(rate)  # "3.990% a.m"
+
+# Combine both for the old-style output: "3.99% a.m"
+rate = InterestRate(
+    "3.99% a.m.",
+    str_decimals=2,
+    abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+)
+print(rate)  # "3.99% a.m"
+
+# Override all abbreviations at once
+no_dots = {
+    CompoundingFrequency.ANNUALLY: "a.a",
+    CompoundingFrequency.MONTHLY: "a.m",
+    CompoundingFrequency.DAILY: "a.d",
+    CompoundingFrequency.QUARTERLY: "a.t",
+    CompoundingFrequency.SEMI_ANNUALLY: "a.s",
+}
+rate = InterestRate("5.25% a.a.", abbrev_labels=no_dots)
+print(rate)  # "5.250% a.a"
+```
+
+### Display settings propagate through conversions
+
+```python
+labels = {CompoundingFrequency.MONTHLY: "a.m", CompoundingFrequency.ANNUALLY: "a.a"}
+rate = InterestRate("12% a.a.", str_decimals=2, abbrev_labels=labels)
+
+print(rate)             # "12.00% a.a"
+print(rate.to_monthly())  # "0.95% a.m"
+```
+
 ## Year Size (Day-Count Convention)
 
 Financial markets use different day-count conventions when converting between daily and annual rates. MoneyWarp supports two conventions through the `YearSize` enum:

--- a/knowledge/rate.md
+++ b/knowledge/rate.md
@@ -42,6 +42,17 @@ Conversion methods use `self.__class__(...)` so `InterestRate.to_monthly()` retu
 
 Since `InterestRate` IS-A `Rate`, any function that accepts `Rate` also accepts `InterestRate`. Comparisons work across types: `Rate("-1% annual") < InterestRate("1% annual")`.
 
+## Display Formatting
+
+Both types support configurable display formatting via two constructor parameters:
+
+- **`str_decimals: int = 3`** — controls the number of decimal places in `__str__`. Default 3 gives `"5.250%"`, use 2 for `"5.25%"`, etc.
+- **`abbrev_labels: Optional[Dict[CompoundingFrequency, str]] = None`** — partial or full override of the default abbreviation map (`_ABBREV_MAP`). Merged with the defaults so you only pass keys you want to change. Example: `{CompoundingFrequency.MONTHLY: "a.m"}` drops the trailing dot for monthly.
+
+Both parameters propagate through `to_daily()`, `to_monthly()`, and `to_annual()`. They are display-only and do not affect arithmetic, conversions, or equality.
+
+The extensions (SQLAlchemy `RateType`/`InterestRateType` and Marshmallow `RateField`/`InterestRateField`) accept these parameters as column-type / field-level defaults and include them in JSON/dict round-trips.
+
 ## Enums and Shared Constants
 
 `YearSize`, `CompoundingFrequency`, and abbreviation maps are defined in `rate.py` and re-exported from `interest_rate.py` for backward compatibility. Imports from either module work.

--- a/money_warp/ext/marshmallow.py
+++ b/money_warp/ext/marshmallow.py
@@ -6,6 +6,7 @@ Requires the ``marshmallow`` extra::
 """
 
 from decimal import Decimal
+from typing import Dict, Optional
 
 from marshmallow import fields
 
@@ -87,6 +88,8 @@ class RateField(fields.Field):
         precision: Default precision for string deserialization.
         rounding: Default rounding mode for string deserialization.
         str_style: Default str_style for string deserialization.
+        str_decimals: Default decimal places for string serialization.
+        abbrev_labels: Default abbreviation label overrides for deserialization.
     """
 
     RATE_CLASS = Rate
@@ -103,6 +106,8 @@ class RateField(fields.Field):
         precision: int | None = None,
         rounding: str = "ROUND_HALF_UP",
         str_style: str = "long",
+        str_decimals: int = 3,
+        abbrev_labels: Optional[Dict[CompoundingFrequency, str]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -115,6 +120,8 @@ class RateField(fields.Field):
         self.rate_precision = precision
         self.rate_rounding = rounding
         self.rate_str_style = str_style
+        self.rate_str_decimals = str_decimals
+        self.rate_abbrev_labels = abbrev_labels
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
@@ -124,8 +131,11 @@ class RateField(fields.Field):
 
         if self.representation == "string":
             token = _FREQUENCY_TOKEN[value.period]
-            return f"{value.as_percentage():.3f}% {token}"
+            decimals = getattr(value, "_str_decimals", 3)
+            return f"{value.as_percentage():.{decimals}f}% {token}"
 
+        abbrev_labels = getattr(value, "_abbrev_labels", None)
+        serialized_labels = {k.name.lower(): v for k, v in abbrev_labels.items()} if abbrev_labels else None
         return {
             "rate": str(value.as_decimal()),
             "period": value.period.name.lower(),
@@ -133,6 +143,8 @@ class RateField(fields.Field):
             "precision": value._precision,
             "rounding": value._rounding,
             "str_style": value._str_style,
+            "str_decimals": getattr(value, "_str_decimals", 3),
+            "abbrev_labels": serialized_labels,
         }
 
     def _deserialize(self, value, attr, data, **kwargs):
@@ -151,6 +163,8 @@ class RateField(fields.Field):
                 precision=self.rate_precision,
                 rounding=self.rate_rounding,
                 str_style=self.rate_str_style,
+                str_decimals=self.rate_str_decimals,
+                abbrev_labels=self.rate_abbrev_labels,
             )
         except Exception as exc:
             raise self.make_error("invalid") from exc
@@ -172,6 +186,13 @@ class RateField(fields.Field):
             precision = value.get("precision", self.rate_precision)
             rounding = value.get("rounding", self.rate_rounding)
             str_style = value.get("str_style", self.rate_str_style)
+            str_decimals = value.get("str_decimals", self.rate_str_decimals)
+
+            raw_labels = value.get("abbrev_labels")
+            if raw_labels:
+                abbrev_labels = {CompoundingFrequency[k.upper()]: v for k, v in raw_labels.items()}
+            else:
+                abbrev_labels = self.rate_abbrev_labels
 
             result = self.RATE_CLASS(
                 rate,
@@ -180,6 +201,8 @@ class RateField(fields.Field):
                 precision=precision,
                 rounding=rounding,
                 str_style=str_style,
+                str_decimals=str_decimals,
+                abbrev_labels=abbrev_labels,
             )
         except Exception as exc:
             raise self.make_error("invalid") from exc

--- a/money_warp/ext/sa/types.py
+++ b/money_warp/ext/sa/types.py
@@ -1,14 +1,14 @@
 """SQLAlchemy TypeDecorators for Money, Rate, and InterestRate."""
 
 from decimal import Decimal
-from typing import Any, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from sqlalchemy import JSON, Integer, Numeric, String
 from sqlalchemy.types import TypeDecorator
 
 from money_warp.interest_rate import InterestRate
 from money_warp.money import Money
-from money_warp.rate import _ABBREV_MAP, CompoundingFrequency, Rate, YearSize
+from money_warp.rate import CompoundingFrequency, Rate, YearSize
 
 _VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents")
 _VALID_RATE_REPRESENTATIONS = ("string", "json")
@@ -89,6 +89,9 @@ class RateType(TypeDecorator):
         precision: Default precision for string deserialization.
         rounding: Default rounding mode for string deserialization.
         str_style: Default str_style for string deserialization.
+        str_decimals: Default decimal places for string serialization.
+        abbrev_labels: Default abbreviation label overrides for string
+            deserialization.
     """
 
     RATE_CLASS: Type[Rate] = Rate
@@ -103,6 +106,8 @@ class RateType(TypeDecorator):
         precision: int | None = None,
         rounding: str = "ROUND_HALF_UP",
         str_style: str = "long",
+        str_decimals: int = 3,
+        abbrev_labels: Optional[Dict[CompoundingFrequency, str]] = None,
     ) -> None:
         if representation not in _VALID_RATE_REPRESENTATIONS:
             raise ValueError(
@@ -113,6 +118,8 @@ class RateType(TypeDecorator):
         self.rate_precision = precision
         self.rate_rounding = rounding
         self.rate_str_style = str_style
+        self.rate_str_decimals = str_decimals
+        self.rate_abbrev_labels = abbrev_labels
         super().__init__()
 
     def load_dialect_impl(self, dialect):
@@ -126,9 +133,13 @@ class RateType(TypeDecorator):
 
         if self.representation == "string":
             is_abbrev = getattr(value, "_str_style", "long") == "abbrev"
-            token = _ABBREV_MAP[value.period] if is_abbrev else _FREQUENCY_TOKEN[value.period]
-            return f"{value.as_percentage():.3f}% {token}"
+            abbrev_map = getattr(value, "_abbrev_map", {})
+            token = abbrev_map[value.period] if is_abbrev else _FREQUENCY_TOKEN[value.period]
+            decimals = getattr(value, "_str_decimals", 3)
+            return f"{value.as_percentage():.{decimals}f}% {token}"
 
+        abbrev_labels = getattr(value, "_abbrev_labels", None)
+        serialized_labels = {k.name.lower(): v for k, v in abbrev_labels.items()} if abbrev_labels else None
         return {
             "rate": str(value.as_decimal()),
             "period": value.period.name.lower(),
@@ -136,6 +147,8 @@ class RateType(TypeDecorator):
             "precision": value._precision,
             "rounding": value._rounding,
             "str_style": value._str_style,
+            "str_decimals": getattr(value, "_str_decimals", 3),
+            "abbrev_labels": serialized_labels,
         }
 
     def process_result_value(self, value: Any, dialect) -> Optional[Rate]:
@@ -153,6 +166,8 @@ class RateType(TypeDecorator):
             precision=self.rate_precision,
             rounding=self.rate_rounding,
             str_style=self.rate_str_style,
+            str_decimals=self.rate_str_decimals,
+            abbrev_labels=self.rate_abbrev_labels,
         )
 
     def _from_dict(self, value: dict) -> Rate:
@@ -162,6 +177,13 @@ class RateType(TypeDecorator):
         precision = value.get("precision", self.rate_precision)
         rounding = value.get("rounding", self.rate_rounding)
         str_style = value.get("str_style", self.rate_str_style)
+        str_decimals = value.get("str_decimals", self.rate_str_decimals)
+
+        raw_labels = value.get("abbrev_labels")
+        if raw_labels:
+            abbrev_labels = {CompoundingFrequency[k.upper()]: v for k, v in raw_labels.items()}
+        else:
+            abbrev_labels = self.rate_abbrev_labels
 
         return self.RATE_CLASS(
             rate,
@@ -170,6 +192,8 @@ class RateType(TypeDecorator):
             precision=precision,
             rounding=rounding,
             str_style=str_style,
+            str_decimals=str_decimals,
+            abbrev_labels=abbrev_labels,
         )
 
 

--- a/money_warp/interest_rate.py
+++ b/money_warp/interest_rate.py
@@ -7,7 +7,7 @@ like IRR and MIRR, use Rate instead.
 """
 
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from money_warp.money import Money
 from money_warp.rate import (
@@ -49,6 +49,8 @@ class InterestRate(Rate):
         rounding: str = ROUND_HALF_UP,
         str_style: str = "long",
         year_size: YearSize = YearSize.commercial,
+        str_decimals: int = 3,
+        abbrev_labels: Optional[Dict[CompoundingFrequency, str]] = None,
     ) -> None:
         """
         Create a non-negative interest rate.
@@ -69,6 +71,11 @@ class InterestRate(Rate):
                        abbreviated form (e.g. "a.a.").
             year_size: Day-count convention for daily conversions.
                        YearSize.commercial (365) or YearSize.banker (360).
+            str_decimals: Number of decimal places for the percentage in
+                          __str__. Default 3 gives "5.250%".
+            abbrev_labels: Partial or full override of the default abbreviation
+                           map. Merged with _ABBREV_MAP so you only need to
+                           pass the keys you want to change.
 
         Raises:
             ValueError: If the rate is negative.
@@ -81,6 +88,8 @@ class InterestRate(Rate):
             rounding=rounding,
             str_style=str_style,
             year_size=year_size,
+            str_decimals=str_decimals,
+            abbrev_labels=abbrev_labels,
         )
 
         if self._decimal_rate < 0:

--- a/money_warp/rate.py
+++ b/money_warp/rate.py
@@ -69,6 +69,8 @@ class Rate:
         rounding: str = ROUND_HALF_UP,
         str_style: str = "long",
         year_size: YearSize = YearSize.commercial,
+        str_decimals: int = 3,
+        abbrev_labels: Optional[Dict[CompoundingFrequency, str]] = None,
     ) -> None:
         """
         Create a rate.
@@ -88,6 +90,13 @@ class Rate:
                        abbreviated form (e.g. "a.a.").
             year_size: Day-count convention for daily conversions.
                        YearSize.commercial (365) or YearSize.banker (360).
+            str_decimals: Number of decimal places for the percentage in
+                          __str__. Default 3 gives "5.250%".
+            abbrev_labels: Partial or full override of the default abbreviation
+                           map. Merged with _ABBREV_MAP so you only need to
+                           pass the keys you want to change. Example:
+                           ``{CompoundingFrequency.MONTHLY: "a.m"}`` removes
+                           the trailing dot for monthly only.
         """
         if str_style not in _VALID_STR_STYLES:
             raise ValueError(f"Invalid str_style: '{str_style}'. Expected one of {_VALID_STR_STYLES}")
@@ -96,6 +105,9 @@ class Rate:
         self._rounding = rounding
         self._str_style = str_style
         self._year_size = year_size
+        self._str_decimals = str_decimals
+        self._abbrev_labels = abbrev_labels
+        self._abbrev_map: Dict[CompoundingFrequency, str] = {**_ABBREV_MAP, **(abbrev_labels or {})}
 
         if isinstance(rate, str):
             parsed_rate = self._parse_rate_string(rate)
@@ -252,6 +264,8 @@ class Rate:
             rounding=self._rounding,
             str_style=self._str_style,
             year_size=self._year_size,
+            str_decimals=self._str_decimals,
+            abbrev_labels=self._abbrev_labels,
         )
 
     def to_monthly(self) -> "Rate":
@@ -269,6 +283,8 @@ class Rate:
             rounding=self._rounding,
             str_style=self._str_style,
             year_size=self._year_size,
+            str_decimals=self._str_decimals,
+            abbrev_labels=self._abbrev_labels,
         )
 
     def to_annual(self) -> "Rate":
@@ -283,6 +299,8 @@ class Rate:
             rounding=self._rounding,
             str_style=self._str_style,
             year_size=self._year_size,
+            str_decimals=self._str_decimals,
+            abbrev_labels=self._abbrev_labels,
         )
 
     def to_periodic_rate(self, num_periods: int) -> Decimal:
@@ -320,8 +338,8 @@ class Rate:
 
     def __str__(self) -> str:
         """Clear string representation."""
-        label = _ABBREV_MAP[self.period] if self._str_style == "abbrev" else self.period.name.lower()
-        return f"{self._percentage_rate:.3f}% {label}"
+        label = self._abbrev_map[self.period] if self._str_style == "abbrev" else self.period.name.lower()
+        return f"{self._percentage_rate:.{self._str_decimals}f}% {label}"
 
     def __repr__(self) -> str:
         """Developer representation."""

--- a/tests/ext/sa/test_sa_rate_type.py
+++ b/tests/ext/sa/test_sa_rate_type.py
@@ -149,6 +149,90 @@ def test_interest_rate_type_roundtrip_json(session):
 
 
 # ===========================================================================
+# RateType — str_decimals and abbrev_labels
+# ===========================================================================
+
+
+def test_rate_type_string_respects_str_decimals(session):
+    original = Rate("5.25% a", str_decimals=2)
+    session.add(RateStringModel(id=1, rate=original))
+    session.flush()
+    raw = session.execute(text("SELECT rate FROM rate_string WHERE id = 1")).scalar()
+    assert raw == "5.25% annual"
+
+
+def test_rate_type_string_respects_abbrev_labels(session):
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    original = Rate("1.5% a.m.", abbrev_labels=labels)
+    session.add(RateStringModel(id=1, rate=original))
+    session.flush()
+    raw = session.execute(text("SELECT rate FROM rate_string WHERE id = 1")).scalar()
+    assert raw == "1.500% a.m"
+
+
+def test_rate_type_json_roundtrip_with_str_decimals(session):
+    original = Rate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_decimals=2,
+    )
+    session.add(RateJsonModel(id=1, rate=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(RateJsonModel, 1)
+    assert loaded.rate._str_decimals == 2
+    assert str(loaded.rate) == "5.25% annually"
+
+
+def test_rate_type_json_roundtrip_with_abbrev_labels(session):
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    original = Rate(
+        Decimal("0.01"),
+        CompoundingFrequency.MONTHLY,
+        str_style="abbrev",
+        abbrev_labels=labels,
+    )
+    session.add(RateJsonModel(id=1, rate=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(RateJsonModel, 1)
+    assert str(loaded.rate) == "1.000% a.m"
+
+
+def test_rate_type_json_roundtrip_with_both_formatting_params(session):
+    labels = {CompoundingFrequency.ANNUALLY: "a.a"}
+    original = Rate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_style="abbrev",
+        str_decimals=2,
+        abbrev_labels=labels,
+    )
+    session.add(RateJsonModel(id=1, rate=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(RateJsonModel, 1)
+    assert str(loaded.rate) == "5.25% a.a"
+
+
+def test_interest_rate_type_json_roundtrip_with_formatting(session):
+    labels = {CompoundingFrequency.ANNUALLY: "a.a"}
+    original = InterestRate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_style="abbrev",
+        str_decimals=2,
+        abbrev_labels=labels,
+    )
+    session.add(InterestRateJsonModel(id=1, rate=original))
+    session.flush()
+    session.expire_all()
+    loaded = session.get(InterestRateJsonModel, 1)
+    assert isinstance(loaded.rate, InterestRate)
+    assert str(loaded.rate) == "5.25% a.a"
+
+
+# ===========================================================================
 # RateType — abbreviated string round-trips
 # ===========================================================================
 

--- a/tests/ext/test_marshmallow.py
+++ b/tests/ext/test_marshmallow.py
@@ -468,3 +468,115 @@ def test_interest_rate_field_roundtrip_dict():
     serialized = DictInterestRateSchema().dump({"rate": original})
     loaded = DictInterestRateSchema().load(serialized)
     assert loaded["rate"] == original
+
+
+# ===========================================================================
+# RateField — str_decimals and abbrev_labels
+# ===========================================================================
+
+
+def test_rate_field_serialize_string_respects_str_decimals():
+    rate = Rate("5.25% a", str_decimals=2)
+    result = StringRateSchema().dump({"rate": rate})
+    assert result["rate"] == "5.25% annual"
+
+
+def test_rate_field_serialize_string_default_three_decimals():
+    rate = Rate("5.25% a")
+    result = StringRateSchema().dump({"rate": rate})
+    assert result["rate"] == "5.250% annual"
+
+
+def test_rate_field_serialize_dict_includes_str_decimals():
+    rate = Rate(Decimal("0.05"), CompoundingFrequency.ANNUALLY, str_decimals=2)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["str_decimals"] == 2
+
+
+def test_rate_field_serialize_dict_includes_abbrev_labels():
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    rate = Rate(Decimal("0.01"), CompoundingFrequency.MONTHLY, str_style="abbrev", abbrev_labels=labels)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["abbrev_labels"] == {"monthly": "a.m"}
+
+
+def test_rate_field_serialize_dict_abbrev_labels_none_when_default():
+    rate = Rate(Decimal("0.05"), CompoundingFrequency.ANNUALLY)
+    result = DictRateSchema().dump({"rate": rate})
+    assert result["rate"]["abbrev_labels"] is None
+
+
+def test_rate_field_roundtrip_dict_with_str_decimals():
+    original = Rate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_decimals=2,
+    )
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert loaded["rate"]._str_decimals == 2
+    assert str(loaded["rate"]) == "5.25% annually"
+
+
+def test_rate_field_roundtrip_dict_with_abbrev_labels():
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    original = Rate(
+        Decimal("0.01"),
+        CompoundingFrequency.MONTHLY,
+        str_style="abbrev",
+        abbrev_labels=labels,
+    )
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert str(loaded["rate"]) == "1.000% a.m"
+
+
+def test_rate_field_roundtrip_dict_with_both_formatting_params():
+    labels = {CompoundingFrequency.ANNUALLY: "a.a"}
+    original = Rate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_style="abbrev",
+        str_decimals=2,
+        abbrev_labels=labels,
+    )
+    serialized = DictRateSchema().dump({"rate": original})
+    loaded = DictRateSchema().load(serialized)
+    assert str(loaded["rate"]) == "5.25% a.a"
+
+
+def test_rate_field_deserialize_string_uses_field_str_decimals():
+    schema_class = type(
+        "S",
+        (Schema,),
+        {"rate": RateField(representation="string", str_decimals=2)},
+    )
+    result = schema_class().load({"rate": "5.25% a"})
+    assert result["rate"]._str_decimals == 2
+    assert str(result["rate"]) == "5.25% annually"
+
+
+def test_rate_field_deserialize_string_uses_field_abbrev_labels():
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    schema_class = type(
+        "S",
+        (Schema,),
+        {"rate": RateField(representation="string", abbrev_labels=labels)},
+    )
+    result = schema_class().load({"rate": "5% a.m."})
+    assert str(result["rate"]) == "5.000% a.m"
+
+
+def test_interest_rate_field_roundtrip_dict_with_formatting():
+    labels = {CompoundingFrequency.ANNUALLY: "a.a"}
+    original = InterestRate(
+        Decimal("0.0525"),
+        CompoundingFrequency.ANNUALLY,
+        str_style="abbrev",
+        str_decimals=2,
+        abbrev_labels=labels,
+    )
+    serialized = DictInterestRateSchema().dump({"rate": original})
+    loaded = DictInterestRateSchema().load(serialized)
+    assert isinstance(loaded["rate"], InterestRate)
+    assert str(loaded["rate"]) == "5.25% a.a"

--- a/tests/test_interest_rate.py
+++ b/tests/test_interest_rate.py
@@ -642,3 +642,104 @@ def test_year_size_string_parsing_with_banker():
     rate = InterestRate("5.25% a.a.", year_size=YearSize.banker)
     assert rate.year_size == YearSize.banker
     assert rate.as_decimal() == Decimal("0.0525")
+
+
+# --- str_decimals tests ---
+
+
+@pytest.mark.parametrize(
+    "str_decimals,expected",
+    [
+        (0, "5% annually"),
+        (2, "5.25% annually"),
+        (3, "5.250% annually"),
+        (5, "5.25000% annually"),
+    ],
+)
+def test_interest_rate_str_decimals_long_style(str_decimals, expected):
+    rate = InterestRate("5.25% a", str_decimals=str_decimals)
+    assert str(rate) == expected
+
+
+@pytest.mark.parametrize(
+    "str_decimals,expected",
+    [
+        (2, "5.25% a.a."),
+        (3, "5.250% a.a."),
+    ],
+)
+def test_interest_rate_str_decimals_abbrev_style(str_decimals, expected):
+    rate = InterestRate("5.25% a.a.", str_decimals=str_decimals)
+    assert str(rate) == expected
+
+
+def test_interest_rate_str_decimals_default_is_three():
+    rate = InterestRate("5.25% a")
+    assert str(rate) == "5.250% annually"
+
+
+def test_interest_rate_str_decimals_propagates_to_monthly():
+    rate = InterestRate("12% a.a.", str_decimals=2)
+    monthly = rate.to_monthly()
+    assert len(str(monthly).split("%")[0].split(".")[-1]) == 2
+
+
+def test_interest_rate_str_decimals_propagates_to_annual():
+    rate = InterestRate("1% a.m.", str_decimals=4)
+    annual = rate.to_annual()
+    assert len(str(annual).split("%")[0].split(".")[-1]) == 4
+
+
+# --- abbrev_labels tests ---
+
+
+def test_interest_rate_abbrev_labels_override_monthly():
+    rate = InterestRate(
+        "3.99% a.m.",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "3.990% a.m"
+
+
+def test_interest_rate_abbrev_labels_combined_with_str_decimals():
+    rate = InterestRate(
+        "3.99% a.m.",
+        str_decimals=2,
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "3.99% a.m"
+
+
+def test_interest_rate_abbrev_labels_partial_keeps_defaults():
+    rate = InterestRate(
+        "5% a.a.",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "5.000% a.a."
+
+
+def test_interest_rate_abbrev_labels_propagates_through_conversion():
+    labels = {
+        CompoundingFrequency.MONTHLY: "a.m",
+        CompoundingFrequency.ANNUALLY: "a.a",
+    }
+    rate = InterestRate("12% a.a.", abbrev_labels=labels)
+    monthly = rate.to_monthly()
+    assert str(monthly).endswith("% a.m")
+    annual = monthly.to_annual()
+    assert str(annual).endswith("% a.a")
+
+
+def test_interest_rate_abbrev_labels_none_uses_defaults():
+    rate = InterestRate(0.05, CompoundingFrequency.MONTHLY, str_style="abbrev")
+    assert str(rate) == "5.000% a.m."
+
+
+def test_interest_rate_abbrev_labels_does_not_affect_long_style():
+    rate = InterestRate(
+        0.05,
+        CompoundingFrequency.MONTHLY,
+        str_style="long",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "pm"},
+    )
+    assert str(rate) == "5.000% monthly"

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -440,3 +440,149 @@ def test_rate_as_float_negative_rate_with_precision():
 def test_rate_as_float_zero_rate():
     rate = Rate("0% annual")
     assert rate.as_float() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# str_decimals tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "str_decimals,expected",
+    [
+        (0, "5% annually"),
+        (1, "5.2% annually"),
+        (2, "5.25% annually"),
+        (3, "5.250% annually"),
+        (5, "5.25000% annually"),
+    ],
+)
+def test_rate_str_decimals_long_style(str_decimals, expected):
+    rate = Rate("5.25% annual", str_decimals=str_decimals)
+    assert str(rate) == expected
+
+
+@pytest.mark.parametrize(
+    "str_decimals,expected",
+    [
+        (0, "5% a.a."),
+        (2, "5.25% a.a."),
+        (3, "5.250% a.a."),
+    ],
+)
+def test_rate_str_decimals_abbrev_style(str_decimals, expected):
+    rate = Rate("5.25% a.a.", str_decimals=str_decimals)
+    assert str(rate) == expected
+
+
+def test_rate_str_decimals_default_is_three():
+    rate = Rate("5.25% annual")
+    assert str(rate) == "5.250% annually"
+
+
+def test_rate_str_decimals_negative_rate():
+    rate = Rate("-2.5% annual", str_decimals=2)
+    assert str(rate) == "-2.50% annually"
+
+
+def test_rate_str_decimals_propagates_to_monthly():
+    rate = Rate("12% annual", str_decimals=2)
+    monthly = rate.to_monthly()
+    assert str(monthly).endswith("% monthly")
+    assert len(str(monthly).split("%")[0].split(".")[-1]) == 2
+
+
+def test_rate_str_decimals_propagates_to_annual():
+    rate = Rate("1% monthly", str_decimals=4)
+    annual = rate.to_annual()
+    assert str(annual).endswith("% annually")
+    assert len(str(annual).split("%")[0].split(".")[-1]) == 4
+
+
+def test_rate_str_decimals_propagates_to_daily():
+    rate = Rate("12% annual", str_decimals=5)
+    daily = rate.to_daily()
+    assert str(daily).endswith("% daily")
+    assert len(str(daily).split("%")[0].split(".")[-1]) == 5
+
+
+# ---------------------------------------------------------------------------
+# abbrev_labels tests
+# ---------------------------------------------------------------------------
+
+
+def test_rate_abbrev_labels_override_single_label():
+    rate = Rate(
+        0.05,
+        CompoundingFrequency.MONTHLY,
+        str_style="abbrev",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "5.000% a.m"
+
+
+def test_rate_abbrev_labels_override_all_labels():
+    labels = {
+        CompoundingFrequency.ANNUALLY: "a.a",
+        CompoundingFrequency.MONTHLY: "a.m",
+        CompoundingFrequency.DAILY: "a.d",
+        CompoundingFrequency.QUARTERLY: "a.t",
+        CompoundingFrequency.SEMI_ANNUALLY: "a.s",
+    }
+    rate = Rate(0.05, CompoundingFrequency.ANNUALLY, str_style="abbrev", abbrev_labels=labels)
+    assert str(rate) == "5.000% a.a"
+
+
+def test_rate_abbrev_labels_partial_override_keeps_defaults():
+    rate = Rate(
+        0.05,
+        CompoundingFrequency.ANNUALLY,
+        str_style="abbrev",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "5.000% a.a."
+
+
+def test_rate_abbrev_labels_none_uses_defaults():
+    rate = Rate(0.05, CompoundingFrequency.MONTHLY, str_style="abbrev")
+    assert str(rate) == "5.000% a.m."
+
+
+def test_rate_abbrev_labels_combined_with_str_decimals():
+    rate = Rate(
+        "3.99% a.m.",
+        str_decimals=2,
+        abbrev_labels={CompoundingFrequency.MONTHLY: "a.m"},
+    )
+    assert str(rate) == "3.99% a.m"
+
+
+def test_rate_abbrev_labels_does_not_affect_long_style():
+    rate = Rate(
+        0.05,
+        CompoundingFrequency.MONTHLY,
+        str_style="long",
+        abbrev_labels={CompoundingFrequency.MONTHLY: "per.month"},
+    )
+    assert str(rate) == "5.000% monthly"
+
+
+def test_rate_abbrev_labels_propagates_to_monthly():
+    labels = {CompoundingFrequency.MONTHLY: "a.m"}
+    rate = Rate("12% a.a.", abbrev_labels=labels)
+    monthly = rate.to_monthly()
+    assert str(monthly) == f"{monthly.as_percentage():.3f}% a.m"
+
+
+def test_rate_abbrev_labels_propagates_to_annual():
+    labels = {CompoundingFrequency.ANNUALLY: "a.a"}
+    rate = Rate("1% a.m.", abbrev_labels=labels)
+    annual = rate.to_annual()
+    assert str(annual).endswith("% a.a")
+
+
+def test_rate_abbrev_labels_propagates_to_daily():
+    labels = {CompoundingFrequency.DAILY: "a.d"}
+    rate = Rate("12% a.a.", abbrev_labels=labels)
+    daily = rate.to_daily()
+    assert str(daily).endswith("% a.d")


### PR DESCRIPTION
## Summary
- Add `str_decimals` and `abbrev_labels` constructor parameters to `Rate` and `InterestRate` for controlling `__str__` output
- `str_decimals` (default 3) sets the number of decimal places in the percentage
- `abbrev_labels` accepts a partial dict that merges with the default `_ABBREV_MAP`, letting users customize abbreviation labels (e.g. drop trailing dots)
- Both propagate through `to_daily()`, `to_monthly()`, `to_annual()`

## Changes
- `money_warp/rate.py`: new params in `Rate.__init__`, instance `_abbrev_map` built via merge, dynamic format in `__str__`, propagation in conversion methods
- `money_warp/interest_rate.py`: mirror params and pass through to `super()`
- `money_warp/ext/sa/types.py`: `RateType` accepts and serializes both params; string mode uses instance values; JSON mode stores/restores for round-trip
- `money_warp/ext/marshmallow.py`: same treatment for `RateField`
- `knowledge/rate.md` and `docs/examples/interest_rates.md`: document the new formatting options

## Test plan
- [x] All 1397 existing tests pass (no regressions)
- [x] Parametrized tests for `str_decimals` with various values (0, 2, 3, 5) in both long and abbrev styles
- [x] Tests for `abbrev_labels` partial override, full override, and None (defaults)
- [x] Tests for combined `str_decimals` + `abbrev_labels`
- [x] Propagation tests through `to_monthly()`, `to_annual()`, `to_daily()`
- [x] SA round-trip tests (string and JSON) with non-default formatting
- [x] Marshmallow round-trip tests (string and dict) with non-default formatting


Made with [Cursor](https://cursor.com)