### PR TITLE
feat: add float representation to MoneyField

### DIFF
--- a/docs/examples/marshmallow.md
+++ b/docs/examples/marshmallow.md
@@ -19,6 +19,7 @@ Serializes `Money` instances. The `representation` parameter controls the format
 | `"raw"` (default) | `str` | `str(money.raw_amount)` | `Money(value)` |
 | `"real"` | `str` | `str(money.real_amount)` | `Money(value)` |
 | `"cents"` | `int` | `money.cents` | `Money.from_cents(value)` |
+| `"float"` | `float` | `float(money.real_amount)` | `Money(str(value))` |
 
 ### RateField
 
@@ -96,6 +97,20 @@ class PaymentSchema(Schema):
 schema = PaymentSchema()
 data = schema.dump({"amount": Money("123.45")})
 # {"amount": 12345}
+
+result = schema.load(data)
+# {"amount": Money("123.45")}
+```
+
+### Float representation for JSON-friendly APIs
+
+```python
+class ApiSchema(Schema):
+    amount = MoneyField(representation="float")
+
+schema = ApiSchema()
+data = schema.dump({"amount": Money("123.45")})
+# {"amount": 123.45}
 
 result = schema.load(data)
 # {"amount": Money("123.45")}

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -17,6 +17,7 @@ Serializes/deserializes `Money` instances. Configurable `representation` paramet
 | `"raw"` (default) | `str`       | `str(money.raw_amount)`   | `Money(value)`         |
 | `"real"`       | `str`           | `str(money.real_amount)`  | `Money(value)`         |
 | `"cents"`      | `int`           | `money.cents`             | `Money.from_cents(value)` |
+| `"float"`      | `float`         | `float(money.real_amount)` | `Money(str(value))`   |
 
 ### RateField
 

--- a/money_warp/ext/marshmallow.py
+++ b/money_warp/ext/marshmallow.py
@@ -20,7 +20,7 @@ __all__ = [
     "InterestRateField",
 ]
 
-_VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents")
+_VALID_MONEY_REPRESENTATIONS = ("raw", "real", "cents", "float")
 _VALID_RATE_REPRESENTATIONS = ("string", "dict")
 
 _FREQUENCY_TOKEN = {
@@ -40,6 +40,7 @@ class MoneyField(fields.Field):
             ``"raw"`` (default) -- full-precision ``raw_amount`` as string.
             ``"real"`` -- rounded ``real_amount`` as string.
             ``"cents"`` -- integer cents.
+            ``"float"`` -- rounded ``real_amount`` as a Python float.
     """
 
     default_error_messages = {
@@ -64,13 +65,20 @@ class MoneyField(fields.Field):
             return str(value.raw_amount)
         if self.representation == "real":
             return str(value.real_amount)
+        if self.representation == "float":
+            return float(value.real_amount)
         return value.cents
 
     def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return None
         try:
-            result = Money.from_cents(int(value)) if self.representation == "cents" else Money(value)
+            if self.representation == "cents":
+                result = Money.from_cents(int(value))
+            elif self.representation == "float":
+                result = Money(str(value))
+            else:
+                result = Money(value)
         except Exception as exc:
             raise self.make_error("invalid") from exc
         else:

--- a/tests/ext/test_marshmallow.py
+++ b/tests/ext/test_marshmallow.py
@@ -27,6 +27,10 @@ class CentsMoneySchema(Schema):
     amount = MoneyField(representation="cents")
 
 
+class FloatMoneySchema(Schema):
+    amount = MoneyField(representation="float")
+
+
 class StringRateSchema(Schema):
     rate = RateField(representation="string")
 
@@ -53,7 +57,7 @@ def test_money_field_invalid_representation_raises():
         MoneyField(representation="unknown")
 
 
-@pytest.mark.parametrize("representation", ["raw", "real", "cents"])
+@pytest.mark.parametrize("representation", ["raw", "real", "cents", "float"])
 def test_money_field_valid_representation_accepted(representation):
     field = MoneyField(representation=representation)
     assert field.representation == representation
@@ -204,6 +208,86 @@ def test_money_field_very_large_amount():
     big = Money("99999999999.99")
     loaded = RawMoneySchema().load(RawMoneySchema().dump({"amount": big}))
     assert loaded["amount"].raw_amount == big.raw_amount
+
+
+# ===========================================================================
+# MoneyField — float representation
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "amount_str,expected",
+    [
+        ("100.50", 100.50),
+        ("0", 0.0),
+        ("999.99", 999.99),
+        ("-50.25", -50.25),
+    ],
+)
+def test_money_field_serialize_float(amount_str, expected):
+    result = FloatMoneySchema().dump({"amount": Money(amount_str)})
+    assert result["amount"] == expected
+    assert isinstance(result["amount"], float)
+
+
+@pytest.mark.parametrize(
+    "amount_str,expected",
+    [
+        ("100.125", 100.13),
+        ("0.001", 0.0),
+        ("-50.255", -50.26),
+    ],
+)
+def test_money_field_serialize_float_rounds_to_two_decimals(amount_str, expected):
+    result = FloatMoneySchema().dump({"amount": Money(amount_str)})
+    assert result["amount"] == expected
+
+
+def test_money_field_serialize_float_none_returns_none():
+    result = FloatMoneySchema().dump({"amount": None})
+    assert result["amount"] is None
+
+
+@pytest.mark.parametrize(
+    "input_val,expected_real",
+    [
+        (100.50, Decimal("100.50")),
+        (0.0, Decimal("0.00")),
+        (999.99, Decimal("999.99")),
+        (-25.99, Decimal("-25.99")),
+    ],
+)
+def test_money_field_deserialize_float(input_val, expected_real):
+    result = FloatMoneySchema().load({"amount": input_val})
+    assert result["amount"].real_amount == expected_real
+
+
+@pytest.mark.parametrize(
+    "input_val,expected_real",
+    [
+        (100, Decimal("100.00")),
+        (0, Decimal("0.00")),
+    ],
+)
+def test_money_field_deserialize_float_from_int(input_val, expected_real):
+    result = FloatMoneySchema().load({"amount": input_val})
+    assert result["amount"].real_amount == expected_real
+
+
+def test_money_field_deserialize_float_invalid_raises():
+    with pytest.raises(ValidationError):
+        FloatMoneySchema().load({"amount": "not-a-number"})
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    ["100.50", "0.01", "0", "-25.99"],
+)
+def test_money_field_roundtrip_float(amount_str):
+    original = Money(amount_str)
+    serialized = FloatMoneySchema().dump({"amount": original})
+    loaded = FloatMoneySchema().load(serialized)
+    assert loaded["amount"].real_amount == original.real_amount
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Add a `"float"` representation to `MoneyField` that serializes `Money` as a Python `float` (2 decimal places via `real_amount`) and deserializes from `float`/`int` input.

## Changes
- `money_warp/ext/marshmallow.py`: Added `"float"` to valid representations, serialize branch returning `float(value.real_amount)`, deserialize branch converting via `str(value)` then `Money()`.
- `tests/ext/test_marshmallow.py`: 16 new test cases covering serialization, rounding, deserialization from float/int, round-trips, None handling, and invalid input.
- `docs/examples/marshmallow.md`: Updated representation table and added usage example.
- `knowledge/ext.md`: Updated MoneyField representation table.

## Test plan
- [x] All existing tests pass (`poetry run pytest` -- 1417 passed)
- [x] New float representation tests cover serialize, deserialize, round-trip, rounding, and error paths

## Docs
- Updated `docs/examples/marshmallow.md` with representation table row and usage example
- Updated `knowledge/ext.md` with representation table row

Made with [Cursor](https://cursor.com)