### PR TITLE
feat: intention-aware settlement replay in bridge

### DIFF
--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -118,12 +118,31 @@ Class decorator that stores column metadata on a settlement model:
     amount="amount",
     interest_date="interest_date",
     processing_date="processing_date",
+    intention="intention",
 )
 ```
 
 All params have defaults matching the names above — `@settlement_bridge()` with no args works if you follow the convention. Stores a `_money_warp_bridge_meta` dict on the class.
 
 The `interest_date` and `processing_date` columns are optional on the model. When absent or `None`, `record_payment` uses its own defaults (`interest_date` defaults to `payment_date`, `processing_date` defaults to `self.now()`).
+
+#### Intention column
+
+The `intention` column is a JSON object that declares which payment method was used when the settlement was created. The column should be NOT NULL. Recognized shapes:
+
+```json
+{"method": "record_payment"}
+{"method": "pay_installment"}
+{"method": "anticipate_payment", "installments": [1, 2]}
+```
+
+During replay (`_replay_settlements`), the intention determines which `Loan` method is called:
+
+- `"record_payment"`: calls `loan.record_payment(amount, date, **kwargs)` with `interest_date` and `processing_date` from the model.
+- `"pay_installment"`: calls `loan.pay_installment(amount)`. The method internally computes `interest_date = max(self.now(), next_due)`, which is correct because time is already warped to the payment date.
+- `"anticipate_payment"`: calls `loan.anticipate_payment(amount, installments=...)` with installment numbers from the JSON.
+
+When the `intention` attribute is absent on the model (backward compatibility), the replay defaults to `{"method": "record_payment"}`.
 
 ### loan_bridge
 
@@ -139,8 +158,8 @@ Stores `_money_warp_bridge_meta` on the loan class with all field mappings.
 
 **`_load_money_warp_loan()`** (instance method, no parameters):
 - Reads `_money_warp_bridge_meta` from `type(self)`.
-- Reconstructs a full `money_warp.Loan` from stored fields, replays settlements with per-payment time warping (loan's `_time_ctx` is overridden to each payment's date before `record_payment`).
-- Passes all three dates from settlement metadata: `payment_date`, `interest_date`, `processing_date` (optional ones skipped when `None`).
+- Reconstructs a full `money_warp.Loan` from stored fields, replays settlements with per-payment time warping (loan's `_time_ctx` is overridden to each payment's date).
+- Dispatches to the correct `Loan` payment method based on the settlement's `intention` JSON: `record_payment`, `pay_installment`, or `anticipate_payment`. Falls back to `record_payment` when intention is absent.
 - Always returns a `Loan` or raises `ValueError` if any required field (`interest_rate`, `due_dates`, `disbursement_date`) is `None`.
 - Never returns `None`.
 

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -41,13 +41,14 @@ def settlement_bridge(
     amount: str = "amount",
     interest_date: str = "interest_date",
     processing_date: str = "processing_date",
+    intention: str = "intention",
 ):
     """Mark a settlement model with column metadata for :func:`loan_bridge`.
 
     Stores a ``_money_warp_bridge_meta`` dict on the class so that
     ``@loan_bridge`` can discover which columns hold the remaining
-    balance, payment date, payment amount, interest date, and
-    processing date.
+    balance, payment date, payment amount, interest date, processing
+    date, and payment intention.
 
     All parameters have sensible defaults.  If your columns follow the
     naming convention, ``@settlement_bridge()`` with no arguments works.
@@ -56,12 +57,24 @@ def settlement_bridge(
     on the model.  When absent or ``None``,
     :meth:`~money_warp.loan.Loan.record_payment` uses its own defaults.
 
+    The ``intention`` column is a JSON object that declares which payment
+    method was used when the settlement was created.  Recognized shapes::
+
+        {"method": "record_payment"}
+        {"method": "pay_installment"}
+        {"method": "anticipate_payment", "installments": [1, 2]}
+
+    When the attribute is absent on the model,
+    ``{"method": "record_payment"}`` is assumed for backward
+    compatibility.
+
     Args:
         balance: Attribute name for the remaining balance after settlement.
         date: Attribute name for the payment/settlement date.
         amount: Attribute name for the payment amount.
         interest_date: Attribute name for the interest accrual cutoff date.
         processing_date: Attribute name for the audit-trail processing date.
+        intention: Attribute name for the payment intention JSON object.
     """
 
     def decorator(cls):
@@ -71,6 +84,7 @@ def settlement_bridge(
             "amount": amount,
             "interest_date": interest_date,
             "processing_date": processing_date,
+            "intention": intention,
         }
         return cls
 
@@ -137,8 +151,24 @@ def _collect_optional_loan_kwargs(instance, meta):
     return kwargs
 
 
+_DEFAULT_INTENTION = {"method": "record_payment"}
+
+
 def _replay_settlements(loan, items):
-    """Replay recorded settlements onto *loan*, warping time per payment."""
+    """Replay recorded settlements onto *loan*, warping time per payment.
+
+    Dispatches to the correct payment method based on the ``intention``
+    JSON stored on each settlement item:
+
+    - ``"record_payment"`` (default): explicit dates via ``record_payment``.
+    - ``"pay_installment"``: delegates to ``loan.pay_installment`` which
+      computes ``interest_date = max(now, next_due)`` internally.
+    - ``"anticipate_payment"``: delegates to ``loan.anticipate_payment``
+      with optional installment numbers from the JSON.
+
+    When the ``intention`` attribute is absent on the model, falls back
+    to ``record_payment`` for backward compatibility.
+    """
     if not items:
         return
 
@@ -147,19 +177,25 @@ def _replay_settlements(loan, items):
         pdate = ensure_aware(getattr(item, s_meta["date"]))
         loan._time_ctx.override(WarpedTime(pdate))
 
-        rp_kwargs: dict = {}
-        idate = getattr(item, s_meta["interest_date"], None)
-        if idate is not None:
-            rp_kwargs["interest_date"] = idate
-        proc_date = getattr(item, s_meta["processing_date"], None)
-        if proc_date is not None:
-            rp_kwargs["processing_date"] = proc_date
+        amount = getattr(item, s_meta["amount"])
+        raw_intention = getattr(item, s_meta["intention"], _DEFAULT_INTENTION)
+        method = raw_intention.get("method", "record_payment")
 
-        loan.record_payment(
-            getattr(item, s_meta["amount"]),
-            pdate,
-            **rp_kwargs,
-        )
+        if method == "pay_installment":
+            loan.pay_installment(amount)
+        elif method == "anticipate_payment":
+            installments = raw_intention.get("installments")
+            loan.anticipate_payment(amount, installments=installments)
+        else:
+            rp_kwargs: dict = {}
+            idate = getattr(item, s_meta["interest_date"], None)
+            if idate is not None:
+                rp_kwargs["interest_date"] = idate
+            proc_date = getattr(item, s_meta["processing_date"], None)
+            if proc_date is not None:
+                rp_kwargs["processing_date"] = proc_date
+
+            loan.record_payment(amount, pdate, **rp_kwargs)
 
 
 def _load_money_warp_loan_impl(self):

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -8,6 +8,7 @@ import factory.alchemy
 import pytest
 from pytest_postgresql import factories as pg_factories
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine
+from sqlalchemy.types import JSON
 from sqlalchemy.orm import DeclarativeBase, Session, relationship
 
 from money_warp import Loan, MoraStrategy
@@ -95,6 +96,7 @@ class SettlementRecord(Base):
     remaining_balance = Column(MoneyType())
     interest_date = Column(DateTime, nullable=True)
     processing_date = Column(DateTime, nullable=True)
+    intention = Column(JSON, nullable=False, default={"method": "record_payment"})
 
 
 @loan_bridge()
@@ -122,6 +124,7 @@ class StringSettlementRecord(Base):
     remaining_balance = Column(MoneyType())
     interest_date = Column(DateTime, nullable=True)
     processing_date = Column(DateTime, nullable=True)
+    intention = Column(JSON, nullable=False, default={"method": "record_payment"})
 
 
 @loan_bridge()
@@ -281,6 +284,7 @@ class SettlementRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
     remaining_balance = factory.LazyFunction(lambda: Money("7000"))
     interest_date = None
     processing_date = None
+    intention = factory.LazyFunction(lambda: {"method": "record_payment"})
 
 
 class StringLoanRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -308,3 +312,4 @@ class StringSettlementRecordFactory(factory.alchemy.SQLAlchemyModelFactory):
     remaining_balance = factory.LazyFunction(lambda: Money("7000"))
     interest_date = None
     processing_date = None
+    intention = factory.LazyFunction(lambda: {"method": "record_payment"})

--- a/tests/ext/sa/test_sa_bridge.py
+++ b/tests/ext/sa/test_sa_bridge.py
@@ -32,6 +32,7 @@ def test_settlement_bridge_defaults():
         "amount": "amount",
         "interest_date": "interest_date",
         "processing_date": "processing_date",
+        "intention": "intention",
     }
 
 
@@ -42,6 +43,7 @@ def test_settlement_bridge_custom_names():
         amount="paid",
         interest_date="int_dt",
         processing_date="proc_dt",
+        intention="intent",
     )
     class Custom(Base):
         __tablename__ = "custom_settlements"
@@ -53,6 +55,7 @@ def test_settlement_bridge_custom_names():
         "amount": "paid",
         "interest_date": "int_dt",
         "processing_date": "proc_dt",
+        "intention": "intent",
     }
 
 

--- a/tests/ext/sa/test_sa_bridge.py
+++ b/tests/ext/sa/test_sa_bridge.py
@@ -8,9 +8,11 @@ import pytest
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, create_engine, select
 from sqlalchemy.orm import Session, relationship
 
-from money_warp import Warp
+from money_warp import Loan, Warp
 from money_warp.ext.sa import MoneyType, loan_bridge, settlement_bridge
+from money_warp.interest_rate import InterestRate
 from money_warp.money import Money
+from money_warp.warp import WarpedTime
 
 from .conftest import (
     Base,
@@ -429,3 +431,145 @@ def test_loan_bridge_raises_without_settlement_bridge():
 
         with pytest.raises(TypeError, match="@settlement_bridge"):
             s.execute(select(BadLoan).where(BadLoan.balance > Decimal("0"))).scalars().all()
+
+
+# ===========================================================================
+# Intention-aware replay
+# ===========================================================================
+
+
+def _make_reference_loan():
+    """Build a fresh Loan matching LoanRecordFactory defaults."""
+    return Loan(
+        Money("10000"),
+        InterestRate("10% a"),
+        [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)],
+        disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _pay_via_override(loan, pay_date, method, amount, **kwargs):
+    """Make a payment by overriding the time context (same as _replay_settlements).
+
+    Persists on the loan directly — unlike Warp which creates a clone.
+    """
+    loan._time_ctx.override(WarpedTime(pay_date))
+    return getattr(loan, method)(amount, **kwargs)
+
+
+def test_pay_installment_intention_matches_direct_loan(session):
+    """Early pay_installment replayed via bridge produces the same balance."""
+    pay_date = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    as_of = datetime(2024, 2, 15, tzinfo=timezone.utc)
+    amount = Money("5500")
+
+    ref = _make_reference_loan()
+    settlement = _pay_via_override(ref, pay_date, "pay_installment", amount)
+    with Warp(ref, as_of) as w:
+        expected = w.current_balance
+
+    loan_rec = LoanRecordFactory()
+    SettlementRecordFactory(
+        loan_id=loan_rec.id,
+        amount=settlement.payment_amount,
+        payment_date=pay_date,
+        remaining_balance=settlement.remaining_balance,
+        intention={"method": "pay_installment"},
+    )
+    session.expire_all()
+    loaded = session.get(LoanRecord, loan_rec.id)
+
+    assert loaded.balance_at(as_of) == expected
+
+
+def test_pay_installment_intention_differs_from_record_payment(session):
+    """Early pay_installment charges more interest than record_payment (no discount)."""
+    pay_date = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    as_of = datetime(2024, 2, 15, tzinfo=timezone.utc)
+    amount = Money("5500")
+
+    ref_inst = _make_reference_loan()
+    s_inst = _pay_via_override(ref_inst, pay_date, "pay_installment", amount)
+
+    ref_rec = _make_reference_loan()
+    ref_rec.record_payment(amount, pay_date)
+
+    loan_inst = LoanRecordFactory()
+    SettlementRecordFactory(
+        loan_id=loan_inst.id,
+        amount=s_inst.payment_amount,
+        payment_date=pay_date,
+        remaining_balance=s_inst.remaining_balance,
+        intention={"method": "pay_installment"},
+    )
+
+    loan_rec = LoanRecordFactory()
+    SettlementRecordFactory(
+        loan_id=loan_rec.id,
+        amount=amount,
+        payment_date=pay_date,
+        remaining_balance=ref_rec.principal_balance,
+        intention={"method": "record_payment"},
+    )
+
+    session.expire_all()
+    loaded_inst = session.get(LoanRecord, loan_inst.id)
+    loaded_rec = session.get(LoanRecord, loan_rec.id)
+
+    assert loaded_inst.balance_at(as_of) != loaded_rec.balance_at(as_of)
+
+
+def test_anticipate_payment_intention_matches_direct_loan(session):
+    """anticipate_payment replayed via bridge produces the same balance."""
+    pay_date = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    as_of = datetime(2024, 2, 15, tzinfo=timezone.utc)
+    amount = Money("5500")
+
+    ref = _make_reference_loan()
+    settlement = _pay_via_override(
+        ref,
+        pay_date,
+        "anticipate_payment",
+        amount,
+        installments=[1],
+    )
+    with Warp(ref, as_of) as w:
+        expected = w.current_balance
+
+    loan_rec = LoanRecordFactory()
+    SettlementRecordFactory(
+        loan_id=loan_rec.id,
+        amount=settlement.payment_amount,
+        payment_date=pay_date,
+        remaining_balance=settlement.remaining_balance,
+        intention={"method": "anticipate_payment", "installments": [1]},
+    )
+    session.expire_all()
+    loaded = session.get(LoanRecord, loan_rec.id)
+
+    assert loaded.balance_at(as_of) == expected
+
+
+def test_record_payment_intention_backward_compatible(session):
+    """Default record_payment intention preserves existing behavior."""
+    pay_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 2, 15, tzinfo=timezone.utc)
+    amount = Money("3000")
+
+    ref = _make_reference_loan()
+    ref.record_payment(amount, pay_date)
+    with Warp(ref, as_of) as w:
+        expected = w.current_balance
+
+    loan_rec = LoanRecordFactory()
+    SettlementRecordFactory(
+        loan_id=loan_rec.id,
+        amount=amount,
+        payment_date=pay_date,
+        remaining_balance=ref.principal_balance,
+        intention={"method": "record_payment"},
+    )
+    session.expire_all()
+    loaded = session.get(LoanRecord, loan_rec.id)
+
+    assert loaded.balance_at(as_of) == expected


### PR DESCRIPTION
## Summary
- Add an `intention` JSON column mapping to `settlement_bridge` so that `_replay_settlements` dispatches to the correct `Loan` payment method (`record_payment`, `pay_installment`, or `anticipate_payment`)
- Fixes incorrect loan reconstruction when the original payment used `pay_installment` (early payments got an unintended interest discount) or `anticipate_payment` (installment deletion was skipped)
- Fully backward compatible: when the intention attribute is absent on the model, replay defaults to `record_payment`

## Changes
- `settlement_bridge` now accepts an `intention` parameter (default attribute name `"intention"`) pointing to a JSON column with shape `{"method": "...", "installments": [...]}`
- `_replay_settlements` parses the intention and dispatches: `pay_installment` computes the correct `interest_date` internally; `anticipate_payment` passes installment numbers from the JSON
- Updated test models (`SettlementRecord`, `StringSettlementRecord`) with the new JSON column
- Added 4 new tests covering intention dispatch for all three payment methods plus a proof that `pay_installment` and `record_payment` produce different balances for early payments

## Test plan
- [x] All existing tests pass (`poetry run pytest` — 1623 passed)
- [x] New tests verify pay_installment intention matches a direct Loan
- [x] New tests verify anticipate_payment intention matches a direct Loan
- [x] New tests verify record_payment intention preserves backward-compatible behavior
- [x] New test proves pay_installment and record_payment produce different balances for early payments

## Docs
- Updated `knowledge/ext.md` with intention column documentation and dispatch logic

Made with [Cursor](https://cursor.com)