### PR TITLE
feat: PostgreSQL support for SQLAlchemy hybrid properties

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,10 +23,11 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # RUN RUN apt-get update && apt-get install iputils-ping bash-completion -y
 
 
-RUN sudo apt-get update
-RUN sudo apt install iputils-ping
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    iputils-ping \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -sfL https://direnv.net/install.sh | bash
-RUN apt update
 
 
 ARG USERNAME=vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     iputils-ping \
+    postgresql \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sfL https://direnv.net/install.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     postgresql \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
+ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 RUN curl -sfL https://direnv.net/install.sh | bash
 
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,31 @@ services:
       - ..:/money_warp:cached
       - bashhistory:/commandhistory
     command: /bin/sh -c "while sleep 1000; do :; done"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+    environment:
+      MONEY_WARP_TEST_PG: "1"
+      PG_HOST: postgres
+      PG_PORT: "5432"
+      PG_USER: test
+      PG_PASSWORD: test
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test_money_warp
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     networks:
       - internal
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,10 +20,6 @@ services:
       - internal
     environment:
       MONEY_WARP_TEST_PG: "1"
-      PG_HOST: postgres
-      PG_PORT: "5432"
-      PG_USER: test
-      PG_PASSWORD: test
 
   postgres:
     image: postgres:16

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,8 +18,6 @@ services:
         condition: service_healthy
     networks:
       - internal
-    environment:
-      MONEY_WARP_TEST_PG: "1"
 
   postgres:
     image: postgres:16
@@ -27,13 +25,12 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: test_money_warp
-    ports:
-      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U test"]
       interval: 5s
-      timeout: 3s
-      retries: 5
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     networks:
       - internal
 

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
 
+      - name: Install PostgreSQL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends postgresql libpq-dev
+
       - name: Set up python
         uses: actions/setup-python@v5
         with:
@@ -56,6 +61,8 @@ jobs:
 
       - name: Test with tox
         run: tox
+        env:
+          MONEY_WARP_TEST_PG: "1"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends postgresql libpq-dev
+          echo "$(pg_config --bindir)" >> $GITHUB_PATH
 
       - name: Set up python
         uses: actions/setup-python@v5
@@ -61,8 +62,6 @@ jobs:
 
       - name: Test with tox
         run: tox
-        env:
-          MONEY_WARP_TEST_PG: "1"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -49,6 +49,7 @@ money_warp/ext/sa/
   __init__.py   -- re-exports for backward compatibility
   types.py      -- MoneyType, RateType, InterestRateType
   bridge.py     -- settlement_bridge, loan_bridge, _load_money_warp_loan, CTE SQL expression
+  compat.py     -- dialect-aware SQL function wrappers (SQLite + PostgreSQL)
 ```
 
 All public symbols are re-exported from `__init__.py`, so `from money_warp.ext.sa import MoneyType, loan_bridge` continues to work.
@@ -136,21 +137,40 @@ Stores `_money_warp_bridge_meta` on the loan class with all field mappings.
 
 The settlement model must be decorated with `@settlement_bridge` — `@loan_bridge` reads `_money_warp_bridge_meta` from the relationship target at query time. Raises `TypeError` if missing.
 
+### Dialect compatibility layer (`compat.py`)
+
+The CTE expressions need SQL functions that differ between SQLite and PostgreSQL. Rather than duplicating CTE logic per dialect, `compat.py` provides `FunctionElement` subclasses with `@compiles` overrides. `bridge.py` calls these wrappers; SQLAlchemy's compiler dispatches to the correct SQL at query compile time.
+
+| Wrapper | SQLite | PostgreSQL |
+|---------|--------|------------|
+| `mw_julianday(expr)` | `julianday(expr)` | `EXTRACT(EPOCH FROM expr::timestamp) / 86400.0` |
+| `mw_json_extract(col, key)` | `json_extract(col, '$.key')` | `(col)::jsonb->>'key'` |
+| `mw_json_array_values(col)` | `json_each(col)` | `jsonb_array_elements_text(col::jsonb)` |
+| `mw_json_array_length(col)` | `json_array_length(col)` | `jsonb_array_length(col::jsonb)` |
+| `mw_instr(str, sub)` | `instr(str, sub)` | `strpos(str, sub)` |
+| `mw_greatest(a, b)` | `max(a, b)` | `GREATEST(a, b)` |
+
+`mw_json_extract` accepts the bare key name (`"rate"`) rather than the SQLite `$.rate` path syntax. The compiler adds the appropriate prefix/operator.
+
+`mw_json_array_values` works with `.table_valued(column("value", String))`. In SQLite, `json_each` returns rows with a `value` column natively. In PostgreSQL, `jsonb_array_elements_text` returns a single unnamed column that is aliased to `value` by the `table_valued` wrapper.
+
+`mw_greatest` replaces `func.max(a, b)` for scalar two-argument maximum. SQLite's `max()` works as both aggregate (1 arg) and scalar (2+ args); PostgreSQL's `max()` is aggregate-only, so `GREATEST()` is needed.
+
 ### CTE-based SQL expression architecture
 
-The SQL side of `balance_at` uses nested CTEs (`nesting=True`) inside a single scalar subquery. Each CTE builds on the previous, keeping the computation readable:
+The SQL side of `balance_at` uses nested CTEs (`nesting=True`) inside a single scalar subquery. Each CTE builds on the previous, keeping the computation readable. All dialect-specific functions go through the `compat.py` wrappers.
 
 | CTE | Purpose |
 |-----|---------|
 | `loan_state` | `COALESCE(last_remaining_balance, principal)` and `COALESCE(last_payment_date, disbursement_date)`. Uses scalar subqueries so it always returns 1 row even with no settlements. |
 | `daily_rates` | Converts rates of any period to daily via `_daily_rate_expr`. Handles all `CompoundingFrequency` values for both JSON and string column representations. NULL mora rate coalesces to 0. |
-| `time_split` | Computes `total_days` and finds `next_due` date after last payment via `json_each(due_dates)`. |
+| `time_split` | Computes `total_days` and finds `next_due` date after last payment via `mw_json_array_values(due_dates)`. |
 | `day_split` | Splits total days into `regular_days` and `mora_days` at the next-due boundary. |
 | `accrued` | `regular_interest` (compound on principal) and `mora_interest` (COMPOUND or SIMPLE branching via `mora_strategy`). |
 | `late_fines` | Counts late installments (`past_grace_count - settlement_count`), estimates PMT, applies fine rate. |
 | Final SELECT | `principal_balance + regular_interest + mora_interest + fines`. |
 
-NULL guard: Falls back to `COALESCE(remaining_balance, principal)` when no rate is present. The check depends on representation: JSON uses `json_extract(interest_rate, '$.rate') IS NULL`; string uses `interest_rate IS NULL`.
+NULL guard: Falls back to `COALESCE(remaining_balance, principal)` when no rate is present. The check depends on representation: JSON uses `mw_json_extract(interest_rate, 'rate') IS NULL`; string uses `interest_rate IS NULL`.
 
 ### Rate conversion helpers
 
@@ -159,14 +179,14 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 **Column introspection:** `_get_rate_col_info(cls, attr_name)` reads the `InterestRateType` from the model's column to determine `representation` ("json" or "string") and `default_year_size`. This happens once at expression-build time — no SQL-side format detection.
 
 **Param extraction:** `_extract_rate_params(rate_col, representation, default_year_size)` returns `(decimal_rate, period, year_size)` as SQL expressions:
-- JSON: uses `json_extract` for all three values.
-- String: parses `"5.250% annual"` via `SUBSTR`/`INSTR`, divides the percentage by 100; uses the column type's `default_year_size` since the string format does not embed year size.
+- JSON: uses `mw_json_extract` for all three values.
+- String: parses `"5.250% annual"` via `SUBSTR`/`mw_instr`, divides the percentage by 100; uses the column type's `default_year_size` since the string format does not embed year size.
 
 **Period mapping:** `_periods_per_year_expr(period, year_size, representation)` builds a SQL `CASE` generated from `CompoundingFrequency` — no hardcoded magic numbers. Period names differ by representation (JSON: `"annually"`, `"semi_annually"`; string: both long tokens like `"annual"`, `"semi-annual"` and abbreviated tokens like `"a.a."`, `"a.s."` from `_ABBREV_MAP`). Each frequency generates CASE branches for all its recognized tokens. `CONTINUOUS` is excluded (handled separately via `exp()`). `DAILY` uses `year_size` instead of a fixed value.
 
-**Conversion:** `_effective_annual_expr(rate_col, representation, default_year_size)` and `_daily_rate_expr(rate_col, representation, default_year_size)` combine the above. Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` which requires the SQLite math extension (available in Python 3.11+ / SQLite 3.35+).
+**Conversion:** `_effective_annual_expr(rate_col, representation, default_year_size)` and `_daily_rate_expr(rate_col, representation, default_year_size)` combine the above. Both are used by the `daily_rates` CTE for `interest_rate` and `mora_interest_rate` columns. The `continuous` period uses `func.exp()` (requires SQLite math extension, available in Python 3.11+ / SQLite 3.35+; native in PostgreSQL).
 
-**NULL guard:** `_has_rate(rate_col, representation)` returns a SQL expression that is NULL when no parseable rate is present. For JSON: checks `json_extract(rate_col, '$.rate')`; for string: checks the column itself.
+**NULL guard:** `_has_rate(rate_col, representation)` returns a SQL expression that is NULL when no parseable rate is present. For JSON: checks `mw_json_extract(rate_col, 'rate')`; for string: checks the column itself.
 
 ## Design Decisions
 
@@ -179,17 +199,18 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 - **Per-loan Warp nesting:** `Warp` tracks active loans by `id(loan)` in a class-level `_active_loans: set`. Warping different `Loan` objects concurrently is allowed, but warping the same `Loan` twice is still blocked with `NestedWarpError`. This enables `balance_at` to use `Warp` internally (it creates a fresh Loan via `_load_money_warp_loan()`, so `id()` is different from any outer-warped loan).
 - **Per-payment time warping during replay:** When `_load_money_warp_loan` replays settlements, the loan's `_time_ctx` is overridden to each payment's date via `WarpedTime(pdate)`. This ensures `self.now()` inside `record_payment` returns the correct historical time, affecting late fine calculations and the `processing_date` default.
 - **Phantom fine prevention:** `balance_at` clears `fines_applied` on the reconstructed loan before passing it to `Warp`. Without this, fines charged during replay of future settlements would persist when warping to an earlier date (e.g., a fine from a Mar 15 settlement would appear at Jan 15). Clearing forces `Warp.calculate_late_fines(as_of)` to recompute fines purely from the point-in-time state, matching the SQL CTE which computes fines based on settlements and due dates visible at `as_of`.
-- **CTE nesting:** `nesting=True` keeps CTEs inside the scalar subquery so correlation to the outer `loans` table works correctly with SQLAlchemy + SQLite.
+- **Dialect-aware compat layer:** `compat.py` uses SQLAlchemy's `@compiles` decorator pattern — the standard way to write cross-dialect SQL. Each `FunctionElement` subclass has a default (SQLite) compilation and a `"postgresql"` override. `bridge.py` is dialect-agnostic; it calls the wrappers and SQLAlchemy dispatches at compile time. Adding a new dialect means adding `@compiles(fn, "mysql")` (etc.) overrides to `compat.py` — no changes to `bridge.py`.
+- **CTE nesting:** `nesting=True` keeps CTEs inside the scalar subquery so correlation to the outer `loans` table works correctly with SQLAlchemy on all dialects.
 - **`loan_state` uses scalar subqueries:** Instead of `SELECT FROM last_settlement_cte` (which returns 0 rows when no settlements exist), `loan_state` uses inline scalar subqueries with `COALESCE`. This guarantees exactly 1 row regardless of settlement presence.
 - **Cartesian product warnings:** The final SELECT joins multiple single-row CTEs without explicit join conditions. SQLAlchemy warns about cartesian products, but this is intentional and correct since each CTE produces exactly 1 row.
 - **`balance_at` + `balance` pattern:** `balance_at(date)` is a `hybrid_method` that accepts a date param. `balance` is a `hybrid_property` that delegates to `balance_at(now())` / `balance_at(func.now())`.
-- **Package split rationale:** `types.py` contains pure column type descriptors (no business logic). `bridge.py` contains the loan/settlement decorators and the Loan reconstruction engine. Separation makes each file focused and testable.
+- **Package split rationale:** `types.py` contains pure column type descriptors (no business logic). `bridge.py` contains the loan/settlement decorators and the Loan reconstruction engine. `compat.py` contains dialect-specific SQL compilation. Separation makes each file focused and testable.
 
 ## Key Gotchas
 
 - String round-trip loses some precision: the percentage rate is formatted with 3 decimal places (`:.3f`). Rates with more than 3 decimal digits in the percentage form should use dict/json representation for lossless round-trips.
 - `None` handling: all type fields pass through `None` in both directions (returns `None`).
-- **SQLite precision:** SQLite stores `Numeric` as floating-point internally. Very high-precision raw amounts (> ~10 significant digits) may lose precision. Use PostgreSQL or MySQL for production.
+- **SQLite precision:** SQLite stores `Numeric` as floating-point internally. Very high-precision raw amounts (> ~10 significant digits) may lose precision. PostgreSQL uses true `DECIMAL` and does not have this limitation.
 - **SQL expression type asymmetry:** The `balance` hybrid_property returns `Money` on instances but raw `Numeric` in SQL expressions. Filter comparisons use `Decimal`, not `Money`: `LoanRecord.balance > Decimal("1000")`.
 - **SQL vs Python precision:** The SQL CTE expression uses float64 arithmetic while Python uses `Decimal`. For exact comparisons in tests, use approximate matching (e.g., `pytest.approx`) when comparing SQL results against Python `balance_at`.
 - **JSON NULL vs SQL NULL:** SQLAlchemy's `JSON` type stores Python `None` as the string `'null'` rather than SQL `NULL`. For JSON representation, the NULL guard checks `json_extract(interest_rate, '$.rate') IS NULL` which correctly handles both cases since `json_extract('null', '$.rate')` returns NULL.
@@ -197,3 +218,13 @@ Private helpers in `bridge.py` convert stored rates to daily rates in SQL, mirro
 - **Data-driven period mapping:** The SQL `CASE` branches in `_periods_per_year_expr` are generated from the `CompoundingFrequency` enum, `_FREQUENCY_TOKEN`, and `_ABBREV_MAP`. Each frequency maps to a list of recognized tokens (long and abbreviated). Adding a new `CompoundingFrequency` member and its tokens automatically extends both JSON and string SQL support.
 - **String representation year_size limitation:** The string format (e.g., `"5.250% annual"`) does not embed `year_size`. The SQL helpers use the `rate_year_size` default from the column's `InterestRateType` definition. If different rates on the same column need different year sizes, use JSON representation instead.
 - **Continuous compounding in string format:** `CompoundingFrequency.CONTINUOUS` is not in `_FREQUENCY_TOKEN` and cannot be serialized as a string. Use JSON representation for continuous rates.
+
+## Testing
+
+All SQLAlchemy extension tests run against both SQLite and PostgreSQL. The `engine` fixture in `tests/ext/sa/conftest.py` is parametrized with `["sqlite", "postgresql"]`, so every test automatically runs on both backends.
+
+PostgreSQL tests use `pytest-postgresql` with `postgresql_proc` — it starts/stops its own temporary PostgreSQL process per session. This requires `pg_ctl` on PATH (installed via the `postgresql` system package). No external Docker service or env var configuration is needed for tests.
+
+The devcontainer Dockerfile installs `postgresql` + `libpq-dev` and adds the PG bin dir to PATH. CI installs the same packages and appends `$(pg_config --bindir)` to `$GITHUB_PATH`.
+
+A separate Docker `postgres:16` service in `docker-compose.yml` is available for general development use (manual queries, testing against a persistent server) but is not used by the test suite.

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -11,6 +11,14 @@ from typing import List
 from sqlalchemy import Float, String, case, cast, column, func, literal, select
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
+from money_warp.ext.sa.compat import (
+    mw_greatest,
+    mw_instr,
+    mw_json_array_length,
+    mw_json_array_values,
+    mw_json_extract,
+    mw_julianday,
+)
 from money_warp.ext.sa.types import _FREQUENCY_TOKEN
 from money_warp.loan import Loan, MoraStrategy
 from money_warp.rate import _ABBREV_MAP, CompoundingFrequency
@@ -210,11 +218,11 @@ def _extract_rate_params(rate_col, representation, default_year_size):
     *default_year_size* since the string format does not embed year size.
     """
     if representation == "json":
-        rate = cast(func.json_extract(rate_col, "$.rate"), Float)
-        period = func.json_extract(rate_col, "$.period")
-        year_size = cast(func.json_extract(rate_col, "$.year_size"), Float)
+        rate = cast(mw_json_extract(rate_col, "rate"), Float)
+        period = mw_json_extract(rate_col, "period")
+        year_size = cast(mw_json_extract(rate_col, "year_size"), Float)
     else:
-        pct_pos = func.instr(rate_col, "%")
+        pct_pos = mw_instr(rate_col, "%")
         rate = cast(func.substr(rate_col, 1, pct_pos - 1), Float) / 100.0
         period = func.trim(func.substr(rate_col, pct_pos + 1))
         year_size = default_year_size
@@ -282,7 +290,7 @@ def _daily_rate_expr(rate_col, representation, default_year_size):
 def _has_rate(rate_col, representation):
     """SQL expression that is NULL when no parseable rate is present."""
     if representation == "json":
-        return cast(func.json_extract(rate_col, "$.rate"), Float)
+        return cast(mw_json_extract(rate_col, "rate"), Float)
     return rate_col
 
 
@@ -379,17 +387,17 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
     )
 
     # -- CTE 3: time_split -------------------------------------------------
-    je_next = func.json_each(dd_col).table_valued(column("value", String))
+    je_next = mw_json_array_values(dd_col).table_valued(column("value", String))
     next_due_sq = (
         select(func.min(je_next.c.value))
-        .where(func.julianday(je_next.c.value) > func.julianday(loan_state.c.last_pay_date))
+        .where(mw_julianday(je_next.c.value) > mw_julianday(loan_state.c.last_pay_date))
         .correlate(cls)
         .scalar_subquery()
     )
 
-    total_days_expr = func.max(
+    total_days_expr = mw_greatest(
         0,
-        func.julianday(as_of) - func.julianday(loan_state.c.last_pay_date),
+        mw_julianday(as_of) - mw_julianday(loan_state.c.last_pay_date),
     )
 
     time_split = (
@@ -406,19 +414,19 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
     regular_days_expr = case(
         (time_split.c.next_due.is_(None), time_split.c.total_days),
         (
-            func.julianday(time_split.c.next_due) >= func.julianday(as_of),
+            mw_julianday(time_split.c.next_due) >= mw_julianday(as_of),
             time_split.c.total_days,
         ),
-        else_=func.max(
+        else_=mw_greatest(
             0,
-            func.julianday(time_split.c.next_due) - func.julianday(time_split.c.last_pay_date),
+            mw_julianday(time_split.c.next_due) - mw_julianday(time_split.c.last_pay_date),
         ),
     )
 
     day_split = (
         select(
             regular_days_expr.label("regular_days"),
-            func.max(0, time_split.c.total_days - regular_days_expr).label("mora_days"),
+            mw_greatest(0, time_split.c.total_days - regular_days_expr).label("mora_days"),
         )
         .correlate(cls)
         .cte("day_split", nesting=True)
@@ -458,26 +466,26 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         .scalar_subquery()
     )
 
-    je_grace = func.json_each(dd_col).table_valued(column("value", String))
+    je_grace = mw_json_array_values(dd_col).table_valued(column("value", String))
     past_grace_count = (
         select(func.count())
-        .where(func.julianday(je_grace.c.value) + func.coalesce(gp_col, 0) < func.julianday(as_of))
+        .where(mw_julianday(je_grace.c.value) + func.coalesce(gp_col, 0) < mw_julianday(as_of))
         .correlate(cls)
         .scalar_subquery()
     )
 
-    num_inst = cast(func.json_array_length(dd_col), Float)
+    num_inst = cast(mw_json_array_length(dd_col), Float)
 
-    je_max = func.json_each(dd_col).table_valued(column("value", String))
+    je_max = mw_json_array_values(dd_col).table_valued(column("value", String))
     max_due_sq = select(func.max(je_max.c.value)).correlate(cls).scalar_subquery()
 
     avg_period = case(
         (num_inst <= 1, 30.0),
-        else_=(func.julianday(max_due_sq) - func.julianday(db_col)) / num_inst,
+        else_=(mw_julianday(max_due_sq) - mw_julianday(db_col)) / num_inst,
     )
     periodic_rate = func.pow(1.0 + daily_rates.c.daily_rate, avg_period) - 1.0
     pmt = pr_col * periodic_rate / (1.0 - func.pow(1.0 + periodic_rate, -num_inst))
-    late_count = func.max(0, past_grace_count - settlement_count)
+    late_count = mw_greatest(0, past_grace_count - settlement_count)
 
     late_fines = (
         select(

--- a/money_warp/ext/sa/compat.py
+++ b/money_warp/ext/sa/compat.py
@@ -1,0 +1,190 @@
+# ruff: noqa: A003
+"""Dialect-aware SQL function wrappers for SQLite and PostgreSQL.
+
+Each wrapper is a :class:`~sqlalchemy.sql.expression.FunctionElement` subclass
+with ``@compiles`` overrides.  The default compilation targets SQLite; a
+``"postgresql"`` override emits the equivalent PostgreSQL syntax.  Bridge code
+calls these wrappers instead of raw ``func.*`` so that SQLAlchemy's compiler
+dispatches to the correct SQL at query compile time.
+"""
+
+from sqlalchemy import Float, Integer
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import FunctionElement
+
+# ---------------------------------------------------------------------------
+# mw_julianday — date to fractional day number
+# ---------------------------------------------------------------------------
+
+
+class mw_julianday(FunctionElement):
+    """Convert a date/timestamp to a fractional day number.
+
+    Only the *difference* between two ``mw_julianday`` calls matters, so
+    the absolute epoch (Julian vs Unix) is irrelevant.
+
+    SQLite:  ``julianday(expr)``
+    PG:      ``EXTRACT(EPOCH FROM expr::timestamp) / 86400.0``
+    """
+
+    type = Float()
+    inherit_cache = True
+    name = "mw_julianday"
+
+
+@compiles(mw_julianday)
+def _julianday_default(element, compiler, **kw):
+    return f"julianday({compiler.process(element.clauses, **kw)})"
+
+
+@compiles(mw_julianday, "postgresql")
+def _julianday_pg(element, compiler, **kw):
+    arg = compiler.process(element.clauses, **kw)
+    return f"(EXTRACT(EPOCH FROM ({arg})::timestamp) / 86400.0)"
+
+
+# ---------------------------------------------------------------------------
+# mw_json_extract — top-level key from a JSON column
+# ---------------------------------------------------------------------------
+
+
+class mw_json_extract(FunctionElement):
+    """Extract a top-level key from a JSON column.
+
+    *key* is the bare field name (e.g. ``"rate"``), **not** the SQLite
+    ``$.rate`` path syntax — the compiler adds the appropriate prefix.
+
+    SQLite:  ``json_extract(col, '$.key')``
+    PG:      ``(col)::jsonb->>'key'``
+    """
+
+    inherit_cache = True
+    name = "mw_json_extract"
+
+    def __init__(self, col, key: str):
+        self._json_key = key
+        super().__init__(col)
+
+
+@compiles(mw_json_extract)
+def _json_extract_default(element, compiler, **kw):
+    col_sql = compiler.process(element.clauses, **kw)
+    return f"json_extract({col_sql}, '$.{element._json_key}')"
+
+
+@compiles(mw_json_extract, "postgresql")
+def _json_extract_pg(element, compiler, **kw):
+    col_sql = compiler.process(element.clauses, **kw)
+    return f"(({col_sql})::jsonb->>'{element._json_key}')"
+
+
+# ---------------------------------------------------------------------------
+# mw_json_array_values — iterate JSON array elements (table-valued)
+# ---------------------------------------------------------------------------
+
+
+class mw_json_array_values(FunctionElement):
+    """Expand a JSON array into rows of text values.
+
+    Use with ``.table_valued(column("value", String))`` to create a
+    table-valued alias whose ``value`` column holds each element.
+
+    SQLite:  ``json_each(col)``   (returns rows with a ``value`` column)
+    PG:      ``jsonb_array_elements_text(col::jsonb)``  (single unnamed column,
+             aliased to ``value`` by the ``table_valued`` wrapper)
+    """
+
+    inherit_cache = True
+    name = "mw_json_array_values"
+
+
+@compiles(mw_json_array_values)
+def _json_array_values_default(element, compiler, **kw):
+    return f"json_each({compiler.process(element.clauses, **kw)})"
+
+
+@compiles(mw_json_array_values, "postgresql")
+def _json_array_values_pg(element, compiler, **kw):
+    col_sql = compiler.process(element.clauses, **kw)
+    return f"jsonb_array_elements_text(({col_sql})::jsonb)"
+
+
+# ---------------------------------------------------------------------------
+# mw_json_array_length — length of a JSON array
+# ---------------------------------------------------------------------------
+
+
+class mw_json_array_length(FunctionElement):
+    """Return the number of elements in a JSON array.
+
+    SQLite:  ``json_array_length(col)``
+    PG:      ``jsonb_array_length(col::jsonb)``
+    """
+
+    type = Integer()
+    inherit_cache = True
+    name = "mw_json_array_length"
+
+
+@compiles(mw_json_array_length)
+def _json_array_length_default(element, compiler, **kw):
+    return f"json_array_length({compiler.process(element.clauses, **kw)})"
+
+
+@compiles(mw_json_array_length, "postgresql")
+def _json_array_length_pg(element, compiler, **kw):
+    col_sql = compiler.process(element.clauses, **kw)
+    return f"jsonb_array_length(({col_sql})::jsonb)"
+
+
+# ---------------------------------------------------------------------------
+# mw_instr — find substring position
+# ---------------------------------------------------------------------------
+
+
+class mw_instr(FunctionElement):
+    """Return the 1-based position of *sub* in *string* (0 if absent).
+
+    SQLite:  ``instr(string, sub)``
+    PG:      ``strpos(string, sub)``
+    """
+
+    type = Integer()
+    inherit_cache = True
+    name = "mw_instr"
+
+
+@compiles(mw_instr)
+def _instr_default(element, compiler, **kw):
+    return f"instr({compiler.process(element.clauses, **kw)})"
+
+
+@compiles(mw_instr, "postgresql")
+def _instr_pg(element, compiler, **kw):
+    return f"strpos({compiler.process(element.clauses, **kw)})"
+
+
+# ---------------------------------------------------------------------------
+# mw_greatest — scalar maximum of two values
+# ---------------------------------------------------------------------------
+
+
+class mw_greatest(FunctionElement):
+    """Return the larger of two values (scalar, not aggregate).
+
+    SQLite:  ``max(a, b)``  (SQLite's ``max()`` acts as scalar with 2+ args)
+    PG:      ``GREATEST(a, b)``
+    """
+
+    inherit_cache = True
+    name = "mw_greatest"
+
+
+@compiles(mw_greatest)
+def _greatest_default(element, compiler, **kw):
+    return f"max({compiler.process(element.clauses, **kw)})"
+
+
+@compiles(mw_greatest, "postgresql")
+def _greatest_pg(element, compiler, **kw):
+    return f"GREATEST({compiler.process(element.clauses, **kw)})"

--- a/poetry.lock
+++ b/poetry.lock
@@ -891,7 +891,7 @@ files = [
     {file = "greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a"},
     {file = "greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2"},
 ]
-markers = {main = "extra == \"sa\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")", dev = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
+markers = {main = "(extra == \"sa\" or extra == \"pg\") and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")", dev = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
 
 [package.extras]
 docs = ["Sphinx", "furo"]
@@ -1744,6 +1744,21 @@ files = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "3.0.2"
+description = "Process executor (not only) for tests."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "mirakuru-3.0.2-py3-none-any.whl", hash = "sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f"},
+    {file = "mirakuru-3.0.2.tar.gz", hash = "sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441"},
+]
+
+[package.dependencies]
+psutil = {version = ">=4.0.0", markers = "sys_platform != \"cygwin\""}
+
+[[package]]
 name = "mistune"
 version = "3.1.4"
 description = "A sane and fast Markdown parser with useful plugins and renderers"
@@ -2383,6 +2398,18 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "port-for"
+version = "1.0.0"
+description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "port_for-1.0.0-py3-none-any.whl", hash = "sha256:35a848b98cf4cc075fe80dc49ae5c3a78e3ca345a23bd39bf5252277b4eef5c2"},
+    {file = "port_for-1.0.0.tar.gz", hash = "sha256:404d161b1b2c82e2f6b31d8646396b4847d02bf5ee10068c92b7263657a14582"},
+]
+
+[[package]]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -2437,7 +2464,7 @@ version = "7.1.0"
 description = "Cross-platform lib for process and system monitoring."
 optional = false
 python-versions = ">=3.6"
-groups = ["notebook"]
+groups = ["dev", "notebook"]
 files = [
     {file = "psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13"},
     {file = "psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5"},
@@ -2449,10 +2476,103 @@ files = [
     {file = "psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07"},
     {file = "psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2"},
 ]
+markers = {dev = "sys_platform != \"cygwin\""}
 
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pyreadline ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32 ; os_name == \"nt\" and platform_python_implementation != \"PyPy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and platform_python_implementation != \"PyPy\"", "wmi ; os_name == \"nt\" and platform_python_implementation != \"PyPy\""]
 test = ["pytest", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32 ; os_name == \"nt\" and platform_python_implementation != \"PyPy\"", "setuptools", "wheel ; os_name == \"nt\" and platform_python_implementation != \"PyPy\"", "wmi ; os_name == \"nt\" and platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+description = "PostgreSQL database adapter for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "dev"]
+files = [
+    {file = "psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698"},
+    {file = "psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9"},
+]
+markers = {main = "extra == \"pg\""}
+
+[package.dependencies]
+psycopg-binary = {version = "3.3.3", optional = true, markers = "implementation_name != \"pypy\" and extra == \"binary\""}
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+binary = ["psycopg-binary (==3.3.3) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.3.3) ; implementation_name != \"pypy\""]
+dev = ["ast-comments (>=1.1.2)", "black (>=26.1.0)", "codespell (>=2.2)", "cython-lint (>=0.16)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.19.0)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
+docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
+pool = ["psycopg-pool"]
+test = ["anyio (>=4.0)", "mypy (>=1.19.0) ; implementation_name != \"pypy\"", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "implementation_name != \"pypy\""
+files = [
+    {file = "psycopg_binary-3.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b3385b58b2fe408a13d084c14b8dcf468cd36cbbe774408250facc128f9fa75c"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1bef235a50a80f6aba05147002bc354559657cb6386dbd04d8e1c97d1d7cbe84"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:97c839717bf8c8df3f6d983a20949c4fb22e2a34ee172e3e427ede363feda27b"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48e500cf1c0984dacf1f28ea482c3cdbb4c2288d51c336c04bc64198ab21fc51"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb36a08859b9432d94ea6b26ec41a2f98f83f14868c91321d0c1e11f672eeae7"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0dde92cfde09293fb63b3f547919ba7d73bd2654573c03502b3263dd0218e44e"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:78c9ce98caaf82ac8484d269791c1b403d7598633e0e4e2fa1097baae244e2f1"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d593612758d0041cb13cb0003f7f8d3fabb7ad9319e651e78afae49b1cf5860e"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f24e8e17035200a465c178e9ea945527ad0738118694184c450f1192a452ff25"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e7b607f0e14f2a4cf7e78a05ebd13df6144acfba87cb90842e70d3f125d9f53f"},
+    {file = "psycopg_binary-3.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:b27d3a23c79fa59557d2cc63a7e8bb4c7e022c018558eda36f9d7c4e6b99a6e0"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:90eecd93073922f085967f3ed3a98ba8c325cbbc8c1a204e300282abd2369e13"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dac7ee2f88b4d7bb12837989ca354c38d400eeb21bce3b73dac02622f0a3c8d6"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62cf8784eb6d35beaee1056d54caf94ec6ecf2b7552395e305518ab61eb8fd2"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a39f34c9b18e8f6794cca17bfbcd64572ca2482318db644268049f8c738f35a6"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:883d68d48ca9ff3cb3d10c5fdebea02c79b48eecacdddbf7cce6e7cdbdc216b8"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cab7bc3d288d37a80aa8c0820033250c95e40b1c2b5c57cf59827b19c2a8b69d"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:56c767007ca959ca32f796b42379fc7e1ae2ed085d29f20b05b3fc394f3715cc"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:da2f331a01af232259a21573a01338530c6016dcfad74626c01330535bcd8628"},
+    {file = "psycopg_binary-3.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:19f93235ece6dbfc4036b5e4f6d8b13f0b8f2b3eeb8b0bd2936d406991bcdd40"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830"},
+    {file = "psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1"},
+    {file = "psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856"},
+    {file = "psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383"},
+]
 
 [[package]]
 name = "ptyprocess"
@@ -2513,7 +2633,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs", "notebook"]
+groups = ["dev", "docs", "notebook"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -2543,26 +2663,27 @@ extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -2582,6 +2703,25 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "pytest-postgresql"
+version = "8.0.0"
+description = "Postgresql fixtures and fixture factories for Pytest."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_postgresql-8.0.0-py3-none-any.whl", hash = "sha256:125b63b16d630c2dea19807062ed4c96e6123f06058ce65b82b4b14174d6c4b8"},
+    {file = "pytest_postgresql-8.0.0.tar.gz", hash = "sha256:26cbd44a0adef76cf4a82a3a2263f0e029bc54b5863556a9bd86ca3edfa91cce"},
+]
+
+[package.dependencies]
+mirakuru = ">=2.6.0"
+packaging = "*"
+port-for = ">=0.7.3"
+psycopg = ">=3.0.0"
+pytest = ">=8.2"
 
 [[package]]
 name = "python-dateutil"
@@ -3307,7 +3447,7 @@ files = [
     {file = "sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096"},
     {file = "sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7"},
 ]
-markers = {main = "extra == \"sa\""}
+markers = {main = "extra == \"sa\" or extra == \"pg\""}
 
 [package.dependencies]
 greenlet = {version = ">=1", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
@@ -3529,7 +3669,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "extra == \"sa\"", docs = "python_version == \"3.10\""}
+markers = {main = "(python_version < \"3.14\" or extra == \"sa\" or extra == \"pg\") and (extra == \"pg\" or extra == \"sa\")", docs = "python_version == \"3.10\""}
 
 [[package]]
 name = "tzdata"
@@ -3537,12 +3677,12 @@ version = "2025.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["dev", "notebook"]
+groups = ["main", "dev", "notebook"]
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
-markers = {dev = "platform_system == \"Windows\""}
+markers = {main = "extra == \"pg\" and sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "uri-template"
@@ -3709,9 +3849,10 @@ files = [
 
 [extras]
 marshmallow = ["marshmallow"]
+pg = ["psycopg", "sqlalchemy"]
 sa = ["sqlalchemy"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "d2ed0ccb4177ad80308d660bc457b7feecc1a4075f9a3a5076f416d967c8e05b"
+content-hash = "a321df2ff6f71b3c1c8ede02744aeed059e8d8a8c1e9570968d112ed51bb8017"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,15 @@ scipy = "^1.10.0"
 python-dateutil = "^2.8.0"
 marshmallow = {version = "^3.20.0", optional = true}
 sqlalchemy = {version = "^2.0", optional = true}
+psycopg = {version = "^3.1", optional = true}
 
 [tool.poetry.extras]
 marshmallow = ["marshmallow"]
 sa = ["sqlalchemy"]
+pg = ["sqlalchemy", "psycopg"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.0"
+pytest = "^8.2.0"
 pytest-cov = "^4.0.0"
 deptry = "^0.6.4"
 pre-commit = "^2.20.0"
@@ -45,6 +47,8 @@ hypothesis = {version = "^6.151.9", python = ">=3.10"}
 marshmallow = "^3.20.0"
 sqlalchemy = "^2.0"
 factory-boy = "^3.3.3"
+pytest-postgresql = "^8.0.0"
+psycopg = {extras = ["binary"], version = "^3.3.3"}
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"
@@ -133,7 +137,8 @@ ignore_transitive = [
 ]
 ignore_misplaced_dev = [
     "sqlalchemy",
-    "marshmallow"
+    "marshmallow",
+    "psycopg"
 ]
 extend_exclude = [
     "notebooks/",

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -2,12 +2,12 @@
 """Shared models, fixtures, and factories for SQLAlchemy extension tests."""
 
 import os
+import shutil
 from datetime import datetime, timezone
 
 import factory
 import factory.alchemy
 import pytest
-from pytest_postgresql import factories as pg_factories
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, relationship
 
@@ -137,23 +137,23 @@ class StringLoanRecord(Base):
 
 
 # ---------------------------------------------------------------------------
-# PostgreSQL fixtures (pytest-postgresql noproc for Docker/CI server)
+# PostgreSQL detection: pg_ctl on PATH + env var opt-in
 # ---------------------------------------------------------------------------
 
-postgresql_noproc = pg_factories.postgresql_noproc(
-    host=os.environ.get("PG_HOST", "postgres"),
-    port=int(os.environ.get("PG_PORT", "5432")),
-    user=os.environ.get("PG_USER", "test"),
-    password=os.environ.get("PG_PASSWORD", "test"),
+_PG_ENABLED = (
+    os.environ.get("MONEY_WARP_TEST_PG", "").lower() in ("1", "true", "yes") and shutil.which("pg_ctl") is not None
 )
-postgresql_conn = pg_factories.postgresql("postgresql_noproc")
+
+if _PG_ENABLED:
+    from pytest_postgresql import factories as pg_factories
+
+    postgresql_proc = pg_factories.postgresql_proc()
+    postgresql_conn = pg_factories.postgresql("postgresql_proc")
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-_PG_ENABLED = os.environ.get("MONEY_WARP_TEST_PG", "").lower() in ("1", "true", "yes")
 
 _engine_params = [pytest.param("sqlite", id="sqlite")]
 if _PG_ENABLED:
@@ -169,11 +169,8 @@ def engine(request):
         return
 
     pg = request.getfixturevalue("postgresql_conn")
-    host = os.environ.get("PG_HOST", "postgres")
-    port = os.environ.get("PG_PORT", "5432")
-    user = os.environ.get("PG_USER", "test")
-    password = os.environ.get("PG_PASSWORD", "test")
-    dsn = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{pg.info.dbname}"
+    info = pg.info
+    dsn = f"postgresql+psycopg://{info.user}@{info.host}:{info.port}/{info.dbname}"
     eng = create_engine(dsn)
     Base.metadata.create_all(eng)
     yield eng

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -1,11 +1,13 @@
 # ruff: noqa: A003
 """Shared models, fixtures, and factories for SQLAlchemy extension tests."""
 
+import os
 from datetime import datetime, timezone
 
 import factory
 import factory.alchemy
 import pytest
+from pytest_postgresql import factories as pg_factories
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, relationship
 
@@ -135,15 +137,47 @@ class StringLoanRecord(Base):
 
 
 # ---------------------------------------------------------------------------
+# PostgreSQL fixtures (pytest-postgresql noproc for Docker/CI server)
+# ---------------------------------------------------------------------------
+
+postgresql_noproc = pg_factories.postgresql_noproc(
+    host=os.environ.get("PG_HOST", "postgres"),
+    port=int(os.environ.get("PG_PORT", "5432")),
+    user=os.environ.get("PG_USER", "test"),
+    password=os.environ.get("PG_PASSWORD", "test"),
+)
+postgresql_conn = pg_factories.postgresql("postgresql_noproc")
+
+
+# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+_PG_ENABLED = os.environ.get("MONEY_WARP_TEST_PG", "").lower() in ("1", "true", "yes")
 
-@pytest.fixture()
-def engine():
-    eng = create_engine("sqlite:///:memory:")
+_engine_params = [pytest.param("sqlite", id="sqlite")]
+if _PG_ENABLED:
+    _engine_params.append(pytest.param("postgresql", id="postgresql"))
+
+
+@pytest.fixture(params=_engine_params)
+def engine(request):
+    if request.param == "sqlite":
+        eng = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(eng)
+        yield eng
+        return
+
+    pg = request.getfixturevalue("postgresql_conn")
+    host = os.environ.get("PG_HOST", "postgres")
+    port = os.environ.get("PG_PORT", "5432")
+    user = os.environ.get("PG_USER", "test")
+    password = os.environ.get("PG_PASSWORD", "test")
+    dsn = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{pg.info.dbname}"
+    eng = create_engine(dsn)
     Base.metadata.create_all(eng)
-    return eng
+    yield eng
+    eng.dispose()
 
 
 @pytest.fixture()

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -1,13 +1,12 @@
 # ruff: noqa: A003
 """Shared models, fixtures, and factories for SQLAlchemy extension tests."""
 
-import os
-import shutil
 from datetime import datetime, timezone
 
 import factory
 import factory.alchemy
 import pytest
+from pytest_postgresql import factories as pg_factories
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, relationship
 
@@ -137,30 +136,19 @@ class StringLoanRecord(Base):
 
 
 # ---------------------------------------------------------------------------
-# PostgreSQL detection: pg_ctl on PATH + env var opt-in
+# PostgreSQL fixtures (pytest-postgresql starts its own PG process)
 # ---------------------------------------------------------------------------
 
-_PG_ENABLED = (
-    os.environ.get("MONEY_WARP_TEST_PG", "").lower() in ("1", "true", "yes") and shutil.which("pg_ctl") is not None
-)
-
-if _PG_ENABLED:
-    from pytest_postgresql import factories as pg_factories
-
-    postgresql_proc = pg_factories.postgresql_proc()
-    postgresql_conn = pg_factories.postgresql("postgresql_proc")
+postgresql_proc = pg_factories.postgresql_proc()
+postgresql_conn = pg_factories.postgresql("postgresql_proc")
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-_engine_params = [pytest.param("sqlite", id="sqlite")]
-if _PG_ENABLED:
-    _engine_params.append(pytest.param("postgresql", id="postgresql"))
 
-
-@pytest.fixture(params=_engine_params)
+@pytest.fixture(params=[pytest.param("sqlite", id="sqlite"), pytest.param("postgresql", id="postgresql")])
 def engine(request):
     if request.param == "sqlite":
         eng = create_engine("sqlite:///:memory:")

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,7 @@ python =
     3.11: py311
     
 [testenv]
-passenv =
-    PYTHON_VERSION
-    MONEY_WARP_TEST_PG
+passenv = PYTHON_VERSION
 allowlist_externals = poetry
 commands =
     poetry install -v

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ python =
     3.11: py311
     
 [testenv]
-passenv = PYTHON_VERSION
+passenv =
+    PYTHON_VERSION
+    MONEY_WARP_TEST_PG
 allowlist_externals = poetry
 commands =
     poetry install -v


### PR DESCRIPTION
## Summary
- Add a dialect-aware SQL compatibility layer (`compat.py`) so the SQLAlchemy bridge's hybrid properties work on both SQLite and PostgreSQL
- All SA extension tests now run against both backends via `pytest-postgresql`

## Changes
- **`money_warp/ext/sa/compat.py`** (new): `FunctionElement` subclasses with `@compiles` overrides for `mw_julianday`, `mw_json_extract`, `mw_json_array_values`, `mw_json_array_length`, `mw_instr`, `mw_greatest`
- **`bridge.py`**: replaced raw `func.*` SQLite calls with compat wrappers -- no dialect logic in bridge itself
- **`tests/ext/sa/conftest.py`**: `engine` fixture always parametrized with `["sqlite", "postgresql"]` using `pytest-postgresql`'s `postgresql_proc` (self-contained)
- **Dependencies**: bumped `pytest` to `^8.2.0`, added `pytest-postgresql ^8.0.0` + `psycopg[binary]` dev deps, added optional `pg` extra
- **Devcontainer**: Dockerfile installs `postgresql` + `libpq-dev`, adds PG bin dir to PATH; docker-compose keeps a `postgres:16` service for general dev use
- **CI**: installs PostgreSQL packages on runner, adds `pg_config --bindir` to `$GITHUB_PATH`
- **Knowledge**: updated `knowledge/ext.md` with compat layer docs and testing section

## Test plan
- [x] All 1574 tests pass (260 SA tests x2 backends + core tests)
- [ ] CI passes on both Python 3.10 and 3.11
- [ ] Verify `poetry install --extras pg` works for downstream consumers

## Docs
- Updated `knowledge/ext.md` with compat module design, dialect mapping table, and testing infrastructure docs


Made with [Cursor](https://cursor.com)