### PR TITLE
refactor: change due_dates from datetime to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ pip install money-warp[sa]            # SQLAlchemy types + bridge
 ```python
 from datetime import datetime, timezone
 from money_warp import Money, InterestRate, Loan, generate_monthly_dates
+from money_warp.tz import to_date
 
 principal = Money("10000.00")
 rate = InterestRate("5% a")  # 5% annually
 
 start_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
-due_dates = generate_monthly_dates(start_date, 12)
+due_dates = [to_date(d) for d in generate_monthly_dates(start_date, 12)]
 
 loan = Loan(principal, rate, due_dates)
 
@@ -67,9 +68,9 @@ Travel to any date and see the loan exactly as it was -- payments, interest, fin
 
 ```python
 from money_warp import Warp, Loan, Money, InterestRate
-from datetime import datetime
+from datetime import date, datetime
 
-loan = Loan(Money("10000"), InterestRate("5% a"), [datetime(2024, 1, 15)])
+loan = Loan(Money("10000"), InterestRate("5% a"), [date(2024, 1, 15)])
 loan.record_payment(Money("500"), datetime(2024, 1, 10))
 loan.record_payment(Money("600"), datetime(2024, 2, 10))
 loan.record_payment(Money("700"), datetime(2024, 3, 10))

--- a/docs/examples/date_generation.md
+++ b/docs/examples/date_generation.md
@@ -124,14 +124,16 @@ short_term = generate_custom_interval_dates(datetime(2024, 1, 1), 12, 10)
 
 ## Integration with Loans
 
-All date generation functions work seamlessly with MoneyWarp loans:
+Generators return `List[datetime]`; `Loan` expects calendar `due_dates: List[date]`. Convert with `to_date` from `money_warp.tz`:
 
 ```python
-from money_warp import Loan, Money, InterestRate, generate_monthly_dates
 from datetime import datetime
 
-# Generate payment dates
-due_dates = generate_monthly_dates(datetime(2024, 1, 15), 24)
+from money_warp import Loan, Money, InterestRate, generate_monthly_dates
+from money_warp.tz import to_date
+
+# Generate payment dates, then strip to calendar dates for the loan
+due_dates = [to_date(d) for d in generate_monthly_dates(datetime(2024, 1, 15), 24)]
 
 # Create loan with generated dates
 loan = Loan(
@@ -197,12 +199,14 @@ quarter_dates = generate_quarterly_dates(datetime(2024, 3, 31), 4)
 ### Mortgage with Monthly Payments
 
 ```python
-from money_warp import Loan, Money, InterestRate, generate_monthly_dates
 from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, generate_monthly_dates
+from money_warp.tz import to_date
 
 # 30-year mortgage starting mid-month
 start_date = datetime(2024, 1, 15)
-payment_dates = generate_monthly_dates(start_date, 360)  # 30 years * 12 months
+payment_dates = [to_date(d) for d in generate_monthly_dates(start_date, 360)]  # 30 years * 12 months
 
 mortgage = Loan(
     principal=Money("400000"),  # $400k house
@@ -218,8 +222,13 @@ print(f"Final payment: {payment_dates[-1]}")
 ### Bi-weekly Auto Loan
 
 ```python
+from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, generate_biweekly_dates
+from money_warp.tz import to_date
+
 # Bi-weekly auto loan (pays off faster)
-biweekly_dates = generate_biweekly_dates(datetime(2024, 1, 5), 130)  # ~5 years
+biweekly_dates = [to_date(d) for d in generate_biweekly_dates(datetime(2024, 1, 5), 130)]  # ~5 years
 
 auto_loan = Loan(
     principal=Money("35000"),
@@ -233,8 +242,13 @@ print(f"Bi-weekly auto loan: {len(biweekly_dates)} payments")
 ### Business Quarterly Loan
 
 ```python
+from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, generate_quarterly_dates
+from money_warp.tz import to_date
+
 # Business loan with quarterly payments
-quarterly_dates = generate_quarterly_dates(datetime(2024, 3, 31), 20)  # 5 years
+quarterly_dates = [to_date(d) for d in generate_quarterly_dates(datetime(2024, 3, 31), 20)]  # 5 years
 
 business_loan = Loan(
     principal=Money("100000"),
@@ -302,7 +316,7 @@ except ValueError as e:
 - **Consistent behavior**: All functions follow the same patterns
 
 ### Immediate Integration
-- **Loan compatibility**: Generated dates work directly with `Loan` objects
+- **Loan compatibility**: Pass `[to_date(d) for d in dates]` into `Loan` — generators yield `datetime`, loan due dates are `date`
 - **Time Machine support**: All dates work with `Warp` for temporal analysis
 - **Schedule generation**: Seamless integration with payment schedulers
 

--- a/docs/examples/fines.md
+++ b/docs/examples/fines.md
@@ -17,12 +17,14 @@ Records a payment at the current date (`self.now()`). Interest accrual depends o
 
 ```python
 from datetime import datetime
+
 from money_warp import Loan, Money, InterestRate, Warp, generate_monthly_dates
+from money_warp.tz import to_date
 
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    generate_monthly_dates(datetime(2024, 2, 1), 12),
+    [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)],
 )
 
 # Pay on time using the Time Machine
@@ -58,18 +60,25 @@ loan.record_payment(Money("856.07"), datetime(2024, 3, 1), "March payment")
 Configure fines and grace periods when creating a loan:
 
 ```python
+from datetime import datetime
+
+from money_warp import InterestRate, Loan, Money, generate_monthly_dates
+from money_warp.tz import to_date
+
+_due = [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)]
+
 # Default: 2% fine, no grace period
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    generate_monthly_dates(datetime(2024, 2, 1), 12),
+    _due,
 )
 
 # Custom: 5% fine with a 7-day grace period
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    generate_monthly_dates(datetime(2024, 2, 1), 12),
+    _due,
     fine_rate=InterestRate("5% annual"),
     grace_period_days=7,
 )
@@ -85,17 +94,19 @@ loan = Loan(
 ### Checking for Late Payments
 
 ```python
-from datetime import datetime
+from datetime import date, datetime
+
 from money_warp import Loan, Money, InterestRate, generate_monthly_dates
+from money_warp.tz import to_date
 
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    generate_monthly_dates(datetime(2024, 2, 1), 3),
+    [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 3)],
 )
 
 # Is the February payment late as of February 15?
-is_late = loan.is_payment_late(datetime(2024, 2, 1), as_of_date=datetime(2024, 2, 15))
+is_late = loan.is_payment_late(date(2024, 2, 1), as_of_date=datetime(2024, 2, 15))
 print(f"Late? {is_late}")  # True — no payment was made
 ```
 
@@ -125,10 +136,14 @@ When a borrower pays late, they are charged extra interest for the days beyond t
 On-time and early payments produce only a regular interest item (no mora).
 
 ```python
+from datetime import date, datetime
+
+from money_warp import InterestRate, Loan, Money, Warp
+
 loan = Loan(
     Money("10000"),
     InterestRate("6% a"),
-    [datetime(2024, 2, 1), datetime(2024, 3, 1), datetime(2024, 4, 1)],
+    [date(2024, 2, 1), date(2024, 3, 1), date(2024, 4, 1)],
     disbursement_date=datetime(2024, 1, 1),
 )
 
@@ -159,20 +174,22 @@ A large late payment naturally covers the missed installment **and** eats into f
 A grace period delays when fines are applied. If `grace_period_days=7`, a payment due on February 1st is not considered late until February 8th.
 
 ```python
-from decimal import Decimal
+from datetime import date, datetime
+
+from money_warp import InterestRate, Loan, Money
 
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    [datetime(2024, 2, 1)],
+    [date(2024, 2, 1)],
     grace_period_days=7,
 )
 
 # Not late on February 5 (within grace period)
-print(loan.is_payment_late(datetime(2024, 2, 1), datetime(2024, 2, 5)))  # False
+print(loan.is_payment_late(date(2024, 2, 1), datetime(2024, 2, 5)))  # False
 
 # Late on February 9 (grace period expired)
-print(loan.is_payment_late(datetime(2024, 2, 1), datetime(2024, 2, 9)))  # True
+print(loan.is_payment_late(date(2024, 2, 1), datetime(2024, 2, 9)))  # True
 ```
 
 Note: the grace period only affects **fines**. Mora interest always accrues for every day past the due date, regardless of the grace period.
@@ -216,24 +233,26 @@ A loan is not a group of installments. Installments are **consequences** of the 
 Access the repayment plan via `loan.installments`. Each `Installment` shows expected amounts, actual paid amounts, and detailed per-payment allocations.
 
 ```python
-from money_warp import Loan, Money, InterestRate, generate_monthly_dates
 from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, generate_monthly_dates
+from money_warp.tz import to_date, to_datetime
 
 loan = Loan(
     Money("10000"),
     InterestRate("6% a"),
-    generate_monthly_dates(datetime(2025, 2, 1), 3),
+    [to_date(d) for d in generate_monthly_dates(datetime(2025, 2, 1), 3)],
     disbursement_date=datetime(2025, 1, 1),
 )
 
 # Before any payments: all unpaid
 for inst in loan.installments:
-    print(f"#{inst.number} due {inst.due_date.date()}: "
+    print(f"#{inst.number} due {inst.due_date}: "
           f"{inst.expected_payment} — paid: {inst.is_fully_paid}")
 
-# After a payment: first installment is paid
+# After a payment: first installment is paid (payment_date is a datetime)
 schedule = loan.get_original_schedule()
-loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+loan.record_payment(schedule[0].payment_amount, to_datetime(schedule[0].due_date))
 
 inst = loan.installments[0]
 print(f"#{inst.number} is_fully_paid={inst.is_fully_paid}")

--- a/docs/examples/interest_rates.md
+++ b/docs/examples/interest_rates.md
@@ -215,7 +215,7 @@ def compare_mortgage_rates(principal, loan_term_years, rates):
     """Compare different mortgage rates."""
     
     from money_warp import Money, Loan
-    from datetime import datetime, timedelta
+    from datetime import date, timedelta
     
     principal = Money(principal)
     
@@ -223,7 +223,7 @@ def compare_mortgage_rates(principal, loan_term_years, rates):
     print("=" * 60)
     
     # Generate monthly payment schedule
-    start_date = datetime(2024, 1, 1)
+    start_date = date(2024, 1, 1)
     num_payments = loan_term_years * 12
     due_dates = [start_date + timedelta(days=30*i) for i in range(1, num_payments + 1)]
     

--- a/docs/examples/present_value_irr.md
+++ b/docs/examples/present_value_irr.md
@@ -175,13 +175,15 @@ print(f"MIRR (360-day year): {mirr_banker}")
 Calculate loan PV from borrower's perspective:
 
 ```python
-from money_warp import Loan
+from datetime import date, datetime
+
+from money_warp import InterestRate, Loan, Money
 
 # Create a loan
 loan = Loan(
     principal=Money("10000"),
     interest_rate=InterestRate("5% annual"),
-    due_dates=[datetime(2024, 6, 1), datetime(2024, 12, 1)],
+    due_dates=[date(2024, 6, 1), date(2024, 12, 1)],
     disbursement_date=datetime(2024, 1, 1)
 )
 
@@ -199,7 +201,11 @@ print(f"PV at 8%: {pv_market_rate}")  # Negative from borrower's perspective
 Calculate loan's effective rate. The loan automatically passes its own `year_size` to the IRR calculation, so loans created with `YearSize.banker` compute IRR using a 360-day year:
 
 ```python
-# Loan IRR (should equal the loan's interest rate)
+from datetime import date, datetime
+
+from money_warp import InterestRate, Loan, Money, YearSize
+
+# Loan IRR (should equal the loan's interest rate); assumes `loan` from previous example
 loan_irr = loan.irr()
 print(f"Loan IRR: {loan_irr}")  # Should be ~5%
 
@@ -211,7 +217,7 @@ print(f"Loan IRR with guess: {loan_irr_guess}")  # Same result
 banker_loan = Loan(
     principal=Money("10000"),
     interest_rate=InterestRate("5% annual", year_size=YearSize.banker),
-    due_dates=[datetime(2024, 6, 1), datetime(2024, 12, 1)],
+    due_dates=[date(2024, 6, 1), date(2024, 12, 1)],
     disbursement_date=datetime(2024, 1, 1)
 )
 banker_loan_irr = banker_loan.irr()

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -28,7 +28,7 @@ pip install money-warp[sa]            # SQLAlchemy types + bridge
 Let's start with a simple loan analysis - the most common use case:
 
 ```python
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 from money_warp import Money, InterestRate, Loan
 
 # Create a $10,000 personal loan at 8% annual interest
@@ -36,7 +36,7 @@ principal = Money("10000.00")
 rate = InterestRate("8% a")  # 8% annually
 
 # Set up monthly payments for 2 years (24 payments)
-start_date = datetime(2024, 1, 1)
+start_date = date(2024, 1, 1)
 due_dates = [start_date + timedelta(days=30*i) for i in range(1, 25)]
 
 # Create the loan
@@ -101,6 +101,8 @@ Notice how the interest portion decreases and principal portion increases over t
 Now let's track what actually happens when you make payments:
 
 ```python
+from datetime import datetime
+
 # Record some actual payments
 loan.record_payment(Money("452.27"), datetime(2024, 2, 1), "First payment")
 loan.record_payment(Money("500.00"), datetime(2024, 3, 1), "Extra payment")  # Paid extra!

--- a/docs/examples/sqlalchemy.md
+++ b/docs/examples/sqlalchemy.md
@@ -83,7 +83,7 @@ class LoanRecord(Base):
     principal = Column(MoneyType())
     interest_rate = Column(InterestRateType(representation="json"))
     disbursement_date = Column(DateTime)
-    due_dates = Column(JSON)
+    due_dates = Column(JSON)  # JSON array of ISO dates; bridge loads as list[date] for Loan
     fine_rate = Column(InterestRateType(representation="json"), nullable=True)
     grace_period_days = Column(Integer(), nullable=True)
     mora_interest_rate = Column(InterestRateType(representation="json"), nullable=True)
@@ -172,7 +172,7 @@ class Loan(Base):
     principal = Column(MoneyType())
     interest_rate = Column(InterestRateType(representation="json"))
     disbursement_date = Column(DateTime)
-    due_dates = Column(JSON)
+    due_dates = Column(JSON)  # ISO date strings -> list[date] when building Loan
     settlements = relationship("Settlement", order_by="Settlement.payment_date")
 
 engine = create_engine("sqlite:///:memory:")

--- a/docs/examples/tax.md
+++ b/docs/examples/tax.md
@@ -10,7 +10,7 @@ IOF has two components applied to each installment's principal payment:
 - **Additional rate**: a flat percentage applied once per installment
 
 ```python
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from money_warp import IOF, Money, InterestRate, PriceScheduler
 
@@ -22,7 +22,7 @@ iof = IOF(daily_rate="0.0082%", additional_rate="0.38%")
 
 # Generate a schedule and calculate IOF
 disbursement = datetime(2024, 1, 1)
-due_dates = [datetime(2024, 2, 1), datetime(2024, 3, 1), datetime(2024, 4, 1)]
+due_dates = [date(2024, 2, 1), date(2024, 3, 1), date(2024, 4, 1)]
 schedule = PriceScheduler.generate_schedule(
     Money("10000"), InterestRate("2% m"), due_dates, disbursement
 )
@@ -93,10 +93,13 @@ The difference between modes is at most 1 cent per installment. Use `PER_COMPONE
 Attach taxes to a `Loan` for reporting. The loan lazily computes and caches tax amounts from the original schedule:
 
 ```python
+from datetime import datetime
+
 from money_warp import Loan, Money, InterestRate, IndividualIOF, generate_monthly_dates
+from money_warp.tz import to_date
 
 iof = IndividualIOF()
-due_dates = generate_monthly_dates(datetime(2024, 2, 1), 12)
+due_dates = [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)]
 
 loan = Loan(
     Money("10000"),
@@ -122,10 +125,13 @@ When taxes are present, `generate_expected_cash_flow()` includes a `"tax"` item 
 When the tax is financed (incorporated into the principal), the borrower receives at least the "requested amount" after tax deduction. The `grossup()` function uses `scipy.optimize.brentq` (bracketed bisection) to find the principal where `principal - tax(principal) >= requested_amount`, then snaps the result to a clean cent-aligned principal. In most cases the net equals the requested amount exactly; in rare rounding-boundary cases the borrower receives up to 1 cent more (never less).
 
 ```python
-from money_warp import grossup, Money, InterestRate, PriceScheduler, IndividualIOF
+from datetime import datetime
+
+from money_warp import grossup, Money, InterestRate, PriceScheduler, IndividualIOF, generate_monthly_dates
+from money_warp.tz import to_date
 
 iof = IndividualIOF()
-due_dates = generate_monthly_dates(datetime(2024, 2, 1), 12)
+due_dates = [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)]
 
 result = grossup(
     requested_amount=Money("10000"),
@@ -150,10 +156,13 @@ print(f"Net disbursement: {loan.net_disbursement}")  # ~= 10,000
 Most of the time you want the grossed-up `Loan` directly. The `grossup_loan()` function does `grossup(...).to_loan(...)` in a single call:
 
 ```python
-from money_warp import grossup_loan, Money, InterestRate, PriceScheduler, IndividualIOF
+from datetime import datetime
+
+from money_warp import grossup_loan, Money, InterestRate, PriceScheduler, IndividualIOF, generate_monthly_dates
+from money_warp.tz import to_date
 
 iof = IndividualIOF()
-due_dates = generate_monthly_dates(datetime(2024, 2, 1), 12)
+due_dates = [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)]
 
 loan = grossup_loan(
     requested_amount=Money("10000"),

--- a/docs/examples/time_machine.md
+++ b/docs/examples/time_machine.md
@@ -5,14 +5,15 @@
 ## Basic Time Travel
 
 ```python
+from datetime import date, datetime
+
 from money_warp import Warp, Loan, Money, InterestRate
-from datetime import datetime
 
 # Create a loan
 loan = Loan(
     Money("10000"), 
     InterestRate("5% annual"), 
-    [datetime(2024, 1, 15), datetime(2024, 2, 15), datetime(2024, 3, 15)]
+    [date(2024, 1, 15), date(2024, 2, 15), date(2024, 3, 15)]
 )
 
 # Make some payments
@@ -104,9 +105,13 @@ except InvalidDateError as e:
 ## Real-World Scenario: Payment Analysis
 
 ```python
+from datetime import date, datetime
+
+from money_warp import InterestRate, Loan, Money, Warp
+
 # Analyze loan performance at different points in time
 loan = Loan(Money("50000"), InterestRate("4.5% annual"), 
-           [datetime(2024, i, 1) for i in range(1, 13)])  # Monthly payments
+           [date(2024, i, 1) for i in range(1, 13)])  # Monthly payments
 
 # Record some irregular payments
 loan.record_payment(Money("4500"), datetime(2024, 1, 1), "On time")

--- a/docs/examples/timezone.md
+++ b/docs/examples/timezone.md
@@ -70,27 +70,29 @@ set_tz("UTC")  # reset
 You don't need to explicitly call `ensure_aware()` — all public APIs handle it automatically. Naive datetimes work as input for convenience:
 
 ```python
-from datetime import datetime
+from datetime import date, datetime
 from money_warp import Loan, Money, InterestRate, generate_monthly_dates
+from money_warp.tz import to_date
 
-# Naive datetimes are silently coerced to UTC
+# Naive datetimes are silently coerced to UTC for disbursement_date.
+# Due dates are calendar dates; convert generator output with to_date.
 loan = Loan(
     Money("10000"),
     InterestRate("5% a"),
-    generate_monthly_dates(datetime(2024, 2, 1), 12),
+    [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)],
     disbursement_date=datetime(2024, 1, 1),
 )
 
-# All stored datetimes are now timezone-aware
+# Disbursement stays a timezone-aware datetime; due_dates are date objects
 print(loan.disbursement_date)  # 2024-01-01 00:00:00+00:00
-print(loan.due_dates[0])       # 2024-02-01 00:00:00+00:00
+print(loan.due_dates[0])       # 2024-02-01
 ```
 
 The same applies to `CashFlowItem`, `Warp`, `record_payment`, and all other datetime-accepting APIs.
 
 ## The `@tz_aware` Decorator
 
-Under the hood, MoneyWarp uses a `@tz_aware` decorator on public API methods. This decorator inspects function arguments and converts any `datetime` (or `list[datetime]`) to timezone-aware before the function body runs.
+Under the hood, MoneyWarp uses a `@tz_aware` decorator on public API methods. This decorator inspects function arguments and converts any `datetime` (or lists whose first element is a `datetime`) to timezone-aware before the function body runs. Lists of `date` (e.g. loan `due_dates`) are unchanged.
 
 You can use it in your own code if you integrate with MoneyWarp:
 
@@ -116,14 +118,12 @@ When writing tests against MoneyWarp, you can either:
 2. **Use explicit `tzinfo=timezone.utc`** — for clarity and to match the stored values exactly
 
 ```python
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
-# Both approaches work for input
-loan = Loan(Money("1000"), InterestRate("5% a"), [datetime(2024, 2, 1)])
-loan = Loan(Money("1000"), InterestRate("5% a"), [datetime(2024, 2, 1, tzinfo=timezone.utc)])
+# Due dates are calendar dates
+loan = Loan(Money("1000"), InterestRate("5% a"), [date(2024, 2, 1)])
 
-# For assertions, use aware datetimes to match stored values
-assert loan.due_dates[0] == datetime(2024, 2, 1, tzinfo=timezone.utc)
+assert loan.due_dates[0] == date(2024, 2, 1)
 ```
 
 ## Public API
@@ -134,4 +134,6 @@ assert loan.due_dates[0] == datetime(2024, 2, 1, tzinfo=timezone.utc)
 | `set_tz(tz)` | Sets the default timezone (string or `tzinfo`) |
 | `now()` | Returns `datetime.now()` in the configured timezone |
 | `ensure_aware(dt)` | Coerces a naive datetime; passes aware datetimes through |
+| `to_date(dt)` | Calendar `date` from a `datetime`, or pass through `date` |
+| `to_datetime(d)` | Midnight on a `date` as timezone-aware `datetime` |
 | `tz_aware` | Decorator that coerces `datetime` arguments automatically |

--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -93,7 +93,7 @@ This keeps the source of truth minimal and avoids stale derived data.
 
 ### Flexible Scheduling via Due Dates
 
-Rather than encoding "monthly" or "bi-weekly" into the loan, the constructor accepts `due_dates: List[datetime]`. This supports irregular schedules, seasonal payments, and custom arrangements. Convenience functions in `date_utils.py` generate common date patterns.
+Rather than encoding "monthly" or "bi-weekly" into the loan, the constructor accepts `due_dates: List[date]` (calendar due dates). This supports irregular schedules, seasonal payments, and custom arrangements. Convenience functions in `date_utils.py` return `List[datetime]`; use `tz.to_date()` element-wise when passing their output into `Loan` and schedulers.
 
 ### Three-Date Payment Model
 

--- a/knowledge/date_utils.md
+++ b/knowledge/date_utils.md
@@ -38,6 +38,8 @@ All generators raise `ValueError` for non-positive `num_payments`. `generate_cus
 
 All return `List[datetime]` with the first element equal to `start_date`.
 
+`Loan` and schedulers take `due_dates: List[date]`. Map generator output with `money_warp.tz.to_date` per element (or build `date` lists directly).
+
 ## Key Learnings
 
 ### Day-of-month drift in chained relativedelta (fixed 2026-02-23)

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -105,7 +105,7 @@ DueDatesType(impl_type=JSON)
 | Bind (Python -> DB) | `[d.isoformat() for d in value]` |
 | Result (DB -> Python) | `[date.fromisoformat(s) for s in value]` |
 
-`None` passes through in both directions. The bridge's `_parse_due_dates` handles `date`, `datetime`, and `str` elements so that models using `DueDatesType` and models using raw `JSON` columns both work with `@loan_bridge`.
+`None` passes through in both directions. **`_parse_due_dates`** (used when loading a loan from ORM columns) accepts `date`, `datetime`, or ISO `str` per list element, normalizes each to a calendar **`date`**, and returns **`List[date]`** for `Loan(...)`. That way models using `DueDatesType` and models using raw `JSON` columns both work with `@loan_bridge`.
 
 ### settlement_bridge
 

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -8,13 +8,15 @@ The `Loan` class is a state machine that models a personal loan with daily-compo
 |---|---|---|---|
 | `principal` | `Money` | required | Must be positive |
 | `interest_rate` | `InterestRate` | required | Annual rate |
-| `due_dates` | `List[datetime]` | required | Sorted automatically |
+| `due_dates` | `List[date]` | required | Sorted automatically (calendar due dates) |
 | `disbursement_date` | `Optional[datetime]` | now | When funds are released; must be strictly before first due date |
 | `scheduler` | `Optional[Type[BaseScheduler]]` | `PriceScheduler` | Amortization strategy |
 | `fine_rate` | `Optional[InterestRate]` | `InterestRate("2% annual")` | Fine rate applied to expected payment |
 | `grace_period_days` | `int` | `0` | Days after due date before fines apply |
 | `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Rate used for mora (late) interest; defaults to the base rate |
 | `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora interest is computed (see Mora Strategy below) |
+
+`Loan` also keeps `_actual_payment_datetimes: List[datetime]`, one entry per `record_payment` call, so settlements and cash-flow grouping use full timestamps while schedule rows use calendar `due_date: date` values.
 
 ## Three-Date Payment Model
 
@@ -85,11 +87,11 @@ Always returns the static schedule based on original loan terms, ignoring any pa
 
 ### PaymentScheduleEntry
 
-Each entry contains: `payment_number`, `due_date`, `days_in_period`, `beginning_balance`, `payment_amount`, `principal_payment`, `interest_payment`, `ending_balance`. The schedule auto-calculates `total_payments`, `total_interest`, and `total_principal`.
+Each entry contains: `payment_number`, `due_date` (`date`), `days_in_period`, `beginning_balance`, `payment_amount`, `principal_payment`, `interest_payment`, `ending_balance`. The schedule auto-calculates `total_payments`, `total_interest`, and `total_principal`.
 
 ## Schedulers
 
-All schedulers implement `BaseScheduler.generate_schedule(principal, interest_rate, due_dates, disbursement_date) -> PaymentSchedule`.
+All schedulers implement `BaseScheduler.generate_schedule(principal, interest_rate, due_dates: List[date], disbursement_date: datetime) -> PaymentSchedule`.
 
 ### PriceScheduler (French Amortization)
 
@@ -126,7 +128,7 @@ A late payment incurs two costs, both handled automatically by `pay_installment`
 
 ### Fines
 
-- `calculate_late_fines(as_of_date)` scans all due dates up to `as_of_date`, applies one fine per missed due date (never duplicated), and stores them in `fines_applied: Dict[datetime, Money]`.
+- `calculate_late_fines(as_of_date)` scans all due dates up to `as_of_date`, applies one fine per missed due date (never duplicated), and stores them in `fines_applied: Dict[date, Money]`.
 - `is_payment_late(due_date, as_of_date)` respects `grace_period_days`.
 - `is_paid_off` requires zero `current_balance` (principal, interest, mora, and fines all zero).
 - Fine amounts are calculated from the **original** schedule (`get_original_schedule`), not the rebuilt schedule.
@@ -219,7 +221,7 @@ A loan is **not** a group of installments. Installments are a **consequence** of
 
 A frozen dataclass representing one period of the repayment plan. Built from the original schedule on demand. Warp-aware: all fields reflect the state at `self.now()`.
 
-Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations: List[SettlementAllocation]`.
+Fields: `number`, `due_date` (`date`), `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations: List[SettlementAllocation]`.
 
 Computed properties:
 - `balance: Money` — the amount still owed to fully settle this installment: `(expected_principal + expected_interest + expected_mora + expected_fine) - (principal_paid + interest_paid + mora_paid + fine_paid)`. Clamped to zero.

--- a/knowledge/tax.md
+++ b/knowledge/tax.md
@@ -74,7 +74,7 @@ class TaxResult:
 @dataclass
 class TaxInstallmentDetail:
     payment_number: int
-    due_date: datetime
+    due_date: date
     principal_payment: Money
     tax_amount: Money
 ```
@@ -132,7 +132,7 @@ Both inherit all behavior from `IOF` -- no new calculation logic.
 def grossup(
     requested_amount: Money,
     interest_rate: InterestRate,
-    due_dates: List[datetime],
+    due_dates: List[date],
     disbursement_date: datetime,
     scheduler: Type[BaseScheduler],
     taxes: List[BaseTax],
@@ -155,7 +155,7 @@ Creates a Loan with the grossed-up principal, `is_grossed_up=True`, and all sche
 def grossup_loan(
     requested_amount: Money,
     interest_rate: InterestRate,
-    due_dates: List[datetime],
+    due_dates: List[date],
     disbursement_date: datetime,
     scheduler: Type[BaseScheduler],
     taxes: List[BaseTax],

--- a/knowledge/tz.md
+++ b/knowledge/tz.md
@@ -15,7 +15,7 @@ Rather than scattering `ensure_aware()` calls in every method body, the `@tz_awa
 - `datetime` values through `ensure_aware`
 - `list` values whose first element is a `datetime` element-wise
 
-Everything else (including `None` for optional params) passes through untouched. This keeps method bodies free of boilerplate.
+Everything else (including `None` for optional params) passes through untouched. Lists are only coerced when the first element is a `datetime`; `List[date]` arguments (e.g. loan `due_dates`) are left as-is. This keeps method bodies free of boilerplate.
 
 ### No New Dependencies
 
@@ -29,6 +29,8 @@ Uses `zoneinfo.ZoneInfo` from the standard library (Python 3.9+). The project re
 | `set_tz(tz)` | function | Set the default timezone (string or `tzinfo`) |
 | `now()` | function | `datetime.now(get_tz())` — always aware |
 | `ensure_aware(dt)` | function | Attach default tz to naive dt; pass aware dt through |
+| `to_date(dt)` | function | Calendar `date` from a `datetime`, or pass through an existing `date` |
+| `to_datetime(d)` | function | Midnight on `d` as a timezone-aware `datetime` (via `ensure_aware`) |
 | `tz_aware` | decorator | Coerce all datetime args of the decorated callable |
 | `default_time_source` | instance | `_DefaultTimeSource` whose `.now()` delegates to `now()` |
 

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -117,21 +117,21 @@ def _resolve_settlement_info(cls, settlements_attr):
     }
 
 
-def _parse_due_dates(raw: List[Union[str, date, datetime]]) -> List[datetime]:
-    """Convert a list of due dates to timezone-aware datetimes.
+def _parse_due_dates(raw: List[Union[str, date, datetime]]) -> List[date]:
+    """Convert a list of due dates to :class:`~datetime.date` objects.
 
     Accepts ISO strings (raw ``JSON`` column), :class:`~datetime.date`
     objects (from :class:`~money_warp.ext.sa.types.DueDatesType`), or
     :class:`~datetime.datetime` objects.
     """
-    result: List[datetime] = []
+    result: List[date] = []
     for d in raw:
         if isinstance(d, datetime):
-            result.append(ensure_aware(d))
+            result.append(d.date())
         elif isinstance(d, date):
-            result.append(ensure_aware(datetime(d.year, d.month, d.day)))
+            result.append(d)
         else:
-            result.append(ensure_aware(datetime.fromisoformat(d)))
+            result.append(date.fromisoformat(d))
     return result
 
 

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -1,7 +1,7 @@
 """Installment data structure for loan repayment plans."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date
 from typing import List, Tuple
 
 from ..money import Money
@@ -24,7 +24,7 @@ class Installment:
     """
 
     number: int
-    due_date: datetime
+    due_date: date
     days_in_period: int
     expected_payment: Money
     expected_principal: Money

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,6 +1,6 @@
 """Simplified Loan class that delegates calculations to configurable scheduler."""
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Dict, List, Optional, Type
 
@@ -11,7 +11,7 @@ from ..rate import Rate
 from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
 from ..tax.base import BaseTax, TaxResult
 from ..time_context import TimeContext
-from ..tz import tz_aware
+from ..tz import to_datetime, tz_aware
 from .installment import Installment
 from .settlement import AnticipationResult, Settlement, SettlementAllocation
 
@@ -45,21 +45,21 @@ class Loan:
 
     Examples:
         >>> from money_warp import Loan, Money, InterestRate
-        >>> from datetime import datetime
+        >>> from datetime import date, datetime
         >>> from decimal import Decimal
         >>>
         >>> # Basic loan with default fine settings
         >>> loan = Loan(
         ...     Money("10000"),
         ...     InterestRate("5% annual"),
-        ...     [datetime(2024, 2, 1), datetime(2024, 3, 1)]
+        ...     [date(2024, 2, 1), date(2024, 3, 1)]
         ... )
         >>>
         >>> # Loan with custom fine settings
         >>> loan = Loan(
         ...     Money("10000"),
         ...     InterestRate("5% annual"),
-        ...     [datetime(2024, 2, 1)],
+        ...     [date(2024, 2, 1)],
         ...     fine_rate=Decimal("0.05"),  # 5% fine
         ...     grace_period_days=7  # 7-day grace period
         ... )
@@ -78,7 +78,7 @@ class Loan:
         self,
         principal: Money,
         interest_rate: InterestRate,
-        due_dates: List[datetime],
+        due_dates: List[date],
         disbursement_date: Optional[datetime] = None,
         scheduler: Optional[Type[BaseScheduler]] = None,
         fine_rate: Optional[InterestRate] = None,
@@ -109,16 +109,16 @@ class Loan:
         Examples:
             >>> # Basic loan with default 2% fine, no grace period
             >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [datetime(2024, 2, 1)])
+            ...            [date(2024, 2, 1)])
             >>>
             >>> # Loan with custom 5% fine and 3-day grace period
             >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [datetime(2024, 2, 1)],
+            ...            [date(2024, 2, 1)],
             ...            fine_rate=InterestRate("5% annual"), grace_period_days=3)
             >>>
             >>> # Loan with separate mora interest rate
             >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [datetime(2024, 2, 1)],
+            ...            [date(2024, 2, 1)],
             ...            mora_interest_rate=InterestRate("12% annual"))
         """
         # Validate inputs first
@@ -137,7 +137,7 @@ class Loan:
         self.mora_strategy = mora_strategy
         self.due_dates = sorted(due_dates)
         self.disbursement_date = disbursement_date if disbursement_date is not None else self._time_ctx.now()
-        if self.disbursement_date >= self.due_dates[0]:
+        if self.disbursement_date.date() >= self.due_dates[0]:
             raise ValueError("disbursement_date must be before the first due date")
         self.scheduler = scheduler or PriceScheduler
         self.fine_rate = fine_rate if fine_rate is not None else InterestRate("2% annual")
@@ -149,7 +149,8 @@ class Loan:
         self._all_payments: List[CashFlowItem] = []  # All payments ever made
         self._payment_item_offsets: List[int] = []  # Start index in _all_payments for each payment
         self._actual_schedule_entries: List[PaymentScheduleEntry] = []  # Actual payment history as schedule entries
-        self.fines_applied: Dict[datetime, Money] = {}  # Track fines applied per due date
+        self._actual_payment_datetimes: List[datetime] = []  # Full timestamps for each record_payment call
+        self.fines_applied: Dict[date, Money] = {}  # Track fines applied per due date
         self._tax_cache: Optional[Dict[str, TaxResult]] = None
 
     @property
@@ -296,8 +297,7 @@ class Loan:
             as_of_date = self.now()
         return (as_of_date - self.last_payment_date).days
 
-    @tz_aware
-    def get_expected_payment_amount(self, due_date: datetime) -> Money:
+    def get_expected_payment_amount(self, due_date: date) -> Money:
         """
         Get the expected payment amount for a specific due date from the original schedule.
 
@@ -325,7 +325,7 @@ class Loan:
         raise ValueError(f"Could not find payment amount for due date {due_date}")
 
     @tz_aware
-    def is_payment_late(self, due_date: datetime, as_of_date: Optional[datetime] = None) -> bool:
+    def is_payment_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
         """
         Check if a payment is late considering the grace period.
 
@@ -341,7 +341,7 @@ class Loan:
 
         effective_due_date = due_date + timedelta(days=self.grace_period_days)
 
-        return as_of_date > effective_due_date
+        return as_of_date.date() > effective_due_date
 
     @tz_aware
     def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
@@ -383,7 +383,7 @@ class Loan:
 
         return new_fines_applied
 
-    def _has_payment_for_due_date(self, due_date: datetime, as_of_date: datetime) -> bool:
+    def _has_payment_for_due_date(self, due_date: date, as_of_date: datetime) -> bool:
         """
         Check if sufficient payment has been made for a specific due date.
 
@@ -392,29 +392,22 @@ class Loan:
         """
         expected_payment = self.get_expected_payment_amount(due_date)
 
-        # Get all payments made on the due date (exact date match for installment payments)
-        # This handles the common case where installment payments are made on the due date
-        # Use _all_payments and filter by as_of_date instead of _actual_payments
         exact_date_payments = [
             payment
             for payment in self._all_payments
-            if payment.datetime.date() == due_date.date()
+            if payment.datetime.date() == due_date
             and payment.datetime <= as_of_date
             and payment.category in ("principal", "interest", "fine")
         ]
 
         total_paid_on_due_date = sum((payment.amount for payment in exact_date_payments), Money.zero())
 
-        # If exact date payment covers the expected amount, consider it paid
-        # Use a small tolerance for floating point precision issues (1 cent)
         tolerance = Money("0.01")
         if total_paid_on_due_date >= (expected_payment - tolerance):
             return True
 
-        # Fallback: check payments made in a reasonable window around the due date
-        # (for cases where payments might be made slightly before or after)
-        window_start = due_date - timedelta(days=3)  # 3 days before
-        window_end = min(as_of_date, due_date + timedelta(days=1))  # up to 1 day after, but not future
+        window_start = to_datetime(due_date - timedelta(days=3))
+        window_end = min(as_of_date, to_datetime(due_date + timedelta(days=1)))
 
         window_payments = [
             payment
@@ -426,8 +419,6 @@ class Loan:
 
         total_paid_in_window = sum((payment.amount for payment in window_payments), Money.zero())
 
-        # Consider payment made if we've received at least the expected amount in the window
-        # Use a small tolerance for floating point precision issues (1 cent)
         tolerance = Money("0.01")
         return total_paid_in_window >= (expected_payment - tolerance)
 
@@ -451,10 +442,10 @@ class Loan:
 
         Examples:
             >>> from money_warp import Loan, Money, InterestRate
-            >>> from datetime import datetime
+            >>> from datetime import date
             >>>
             >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [datetime(2024, 1, 15), datetime(2024, 2, 15)])
+            ...            [date(2024, 1, 15), date(2024, 2, 15)])
             >>>
             >>> # Get present value using loan's own rate (should be close to zero)
             >>> pv = loan.present_value()
@@ -500,17 +491,17 @@ class Loan:
 
         Examples:
             >>> from money_warp import Loan, Money, InterestRate, Warp
-            >>> from datetime import datetime
+            >>> from datetime import date
             >>>
             >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [datetime(2024, 1, 15), datetime(2024, 2, 15)])
+            ...            [date(2024, 1, 15), date(2024, 2, 15)])
             >>>
             >>> # Get IRR - should be close to loan's interest rate
             >>> loan_irr = loan.irr()
             >>> print(f"Loan IRR: {loan_irr}")
             >>>
             >>> # Get IRR from a specific date using Time Machine
-            >>> with Warp(loan, datetime(2024, 1, 10)) as warped_loan:
+            >>> with Warp(loan, date(2024, 1, 10)) as warped_loan:
             ...     past_irr = warped_loan.irr()
             >>> print(f"IRR from past perspective: {past_irr}")
         """
@@ -592,10 +583,11 @@ class Loan:
         schedule = self.get_original_schedule()
 
         for entry in schedule:
+            due_dt = to_datetime(entry.due_date)
             items.append(
                 CashFlowItem(
                     Money(-entry.interest_payment.raw_amount),
-                    entry.due_date,
+                    due_dt,
                     f"Interest payment {entry.payment_number}",
                     "interest",
                     kind=expected,
@@ -605,7 +597,7 @@ class Loan:
             items.append(
                 CashFlowItem(
                     Money(-entry.principal_payment.raw_amount),
-                    entry.due_date,
+                    due_dt,
                     f"Principal payment {entry.payment_number}",
                     "principal",
                     kind=expected,
@@ -641,7 +633,7 @@ class Loan:
         self,
         days: int,
         principal_balance: Money,
-        due_date: Optional[datetime],
+        due_date: Optional[date],
         last_payment_date: Optional[datetime],
     ) -> tuple:
         """
@@ -654,7 +646,7 @@ class Loan:
         if due_date is None or last_payment_date is None:
             return self.interest_rate.accrue(principal_balance, days), Money.zero()
 
-        regular_days = (due_date - last_payment_date).days
+        regular_days = (due_date - last_payment_date.date()).days
 
         if regular_days <= 0:
             return Money.zero(), self.mora_interest_rate.accrue(principal_balance, days)
@@ -679,7 +671,7 @@ class Loan:
         days: int,
         principal_balance: Money,
         description: Optional[str],
-        due_date: Optional[datetime] = None,
+        due_date: Optional[date] = None,
         last_payment_date: Optional[datetime] = None,
     ) -> tuple:
         """
@@ -820,10 +812,11 @@ class Loan:
             ending_balance = Money.zero()
 
         payment_number = len(self._actual_schedule_entries) + 1
+        self._actual_payment_datetimes.append(payment_date)
         self._actual_schedule_entries.append(
             PaymentScheduleEntry(
                 payment_number=payment_number,
-                due_date=payment_date,
+                due_date=payment_date.date(),
                 days_in_period=days,
                 beginning_balance=principal_balance,
                 payment_amount=amount - fine_paid,
@@ -862,7 +855,7 @@ class Loan:
         """
         payment_date = self.now()
         next_due = self._next_unpaid_due_date()
-        interest_date = max(payment_date, next_due)
+        interest_date = max(payment_date, to_datetime(next_due))
         return self.record_payment(
             amount,
             payment_date=payment_date,
@@ -951,7 +944,7 @@ class Loan:
             kept_items.append(
                 CashFlowItem(
                     Money(-entry.payment_amount.raw_amount),
-                    entry.due_date,
+                    to_datetime(entry.due_date),
                     f"Kept payment {entry.payment_number}",
                     "kept_payment",
                 )
@@ -1049,12 +1042,13 @@ class Loan:
         if entry_index == 0:
             last_pay_date = self.disbursement_date
         else:
-            last_pay_date = self._actual_schedule_entries[entry_index - 1].due_date
+            last_pay_date = self._actual_payment_datetimes[entry_index - 1]
 
+        payment_dt = self._actual_payment_datetimes[entry_index]
         installments = self._build_installments_snapshot(
             allocations_by_number,
             entry.beginning_balance,
-            entry.due_date,
+            payment_dt,
             last_pay_date,
         )
         allocations = self._build_settlement_allocations(
@@ -1068,7 +1062,7 @@ class Loan:
 
         return Settlement(
             payment_amount=payment_amount,
-            payment_date=entry.due_date,
+            payment_date=payment_dt,
             fine_paid=fine_paid,
             interest_paid=interest_paid,
             mora_paid=mora_paid,
@@ -1154,7 +1148,7 @@ class Loan:
         allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
         result: List[Settlement] = []
         for i, entry in enumerate(self._actual_schedule_entries):
-            if entry.due_date > current_time:
+            if self._actual_payment_datetimes[i] > current_time:
                 break
             settlement = self._compute_settlement(i, allocs_by_number)
             for a in settlement.allocations:
@@ -1205,7 +1199,7 @@ class Loan:
 
             if i < covered:
                 expected_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
-            elif i == covered and entry.due_date < as_of_date:
+            elif i == covered and entry.due_date < as_of_date.date():
                 if last_payment_date is not None:
                     total_days = (as_of_date - last_payment_date).days
                     _, expected_mora = self._compute_accrued_interest(
@@ -1215,12 +1209,12 @@ class Loan:
                         last_payment_date,
                     )
                 else:
-                    days_overdue = (as_of_date - entry.due_date).days
+                    days_overdue = (as_of_date.date() - entry.due_date).days
                     _, expected_mora = self._compute_accrued_interest(
                         days_overdue,
                         principal_balance,
                         entry.due_date,
-                        entry.due_date,
+                        to_datetime(entry.due_date),
                     )
             else:
                 expected_mora = Money.zero()
@@ -1279,7 +1273,7 @@ class Loan:
                 break
         return covered
 
-    def _next_unpaid_due_date(self) -> datetime:
+    def _next_unpaid_due_date(self) -> date:
         """
         Find the next due date that hasn't been fully paid yet.
 
@@ -1312,8 +1306,8 @@ class Loan:
             items.append(
                 CashFlowItem(
                     fine_amount,
-                    due_date + timedelta(days=self.grace_period_days + 1),
-                    f"Late payment fine applied for {due_date.date()}",
+                    to_datetime(due_date + timedelta(days=self.grace_period_days + 1)),
+                    f"Late payment fine applied for {due_date}",
                     "fine",
                     time_context=self._time_ctx,
                 )
@@ -1373,7 +1367,7 @@ class Loan:
         if remaining_principal.is_zero() or remaining_principal.is_negative():
             return PaymentSchedule(entries=actual_entries)
 
-        last_payment_date = actual_entries[-1].due_date
+        last_payment_date = self._actual_payment_datetimes[-1]
         projected_schedule = self.scheduler.generate_schedule(
             remaining_principal,
             self.interest_rate,

--- a/money_warp/scheduler/base.py
+++ b/money_warp/scheduler/base.py
@@ -1,7 +1,7 @@
 """Base scheduler interface for loan payment calculations."""
 
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import date, datetime
 from typing import List
 
 from ..interest_rate import InterestRate
@@ -19,7 +19,7 @@ class BaseScheduler(ABC):
     @classmethod
     @abstractmethod
     def generate_schedule(
-        cls, principal: Money, interest_rate: InterestRate, due_dates: List[datetime], disbursement_date: datetime
+        cls, principal: Money, interest_rate: InterestRate, due_dates: List[date], disbursement_date: datetime
     ) -> PaymentSchedule:
         """
         Generate the payment schedule.

--- a/money_warp/scheduler/inverted_price_scheduler.py
+++ b/money_warp/scheduler/inverted_price_scheduler.py
@@ -1,6 +1,6 @@
 """Inverted Price scheduler implementing Constant Amortization System (SAC)."""
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List
 
@@ -27,7 +27,7 @@ class InvertedPriceScheduler(BaseScheduler):
 
     @classmethod
     def generate_schedule(
-        cls, principal: Money, interest_rate: InterestRate, due_dates: List[datetime], disbursement_date: datetime
+        cls, principal: Money, interest_rate: InterestRate, due_dates: List[date], disbursement_date: datetime
     ) -> PaymentSchedule:
         """
         Generate Constant Amortization Schedule with fixed principal payments.
@@ -56,7 +56,7 @@ class InvertedPriceScheduler(BaseScheduler):
 
         for i, due_date in enumerate(due_dates):
             # Calculate days since last payment (or disbursement)
-            prev_date = disbursement_date if i == 0 else due_dates[i - 1]
+            prev_date = disbursement_date.date() if i == 0 else due_dates[i - 1]
             days = (due_date - prev_date).days
 
             # Store beginning balance

--- a/money_warp/scheduler/price_scheduler.py
+++ b/money_warp/scheduler/price_scheduler.py
@@ -1,6 +1,6 @@
 """Price scheduler implementing Progressive Price Schedule (French amortization system)."""
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional
 
@@ -36,7 +36,7 @@ class PriceScheduler(BaseScheduler):
 
     @classmethod
     def generate_schedule(
-        cls, principal: Money, interest_rate: InterestRate, due_dates: List[datetime], disbursement_date: datetime
+        cls, principal: Money, interest_rate: InterestRate, due_dates: List[date], disbursement_date: datetime
     ) -> PaymentSchedule:
         """
         Generate Progressive Price Schedule with fixed payment amounts.
@@ -54,7 +54,7 @@ class PriceScheduler(BaseScheduler):
             raise ValueError("At least one due date is required")
 
         # Calculate return days (days from disbursement to each payment)
-        return_days = [(due_date - disbursement_date).days for due_date in due_dates]
+        return_days = [(due_date - disbursement_date.date()).days for due_date in due_dates]
 
         # Calculate PMT using the reference formula
         daily_rate = interest_rate.to_daily().as_decimal()
@@ -72,7 +72,7 @@ class PriceScheduler(BaseScheduler):
         remaining_balance = principal.real_amount
 
         for i, due_date in enumerate(due_dates):
-            prev_date = disbursement_date if i == 0 else due_dates[i - 1]
+            prev_date = disbursement_date.date() if i == 0 else due_dates[i - 1]
             days = (due_date - prev_date).days
 
             beginning_balance = remaining_balance

--- a/money_warp/scheduler/schedule.py
+++ b/money_warp/scheduler/schedule.py
@@ -1,7 +1,7 @@
 """Payment schedule data structures."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date
 from typing import Iterator, List
 
 from ..money import Money
@@ -16,7 +16,7 @@ class PaymentScheduleEntry:
     """
 
     payment_number: int
-    due_date: datetime
+    due_date: date
     days_in_period: int
     beginning_balance: Money
     payment_amount: Money
@@ -29,7 +29,7 @@ class PaymentScheduleEntry:
         return (
             f"Payment {self.payment_number}: {self.payment_amount} "
             f"(Principal: {self.principal_payment}, Interest: {self.interest_payment}) "
-            f"on {self.due_date.date()}"
+            f"on {self.due_date}"
         )
 
 

--- a/money_warp/tax/base.py
+++ b/money_warp/tax/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from typing import List
 
 from ..money import Money
@@ -14,7 +14,7 @@ class TaxInstallmentDetail:
     """Tax breakdown for a single installment."""
 
     payment_number: int
-    due_date: datetime
+    due_date: date
     principal_payment: Money
     tax_amount: Money
 

--- a/money_warp/tax/grossup.py
+++ b/money_warp/tax/grossup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -36,7 +36,7 @@ class GrossupResult:
         requested_amount: Money,
         total_tax: Money,
         interest_rate: InterestRate,
-        due_dates: list[datetime],
+        due_dates: list[date],
         disbursement_date: datetime,
         scheduler: type[BaseScheduler],
         taxes: list[BaseTax],
@@ -89,7 +89,7 @@ def _snap_to_cents(
     solved_p: float,
     requested_amount: Money,
     interest_rate: InterestRate,
-    due_dates: list[datetime],
+    due_dates: list[date],
     disbursement_date: datetime,
     scheduler: type[BaseScheduler],
     taxes: list[BaseTax],
@@ -131,7 +131,7 @@ def _snap_to_cents(
 def _compute_total_tax(
     principal: Money,
     interest_rate: InterestRate,
-    due_dates: list[datetime],
+    due_dates: list[date],
     disbursement_date: datetime,
     scheduler: type[BaseScheduler],
     taxes: list[BaseTax],
@@ -147,7 +147,7 @@ def _compute_total_tax(
 def grossup(
     requested_amount: Money,
     interest_rate: InterestRate,
-    due_dates: list[datetime],
+    due_dates: list[date],
     disbursement_date: datetime,
     scheduler: type[BaseScheduler],
     taxes: list[BaseTax],
@@ -225,7 +225,7 @@ def grossup(
 def grossup_loan(
     requested_amount: Money,
     interest_rate: InterestRate,
-    due_dates: list[datetime],
+    due_dates: list[date],
     disbursement_date: datetime,
     scheduler: type[BaseScheduler],
     taxes: list[BaseTax],

--- a/money_warp/tax/iof.py
+++ b/money_warp/tax/iof.py
@@ -100,7 +100,7 @@ class IOF(BaseTax):
 
         for entry in schedule:
             days = min(
-                (entry.due_date - disbursement_date).days,
+                (entry.due_date - disbursement_date.date()).days,
                 self._max_daily_days,
             )
             principal_raw = entry.principal_payment.raw_amount

--- a/money_warp/tz.py
+++ b/money_warp/tz.py
@@ -6,7 +6,7 @@ All datetimes produced by the library are timezone-aware.
 
 import functools
 import inspect
-from datetime import datetime, timezone, tzinfo
+from datetime import date, datetime, timezone, tzinfo
 from typing import Callable, TypeVar, Union
 from zoneinfo import ZoneInfo
 
@@ -44,6 +44,18 @@ def ensure_aware(dt: datetime) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=_default_tz)
     return dt
+
+
+def to_date(dt: Union[date, datetime]) -> date:
+    """Extract the calendar date from a datetime, or return a date as-is."""
+    if isinstance(dt, datetime):
+        return dt.date()
+    return dt
+
+
+def to_datetime(d: date) -> datetime:
+    """Convert a calendar date to a timezone-aware datetime at midnight."""
+    return ensure_aware(datetime.combine(d, datetime.min.time()))
 
 
 def tz_aware(func: F) -> F:

--- a/tests/credit_card/test_warp_integration.py
+++ b/tests/credit_card/test_warp_integration.py
@@ -1,6 +1,6 @@
 """Tests for CreditCard + Warp integration."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -81,7 +81,7 @@ def test_warp_credit_card_and_loan_concurrently():
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 

--- a/tests/ext/sa/conftest.py
+++ b/tests/ext/sa/conftest.py
@@ -202,12 +202,10 @@ def _build_late_payment_settlements(obj, create, extracted, **kwargs):
     if not create:
         return
 
-    due_dates_dt = [datetime(d.year, d.month, d.day, tzinfo=timezone.utc) for d in obj.due_dates]
-
     loan = Loan(
         obj.principal,
         obj.interest_rate,
-        due_dates_dt,
+        list(obj.due_dates),
         disbursement_date=obj.disbursement_date,
         fine_rate=obj.fine_rate,
         grace_period_days=obj.grace_period_days,

--- a/tests/ext/sa/test_sa_bridge.py
+++ b/tests/ext/sa/test_sa_bridge.py
@@ -1,7 +1,7 @@
 # ruff: noqa: A003
 """Tests for settlement_bridge, loan_bridge, balance, and balance_at."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -443,7 +443,7 @@ def _make_reference_loan():
     return Loan(
         Money("10000"),
         InterestRate("10% a"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1), date(2024, 3, 1)],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 

--- a/tests/ext/sa/test_sa_integration.py
+++ b/tests/ext/sa/test_sa_integration.py
@@ -27,7 +27,7 @@ from .conftest import (
 _LOAN_PRINCIPAL = Money("10000")
 _LOAN_RATE = InterestRate("6% a")
 _LOAN_DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-_LOAN_DUE_DATETIMES = [datetime(d.year, d.month, d.day, tzinfo=timezone.utc) for d in _LATE_PAYMENT_DUE_DATES]
+_LOAN_DUE_DATES = list(_LATE_PAYMENT_DUE_DATES)
 
 
 @pytest.fixture()
@@ -36,7 +36,7 @@ def loan_with_payments():
     loan = Loan(
         _LOAN_PRINCIPAL,
         _LOAN_RATE,
-        _LOAN_DUE_DATETIMES,
+        _LOAN_DUE_DATES,
         disbursement_date=_LOAN_DISBURSEMENT,
         fine_rate=InterestRate("2% annual"),
         grace_period_days=0,
@@ -87,7 +87,7 @@ def test_late_payment_remaining_balance_higher_than_on_time(loan_with_payments):
     on_time_loan = Loan(
         _LOAN_PRINCIPAL,
         _LOAN_RATE,
-        _LOAN_DUE_DATETIMES,
+        _LOAN_DUE_DATES,
         disbursement_date=_LOAN_DISBURSEMENT,
         fine_rate=InterestRate("2% annual"),
         mora_interest_rate=InterestRate("12% a"),

--- a/tests/loan/conftest.py
+++ b/tests/loan/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for loan tests."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -13,16 +13,22 @@ def loan_with_all_installments_paid():
     principal = Money("1000.00")
     rate = InterestRate("5% a")
     due_dates = [
-        datetime(2025, 11, 1, tzinfo=timezone.utc),
-        datetime(2025, 12, 1, tzinfo=timezone.utc),
-        datetime(2026, 1, 1, tzinfo=timezone.utc),
+        date(2025, 11, 1),
+        date(2025, 12, 1),
+        date(2026, 1, 1),
     ]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 10, 2, tzinfo=timezone.utc))
 
     schedule = loan.get_original_schedule()
     for entry in schedule:
-        loan.record_payment(entry.payment_amount, entry.due_date)
+        payment_dt = datetime(
+            entry.due_date.year,
+            entry.due_date.month,
+            entry.due_date.day,
+            tzinfo=timezone.utc,
+        )
+        loan.record_payment(entry.payment_amount, payment_dt)
 
     return loan, due_dates
 
@@ -33,7 +39,7 @@ def partial_payment_loan():
     principal = Money("1000.00")
     rate = InterestRate("5% a")
     payment_date = datetime(2025, 11, 1, tzinfo=timezone.utc)
-    due_dates = [payment_date]
+    due_dates = [payment_date.date()]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 10, 2, tzinfo=timezone.utc))
     loan.record_payment(Money("500.00"), payment_date)

--- a/tests/loan/settlements/conftest.py
+++ b/tests/loan/settlements/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for settlement tests."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -14,9 +14,9 @@ def three_installment_loan():
         Money("890.22"),
         InterestRate("15% annual"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )

--- a/tests/loan/settlements/late_payments/conftest.py
+++ b/tests/loan/settlements/late_payments/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for late payment settlement tests."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -14,9 +14,9 @@ def loan_with_fine():
         Money("890.22"),
         InterestRate("15% annual"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),

--- a/tests/loan/settlements/up_to_date_payments/conftest.py
+++ b/tests/loan/settlements/up_to_date_payments/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for up-to-date payment settlement tests."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -14,9 +14,9 @@ def no_fine_loan():
         Money("890.22"),
         InterestRate("15% annual"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("0% annual"),

--- a/tests/loan/test_anticipation.py
+++ b/tests/loan/test_anticipation.py
@@ -1,6 +1,6 @@
 """Tests for installment anticipation (calculate_anticipation, anticipate_payment)."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 from hypothesis import given, settings
@@ -17,9 +17,9 @@ def three_installment_loan():
         Money("10000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -31,12 +31,12 @@ def six_installment_loan():
         Money("60000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
-            datetime(2024, 5, 1, tzinfo=timezone.utc),
-            datetime(2024, 6, 1, tzinfo=timezone.utc),
-            datetime(2024, 7, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
+            date(2024, 5, 1),
+            date(2024, 6, 1),
+            date(2024, 7, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -145,9 +145,9 @@ def test_anticipation_with_sac_scheduler():
         Money("10000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
         scheduler=InvertedPriceScheduler,
@@ -175,9 +175,9 @@ def test_anticipation_full_lifecycle_zeroes_balance():
         Money("10000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -195,7 +195,11 @@ def test_anticipation_full_lifecycle_zeroes_balance():
     kept = [e for e in loan.get_original_schedule().entries if e.payment_number != 3]
 
     for entry in kept:
-        loan.record_payment(entry.payment_amount, entry.due_date)
+        d = entry.due_date
+        loan.record_payment(
+            entry.payment_amount,
+            datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+        )
 
     tolerance = Money("0.10")
     assert loan.principal_balance < tolerance
@@ -209,9 +213,9 @@ def test_anticipation_all_remaining_full_payoff():
         Money("10000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -257,12 +261,12 @@ def test_kept_installments_unchanged_regardless_of_anticipation(anticipated, day
         Money("60000"),
         InterestRate("12% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
-            datetime(2024, 5, 1, tzinfo=timezone.utc),
-            datetime(2024, 6, 1, tzinfo=timezone.utc),
-            datetime(2024, 7, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
+            date(2024, 5, 1),
+            date(2024, 6, 1),
+            date(2024, 7, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )

--- a/tests/loan/test_balance.py
+++ b/tests/loan/test_balance.py
@@ -1,6 +1,6 @@
 """Tests for Loan balance properties and balance composition."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from money_warp import InterestRate, Loan, Money, Warp
 
@@ -8,7 +8,7 @@ from money_warp import InterestRate, Loan, Money, Warp
 def test_loan_initial_current_balance():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date=disbursement_date)
@@ -21,7 +21,7 @@ def test_loan_initial_current_balance():
 def test_loan_last_payment_date_initial():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
@@ -31,7 +31,7 @@ def test_loan_last_payment_date_initial():
 def test_loan_days_since_last_payment_initial():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
@@ -42,7 +42,7 @@ def test_loan_days_since_last_payment_initial():
 def test_loan_days_since_last_payment_defaults_to_now():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     # Should not raise error and return some number
@@ -54,7 +54,7 @@ def test_loan_principal_balance_initial():
     """Test principal_balance property returns original principal initially."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -65,7 +65,7 @@ def test_loan_principal_balance_after_payment():
     """Test principal_balance decreases after principal payments."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     initial_principal = loan.principal_balance
@@ -82,7 +82,7 @@ def test_loan_principal_balance_zero_after_full_payment():
     """Test principal_balance becomes zero after full principal is paid."""
     principal = Money("1000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -96,7 +96,7 @@ def test_loan_interest_balance_initial_zero():
     """Test interest_balance is zero at disbursement time."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date=disbursement_date)
@@ -109,7 +109,7 @@ def test_loan_interest_balance_grows_over_time():
     """Test interest_balance increases over time."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -127,7 +127,7 @@ def test_loan_interest_balance_resets_after_payment():
     """Test interest_balance resets after interest payment."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -148,7 +148,7 @@ def test_loan_current_balance_composition():
     """Test current_balance equals sum of four component balances."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -175,7 +175,7 @@ def test_loan_balance_components_with_payments():
     """Test balance components work correctly with multiple payments."""
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1), date(2024, 3, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -197,7 +197,7 @@ def test_loan_balance_components_with_fines_and_payments():
     """Test balance components with fines and payments interaction."""
     principal = Money("5000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,

--- a/tests/loan/test_cash_flow.py
+++ b/tests/loan/test_cash_flow.py
@@ -1,6 +1,6 @@
 """Tests for Loan expected and actual cash flow generation."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from money_warp import InterestRate, Loan, Money
@@ -9,7 +9,7 @@ from money_warp import InterestRate, Loan, Money
 def test_loan_generate_expected_cash_flow_includes_disbursement():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     cash_flow = loan.generate_expected_cash_flow()
@@ -22,7 +22,7 @@ def test_loan_generate_expected_cash_flow_includes_disbursement():
 def test_loan_generate_expected_cash_flow_has_payment_breakdown():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     cash_flow = loan.generate_expected_cash_flow()
@@ -38,9 +38,9 @@ def test_loan_generate_expected_cash_flow_multiple_payments():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
     due_dates = [
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
-        datetime(2024, 4, 1, tzinfo=timezone.utc),
+        date(2024, 2, 1),
+        date(2024, 3, 1),
+        date(2024, 4, 1),
     ]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
@@ -58,7 +58,7 @@ def test_loan_generate_expected_cash_flow_multiple_payments():
 def test_loan_generate_expected_cash_flow_net_zero():
     principal = Money("10000.00")
     rate = InterestRate("0% a")  # Zero interest for simplicity
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1), date(2024, 3, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     cash_flow = loan.generate_expected_cash_flow()
@@ -71,7 +71,7 @@ def test_loan_generate_expected_cash_flow_net_zero():
 def test_loan_get_actual_cash_flow_empty_initially():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     actual_cf = loan.get_actual_cash_flow()
@@ -87,7 +87,7 @@ def test_loan_get_actual_cash_flow_empty_initially():
 def test_loan_get_actual_cash_flow_includes_payments():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     loan.record_payment(Money("5000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc), description="First payment")
@@ -105,7 +105,7 @@ def test_loan_get_actual_cash_flow_includes_payments():
 def test_loan_get_actual_cash_flow_includes_fines():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,

--- a/tests/loan/test_creation.py
+++ b/tests/loan/test_creation.py
@@ -1,6 +1,6 @@
 """Tests for Loan creation, validation, defaults, and string representation."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -11,9 +11,9 @@ def test_loan_creation_basic():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
     due_dates = [
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
-        datetime(2024, 4, 1, tzinfo=timezone.utc),
+        date(2024, 2, 1),
+        date(2024, 3, 1),
+        date(2024, 4, 1),
     ]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
@@ -26,7 +26,7 @@ def test_loan_creation_basic():
 def test_loan_creation_with_disbursement_date():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
@@ -36,7 +36,7 @@ def test_loan_creation_with_disbursement_date():
 def test_loan_creation_with_custom_scheduler():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -52,7 +52,7 @@ def test_loan_creation_default_disbursement_date():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
     # Use a future first due date so default "now" is before it (validation requires disbursement < first due)
-    due_dates = [datetime(2030, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2030, 2, 1)]
 
     t_before = datetime.now(tz=timezone.utc)
     loan = Loan(principal, rate, due_dates)
@@ -65,16 +65,16 @@ def test_loan_creation_sorts_due_dates():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
     due_dates = [
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
-        datetime(2024, 1, 1, tzinfo=timezone.utc),
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
+        date(2024, 3, 1),
+        date(2024, 1, 1),
+        date(2024, 2, 1),
     ]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2023, 12, 1, tzinfo=timezone.utc))
     expected_sorted = [
-        datetime(2024, 1, 1, tzinfo=timezone.utc),
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
+        date(2024, 1, 1),
+        date(2024, 2, 1),
+        date(2024, 3, 1),
     ]
     assert loan.due_dates == expected_sorted
 
@@ -89,7 +89,7 @@ def test_loan_creation_empty_due_dates_raises_error():
 
 def test_loan_creation_zero_principal_raises_error():
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     with pytest.raises(ValueError, match="Principal must be positive"):
         Loan(Money.zero(), rate, due_dates)
@@ -97,7 +97,7 @@ def test_loan_creation_zero_principal_raises_error():
 
 def test_loan_creation_negative_principal_raises_error():
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     with pytest.raises(ValueError, match="Principal must be positive"):
         Loan(Money("-1000.00"), rate, due_dates)
@@ -106,7 +106,7 @@ def test_loan_creation_negative_principal_raises_error():
 def test_loan_creation_disbursement_on_or_after_first_due_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     with pytest.raises(ValueError, match="disbursement_date must be before the first due date"):
         Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 2, 1, tzinfo=timezone.utc))
@@ -118,7 +118,7 @@ def test_loan_creation_disbursement_on_or_after_first_due_raises_error():
 def test_loan_initial_not_paid_off():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     assert not loan.is_paid_off
@@ -127,7 +127,7 @@ def test_loan_initial_not_paid_off():
 def test_loan_string_representation():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     loan_str = str(loan)
@@ -140,7 +140,7 @@ def test_loan_string_representation():
 def test_loan_repr_representation():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)

--- a/tests/loan/test_external_schedule_verification.py
+++ b/tests/loan/test_external_schedule_verification.py
@@ -28,7 +28,7 @@ addition and rounds once per installment; it stays within 1 cent of every
 external value.
 """
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -157,18 +157,18 @@ def test_price_schedule_total_principal_equals_loan_amount(external_loan_schedul
 DISBURSEMENT_DATE = datetime(2026, 2, 22, tzinfo=timezone.utc)
 
 DUE_DATES = [
-    datetime(2026, 3, 22, tzinfo=timezone.utc),
-    datetime(2026, 4, 22, tzinfo=timezone.utc),
-    datetime(2026, 5, 22, tzinfo=timezone.utc),
-    datetime(2026, 6, 22, tzinfo=timezone.utc),
-    datetime(2026, 7, 22, tzinfo=timezone.utc),
-    datetime(2026, 8, 22, tzinfo=timezone.utc),
-    datetime(2026, 9, 22, tzinfo=timezone.utc),
-    datetime(2026, 10, 22, tzinfo=timezone.utc),
-    datetime(2026, 11, 22, tzinfo=timezone.utc),
-    datetime(2026, 12, 22, tzinfo=timezone.utc),
-    datetime(2027, 1, 22, tzinfo=timezone.utc),
-    datetime(2027, 2, 22, tzinfo=timezone.utc),
+    date(2026, 3, 22),
+    date(2026, 4, 22),
+    date(2026, 5, 22),
+    date(2026, 6, 22),
+    date(2026, 7, 22),
+    date(2026, 8, 22),
+    date(2026, 9, 22),
+    date(2026, 10, 22),
+    date(2026, 11, 22),
+    date(2026, 12, 22),
+    date(2027, 1, 22),
+    date(2027, 2, 22),
 ]
 
 IOF_DAILY_RATE = Decimal("0.000082")

--- a/tests/loan/test_fines.py
+++ b/tests/loan/test_fines.py
@@ -1,6 +1,6 @@
 """Tests for fines and late overpayment allocation."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -11,7 +11,7 @@ from money_warp import InterestRate, Loan, Money, Warp
 def test_loan_creation_with_fine_parameters():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -28,7 +28,7 @@ def test_loan_creation_with_fine_parameters():
 def test_loan_creation_with_default_fine_parameters():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     assert loan.fine_rate == InterestRate("2% annual")  # Default 2%
@@ -38,7 +38,7 @@ def test_loan_creation_with_default_fine_parameters():
 def test_loan_creation_negative_fine_rate_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     with pytest.raises(ValueError, match="Interest rate cannot be negative"):
         Loan(
@@ -53,7 +53,7 @@ def test_loan_creation_negative_fine_rate_raises_error():
 def test_loan_creation_negative_grace_period_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     with pytest.raises(ValueError, match="Grace period days must be non-negative"):
         Loan(
@@ -68,7 +68,7 @@ def test_loan_creation_negative_grace_period_raises_error():
 def test_loan_initial_fine_properties():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     assert loan.total_fines == Money.zero()
@@ -79,63 +79,63 @@ def test_loan_initial_fine_properties():
 def test_loan_get_expected_payment_amount_valid_date():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1), date(2024, 3, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
-    expected_payment = loan.get_expected_payment_amount(datetime(2024, 2, 1, tzinfo=timezone.utc))
+    expected_payment = loan.get_expected_payment_amount(date(2024, 2, 1))
     assert expected_payment > Money.zero()
 
 
 def test_loan_get_expected_payment_amount_invalid_date_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     with pytest.raises(ValueError, match="Due date .* is not in loan's due dates"):
-        loan.get_expected_payment_amount(datetime(2024, 3, 1, tzinfo=timezone.utc))
+        loan.get_expected_payment_amount(date(2024, 3, 1))
 
 
 def test_loan_is_payment_late_within_grace_period():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc), grace_period_days=5
     )
     check_date = datetime(2024, 2, 3, tzinfo=timezone.utc)  # 2 days after due date, within grace period
-    assert not loan.is_payment_late(datetime(2024, 2, 1, tzinfo=timezone.utc), check_date)
+    assert not loan.is_payment_late(date(2024, 2, 1), check_date)
 
 
 def test_loan_is_payment_late_after_grace_period():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc), grace_period_days=5
     )
     check_date = datetime(2024, 2, 7, tzinfo=timezone.utc)  # 6 days after due date, past grace period
-    assert loan.is_payment_late(datetime(2024, 2, 1, tzinfo=timezone.utc), check_date)
+    assert loan.is_payment_late(date(2024, 2, 1), check_date)
 
 
 def test_loan_is_payment_late_no_grace_period():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc), grace_period_days=0
     )
     check_date = datetime(2024, 2, 2, tzinfo=timezone.utc)  # 1 day after due date
-    assert loan.is_payment_late(datetime(2024, 2, 1, tzinfo=timezone.utc), check_date)
+    assert loan.is_payment_late(date(2024, 2, 1), check_date)
 
 
 def test_loan_calculate_late_fines_applies_fine():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -155,7 +155,7 @@ def test_loan_calculate_late_fines_applies_fine():
 def test_loan_calculate_late_fines_correct_amount():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -164,7 +164,7 @@ def test_loan_calculate_late_fines_correct_amount():
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("5% annual"),
     )  # 5% fine
-    expected_payment = loan.get_expected_payment_amount(datetime(2024, 2, 1, tzinfo=timezone.utc))
+    expected_payment = loan.get_expected_payment_amount(date(2024, 2, 1))
     expected_fine = Money(expected_payment.raw_amount * Decimal("0.05"))
 
     loan.calculate_late_fines(datetime(2024, 2, 5, tzinfo=timezone.utc))
@@ -174,7 +174,7 @@ def test_loan_calculate_late_fines_correct_amount():
 def test_loan_calculate_late_fines_only_once_per_due_date():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -195,7 +195,7 @@ def test_loan_calculate_late_fines_only_once_per_due_date():
 def test_loan_calculate_late_fines_multiple_due_dates():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1), date(2024, 3, 1)]
 
     loan = Loan(
         principal,
@@ -216,7 +216,7 @@ def test_loan_calculate_late_fines_multiple_due_dates():
 def test_loan_record_payment_allocates_to_fines_first():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -243,7 +243,7 @@ def test_loan_record_payment_allocates_to_fines_first():
 def test_loan_record_payment_allocates_fines_then_principal():
     principal = Money("1000.00")  # Smaller loan for easier testing
     rate = InterestRate("0% a")  # No interest for simplicity
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -274,7 +274,7 @@ def test_loan_record_payment_allocates_fines_then_principal():
 def test_loan_current_balance_includes_fine_balance():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -295,7 +295,7 @@ def test_loan_current_balance_includes_fine_balance():
 def test_loan_is_paid_off_considers_fines():
     principal = Money("1000.00")
     rate = InterestRate("0% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal,
@@ -328,12 +328,12 @@ def test_loan_is_paid_off_considers_fines():
 def test_loan_fine_calculation_with_different_rates(fine_rate, expected_multiplier):
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(
         principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc), fine_rate=fine_rate
     )
-    expected_payment = loan.get_expected_payment_amount(datetime(2024, 2, 1, tzinfo=timezone.utc))
+    expected_payment = loan.get_expected_payment_amount(date(2024, 2, 1))
     expected_fine = Money(expected_payment.raw_amount * expected_multiplier)
 
     loan.calculate_late_fines(datetime(2024, 2, 5, tzinfo=timezone.utc))
@@ -353,7 +353,7 @@ def test_loan_fine_calculation_with_different_rates(fine_rate, expected_multipli
 def test_loan_grace_period_scenarios(grace_days, check_day, should_be_late):
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2024, 2, 1)
     due_dates = [due_date]
 
     loan = Loan(
@@ -363,7 +363,7 @@ def test_loan_grace_period_scenarios(grace_days, check_day, should_be_late):
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
         grace_period_days=grace_days,
     )
-    check_date = due_date + timedelta(days=check_day)
+    check_date = datetime(2024, 2, 1, tzinfo=timezone.utc) + timedelta(days=check_day)
 
     assert loan.is_payment_late(due_date, check_date) == should_be_late
 
@@ -372,7 +372,7 @@ def test_pay_installment_late_triggers_fines_and_extra_interest():
     """Late payment should apply both fines and charge interest beyond the due date."""
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(
@@ -416,15 +416,15 @@ def test_late_overpayment_fine_equals_two_percent_of_scheduled_payment():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),
     )
 
-    scheduled_payment = loan.get_expected_payment_amount(datetime(2025, 2, 1, tzinfo=timezone.utc))
+    scheduled_payment = loan.get_expected_payment_amount(date(2025, 2, 1))
     expected_fine = Money(scheduled_payment.raw_amount * Decimal("0.02"))
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -440,9 +440,9 @@ def test_late_overpayment_total_interest_for_45_days():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),
@@ -465,15 +465,15 @@ def test_late_overpayment_principal_is_remainder_after_fine_and_interest():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),
     )
 
-    scheduled_payment = loan.get_expected_payment_amount(datetime(2025, 2, 1, tzinfo=timezone.utc))
+    scheduled_payment = loan.get_expected_payment_amount(date(2025, 2, 1))
     fine = scheduled_payment.raw_amount * Decimal("0.02")
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
@@ -492,15 +492,15 @@ def test_late_overpayment_ending_balance_in_actual_entry():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),
     )
 
-    scheduled_payment = loan.get_expected_payment_amount(datetime(2025, 2, 1, tzinfo=timezone.utc))
+    scheduled_payment = loan.get_expected_payment_amount(date(2025, 2, 1))
     fine = scheduled_payment.raw_amount * Decimal("0.02")
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
@@ -520,9 +520,9 @@ def test_late_overpayment_covers_two_installments():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),
@@ -532,7 +532,7 @@ def test_late_overpayment_covers_two_installments():
         warped.pay_installment(Money("7000.00"))
         next_unpaid = warped._next_unpaid_due_date()
 
-    assert next_unpaid == datetime(2025, 4, 1, tzinfo=timezone.utc)
+    assert next_unpaid == date(2025, 4, 1)
 
 
 def test_late_overpayment_projected_entry_closes_loan():
@@ -541,9 +541,9 @@ def test_late_overpayment_projected_entry_closes_loan():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("2% annual"),

--- a/tests/loan/test_installment.py
+++ b/tests/loan/test_installment.py
@@ -1,11 +1,16 @@
 """Tests for Installment — the public-facing repayment plan view."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
 
 from money_warp import Installment, InterestRate, Loan, Money, Warp
+
+
+def _payment_datetime(d: date) -> datetime:
+    """Calendar due date as UTC midnight — record_payment requires datetime."""
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
 
 
 @pytest.fixture
@@ -14,9 +19,9 @@ def simple_loan():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     return Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc))
 
@@ -64,7 +69,7 @@ def test_installments_allocations_empty_before_any_payment(simple_loan):
 
 def test_first_installment_is_fully_paid_after_covering_payment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     assert simple_loan.installments[0].is_fully_paid is True
     assert simple_loan.installments[1].is_fully_paid is False
@@ -72,7 +77,7 @@ def test_first_installment_is_fully_paid_after_covering_payment(simple_loan):
 
 def test_first_installment_has_allocations_after_payment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     allocs = simple_loan.installments[0].allocations
     assert len(allocs) == 1
@@ -81,7 +86,7 @@ def test_first_installment_has_allocations_after_payment(simple_loan):
 
 def test_installment_principal_paid_reflects_actual_payment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     inst = simple_loan.installments[0]
     assert inst.principal_paid.is_positive()
@@ -91,7 +96,7 @@ def test_installment_principal_paid_reflects_actual_payment(simple_loan):
 def test_all_installments_paid_after_full_repayment(simple_loan):
     schedule = simple_loan.get_original_schedule()
     for entry in schedule:
-        simple_loan.record_payment(entry.payment_amount, entry.due_date)
+        simple_loan.record_payment(entry.payment_amount, _payment_datetime(entry.due_date))
 
     assert all(inst.is_fully_paid for inst in simple_loan.installments)
 
@@ -120,7 +125,7 @@ def test_from_schedule_entry_creates_correct_installment():
 
     entry = PaymentScheduleEntry(
         payment_number=1,
-        due_date=datetime(2025, 2, 1, tzinfo=timezone.utc),
+        due_date=date(2025, 2, 1),
         days_in_period=31,
         beginning_balance=Money("10000"),
         payment_amount=Money("3400"),
@@ -136,7 +141,7 @@ def test_from_schedule_entry_creates_correct_installment():
     )
 
     assert inst.number == 1
-    assert inst.due_date == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert inst.due_date == date(2025, 2, 1)
     assert inst.days_in_period == 31
     assert inst.expected_payment == Money("3400")
     assert inst.expected_principal == Money("3200")
@@ -157,7 +162,7 @@ def test_balance_equals_expected_payment_before_any_payment(simple_loan):
 
 def test_balance_is_zero_after_full_payment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     with Warp(simple_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         assert warped.installments[0].balance.is_zero()
@@ -177,7 +182,7 @@ def test_balance_decreases_after_partial_payment(simple_loan):
 
 def test_is_fully_paid_true_when_balance_is_zero(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     with Warp(simple_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         assert warped.installments[0].balance.is_zero()
@@ -202,7 +207,7 @@ def test_expected_mora_positive_when_overdue():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -213,7 +218,7 @@ def test_expected_mora_equals_mora_paid_after_late_settlement():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -228,8 +233,8 @@ def test_expected_mora_only_on_first_uncovered_installment():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -250,7 +255,7 @@ def test_expected_fine_reflects_applied_fine():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -263,7 +268,7 @@ def test_balance_includes_fine():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
@@ -276,7 +281,7 @@ def test_balance_includes_mora():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:

--- a/tests/loan/test_loan_with_tax.py
+++ b/tests/loan/test_loan_with_tax.py
@@ -1,6 +1,6 @@
 """Tests for Loan integration with taxes."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -21,9 +21,9 @@ def disbursement_date():
 @pytest.fixture
 def due_dates():
     return [
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
-        datetime(2024, 4, 1, tzinfo=timezone.utc),
+        date(2024, 2, 1),
+        date(2024, 3, 1),
+        date(2024, 4, 1),
     ]
 
 
@@ -189,7 +189,7 @@ def test_grossup_loan_is_grossed_up_flag():
     loan = grossup_loan(
         requested_amount=Money("1000"),
         interest_rate=InterestRate(0.0399, CompoundingFrequency.MONTHLY),
-        due_dates=[datetime(2024, 9, 20, tzinfo=timezone.utc), datetime(2024, 10, 20, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 9, 20), date(2024, 10, 20)],
         disbursement_date=datetime(2024, 8, 28, tzinfo=timezone.utc),
         scheduler=PriceScheduler,
         taxes=[IOF(daily_rate="0.0082%", additional_rate="0.38%")],
@@ -201,7 +201,7 @@ def test_grossup_loan_cash_flow_has_no_tax_item():
     loan = grossup_loan(
         requested_amount=Money("1000"),
         interest_rate=InterestRate(0.0399, CompoundingFrequency.MONTHLY),
-        due_dates=[datetime(2024, 9, 20, tzinfo=timezone.utc), datetime(2024, 10, 20, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 9, 20), date(2024, 10, 20)],
         disbursement_date=datetime(2024, 8, 28, tzinfo=timezone.utc),
         scheduler=PriceScheduler,
         taxes=[IOF(daily_rate="0.0082%", additional_rate="0.38%")],
@@ -215,7 +215,7 @@ def test_grossup_loan_cash_flow_disbursement_equals_net_disbursement():
     loan = grossup_loan(
         requested_amount=Money("1000"),
         interest_rate=InterestRate(0.0399, CompoundingFrequency.MONTHLY),
-        due_dates=[datetime(2024, 9, 20, tzinfo=timezone.utc), datetime(2024, 10, 20, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 9, 20), date(2024, 10, 20)],
         disbursement_date=datetime(2024, 8, 28, tzinfo=timezone.utc),
         scheduler=PriceScheduler,
         taxes=[IOF(daily_rate="0.0082%", additional_rate="0.38%")],
@@ -229,7 +229,7 @@ def test_grossup_loan_irr_not_inflated_by_double_counted_tax():
     loan = grossup_loan(
         requested_amount=Money("1000"),
         interest_rate=InterestRate(0.0399, CompoundingFrequency.MONTHLY),
-        due_dates=[datetime(2024, 9, 20, tzinfo=timezone.utc), datetime(2024, 10, 20, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 9, 20), date(2024, 10, 20)],
         disbursement_date=datetime(2024, 8, 28, tzinfo=timezone.utc),
         scheduler=PriceScheduler,
         taxes=[IOF(daily_rate="0.0082%", additional_rate="0.38%")],

--- a/tests/loan/test_mora_interest.py
+++ b/tests/loan/test_mora_interest.py
@@ -1,6 +1,6 @@
 """Tests for mora interest: extra daily-compounded interest accrued beyond the due date."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -13,7 +13,7 @@ def test_late_payment_produces_separate_mora_interest_item():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -31,7 +31,7 @@ def test_mora_interest_equals_difference_between_total_and_regular():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -54,7 +54,7 @@ def test_regular_interest_matches_scheduled_interest():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -75,12 +75,12 @@ def test_total_interest_on_late_payment_matches_manual_calculation(late_days):
     """Sum of regular + mora matches daily-compounded accrual from disbursement to payment date."""
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, [due_date], disbursement_date=disbursement)
     payment_date = due_date + timedelta(days=late_days)
-    total_days = (payment_date - disbursement).days
+    total_days = (payment_date - disbursement.date()).days
 
     daily_rate = rate.to_daily().as_decimal()
     expected_total = Decimal("10000") * ((1 + daily_rate) ** total_days - 1)
@@ -98,7 +98,7 @@ def test_on_time_payment_produces_no_mora_interest_item():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -116,7 +116,7 @@ def test_early_payment_produces_no_mora_interest_item():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -131,11 +131,11 @@ def test_on_time_interest_unchanged():
     """On-time payment still charges interest exactly up to the due date (regression guard)."""
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, [due_date], disbursement_date=disbursement)
-    days_to_due = (due_date - disbursement).days
+    days_to_due = (due_date - disbursement.date()).days
 
     daily_rate = rate.to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** days_to_due - 1)
@@ -156,7 +156,7 @@ def test_mora_rate_defaults_to_base_rate():
     loan = Loan(
         Money("10000.00"),
         rate,
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -168,7 +168,7 @@ def test_mora_strategy_defaults_to_compound():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -180,7 +180,7 @@ def test_on_time_payment_unaffected_by_custom_mora_rate():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("24% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
 
     loan = Loan(
         Money("10000.00"),
@@ -191,7 +191,7 @@ def test_on_time_payment_unaffected_by_custom_mora_rate():
     )
 
     daily_base = base_rate.to_daily().as_decimal()
-    days = (due_date - disbursement).days
+    days = (due_date - disbursement.date()).days
     expected_interest = Decimal("10000") * ((1 + daily_base) ** days - 1)
 
     with Warp(loan, due_date) as warped:
@@ -209,7 +209,7 @@ def test_mora_with_custom_rate_compound_strategy():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("12% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
     loan = Loan(
@@ -221,8 +221,8 @@ def test_mora_with_custom_rate_compound_strategy():
         mora_strategy=MoraStrategy.COMPOUND,
     )
 
-    regular_days = (due_date - disbursement).days  # 31
-    mora_days = (payment_date - due_date).days  # 14
+    regular_days = (due_date - disbursement.date()).days  # 31
+    mora_days = (payment_date.date() - due_date).days  # 14
 
     daily_base = base_rate.to_daily().as_decimal()
     daily_mora = mora_rate.to_daily().as_decimal()
@@ -244,7 +244,7 @@ def test_mora_with_custom_rate_simple_strategy():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("12% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
     loan = Loan(
@@ -256,7 +256,7 @@ def test_mora_with_custom_rate_simple_strategy():
         mora_strategy=MoraStrategy.SIMPLE,
     )
 
-    mora_days = (payment_date - due_date).days  # 14
+    mora_days = (payment_date.date() - due_date).days  # 14
     daily_mora = mora_rate.to_daily().as_decimal()
     expected_mora = principal * ((1 + daily_mora) ** mora_days - 1)
 
@@ -272,7 +272,7 @@ def test_simple_vs_compound_mora_compound_produces_more():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("12% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
     loan_compound = Loan(
@@ -309,10 +309,10 @@ def test_regular_interest_unchanged_regardless_of_mora_rate():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("24% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
-    regular_days = (due_date - disbursement).days
+    regular_days = (due_date - disbursement.date()).days
     daily_base = base_rate.to_daily().as_decimal()
     expected_regular = Decimal("10000") * ((1 + daily_base) ** regular_days - 1)
 
@@ -348,11 +348,11 @@ def test_total_interest_with_custom_mora_rate_matches_manual(mora_rate_str, stra
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate(mora_rate_str)
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
-    regular_days = (due_date - disbursement).days
-    mora_days = (payment_date - due_date).days
+    regular_days = (due_date - disbursement.date()).days
+    mora_days = (payment_date.date() - due_date).days
 
     daily_base = base_rate.to_daily().as_decimal()
     daily_mora = mora_rate.to_daily().as_decimal()
@@ -392,11 +392,11 @@ def test_interest_and_mora_balance_uses_mora_rate_when_past_due():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("24% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     check_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
-    regular_days = (due_date - disbursement).days
-    mora_days = (check_date - due_date).days
+    regular_days = (due_date - disbursement.date()).days
+    mora_days = (check_date.date() - due_date).days
 
     daily_base = base_rate.to_daily().as_decimal()
     daily_mora = mora_rate.to_daily().as_decimal()
@@ -423,10 +423,10 @@ def test_interest_balance_uses_base_rate_when_not_late():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("24% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     check_date = datetime(2025, 1, 20, tzinfo=timezone.utc)
 
-    days = (check_date - disbursement).days
+    days = (check_date.date() - disbursement.date()).days
     daily_base = base_rate.to_daily().as_decimal()
     expected = principal * ((1 + daily_base) ** days - 1)
 
@@ -449,11 +449,11 @@ def test_current_balance_reflects_mora_rate_when_past_due():
     base_rate = InterestRate("6% a")
     mora_rate = InterestRate("24% a")
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_date = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    due_date = date(2025, 2, 1)
     check_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
 
-    regular_days = (due_date - disbursement).days
-    mora_days = (check_date - due_date).days
+    regular_days = (due_date - disbursement.date()).days
+    mora_days = (check_date.date() - due_date).days
 
     daily_base = base_rate.to_daily().as_decimal()
     daily_mora = mora_rate.to_daily().as_decimal()

--- a/tests/loan/test_pay_installment.py
+++ b/tests/loan/test_pay_installment.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -26,7 +26,7 @@ from money_warp import InterestRate, Loan, Money
 def test_loan_pay_instalment_all_money_is_alocated(principal, payment):
     rate = InterestRate("5% a")
     disbursement_date = datetime.now(timezone.utc)
-    due_dates = [disbursement_date + timedelta(days=20)]
+    due_dates = [(disbursement_date + timedelta(days=20)).date()]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=disbursement_date)
     loan.pay_installment(payment)

--- a/tests/loan/test_payment_methods.py
+++ b/tests/loan/test_payment_methods.py
@@ -1,6 +1,6 @@
 """Tests for sugar payment methods (pay_installment, anticipate_payment) and schedule rebuild."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -16,7 +16,7 @@ def test_pay_installment_uses_now_as_payment_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -29,7 +29,7 @@ def test_pay_installment_charges_interest_to_due_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -46,7 +46,7 @@ def test_pay_installment_charges_interest_to_due_date():
 
 def test_pay_installment_no_discount_vs_anticipate_discount():
     """pay_installment charges full-period interest; anticipate_payment only charges for elapsed days."""
-    due_dates = [datetime(2025, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2025, 2, 1)]
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
     principal = Money("10000.00")
     rate = InterestRate("6% a")
@@ -68,7 +68,7 @@ def test_pay_installment_no_discount_vs_anticipate_discount():
 
 def test_pay_installment_more_principal_with_anticipate():
     """anticipate_payment allocates more to principal since interest is lower."""
-    due_dates = [datetime(2025, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2025, 2, 1)]
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
     principal = Money("10000.00")
     rate = InterestRate("6% a")
@@ -94,7 +94,7 @@ def test_anticipate_payment_uses_now_as_payment_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -107,7 +107,7 @@ def test_anticipate_payment_charges_interest_only_for_elapsed_days():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -124,7 +124,7 @@ def test_anticipate_payment_negative_amount_raises_error():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -141,31 +141,31 @@ def test_next_unpaid_due_date_returns_first_due_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
-    assert loan._next_unpaid_due_date() == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 2, 1)
 
 
 def test_next_unpaid_due_date_advances_after_full_installment():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
     scheduled_pmt = loan.get_original_schedule()[0].payment_amount
     loan.record_payment(scheduled_pmt, datetime(2025, 2, 1, tzinfo=timezone.utc))
-    assert loan._next_unpaid_due_date() == datetime(2025, 3, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 3, 1)
 
 
 def test_next_unpaid_due_date_raises_when_all_paid():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -182,7 +182,7 @@ def test_record_payment_with_explicit_interest_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -203,7 +203,7 @@ def test_record_payment_interest_date_defaults_to_payment_date():
     loan = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -223,9 +223,9 @@ def test_schedule_rebuild_first_entry_reflects_actual_payment():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -241,9 +241,9 @@ def test_schedule_rebuild_remaining_entries_are_projected():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -257,9 +257,9 @@ def test_schedule_rebuild_remaining_entries_are_projected():
 
 def test_schedule_rebuild_total_entries_match_due_dates():
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     loan = Loan(
         Money("10000.00"),
@@ -277,9 +277,9 @@ def test_schedule_rebuild_total_entries_match_due_dates():
 def test_schedule_rebuild_projected_pmt_recalculated():
     """After a payment, the remaining PMT should be recalculated based on remaining principal."""
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     loan = Loan(
         Money("10000.00"),
@@ -305,9 +305,9 @@ def test_schedule_rebuild_projected_pmt_recalculated():
 
 def test_schedule_rebuild_payment_numbers_are_sequential():
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     loan = Loan(
         Money("10000.00"),
@@ -326,7 +326,7 @@ def test_schedule_no_rebuild_without_payments():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -342,13 +342,19 @@ def test_schedule_fully_paid_returns_only_actual():
     loan = Loan(
         Money("1000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
     schedule = loan.get_original_schedule()
     for entry in schedule:
-        loan.record_payment(entry.payment_amount, entry.due_date)
+        payment_dt = datetime(
+            entry.due_date.year,
+            entry.due_date.month,
+            entry.due_date.day,
+            tzinfo=timezone.utc,
+        )
+        loan.record_payment(entry.payment_amount, payment_dt)
 
     rebuilt = loan.get_amortization_schedule()
 
@@ -359,7 +365,7 @@ def test_original_schedule_unchanged_after_payments():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -379,7 +385,7 @@ def test_actual_entry_beginning_balance_matches_principal():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -393,7 +399,7 @@ def test_actual_entry_ending_balance_reflects_principal_paid():
     loan = Loan(
         Money("10000.00"),
         InterestRate("5% a"),
-        [datetime(2025, 2, 1, tzinfo=timezone.utc), datetime(2025, 3, 1, tzinfo=timezone.utc)],
+        [date(2025, 2, 1), date(2025, 3, 1)],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -409,9 +415,9 @@ def test_projected_beginning_balance_matches_previous_ending():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -431,18 +437,18 @@ def test_two_partial_payments_same_installment_next_due_date_unchanged():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
     loan.record_payment(Money("1000.00"), datetime(2025, 1, 20, tzinfo=timezone.utc))
-    assert loan._next_unpaid_due_date() == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 2, 1)
 
     loan.record_payment(Money("1000.00"), datetime(2025, 1, 25, tzinfo=timezone.utc))
-    assert loan._next_unpaid_due_date() == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 2, 1)
 
 
 def test_two_partial_payments_covering_one_installment():
@@ -451,9 +457,9 @@ def test_two_partial_payments_covering_one_installment():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -461,10 +467,10 @@ def test_two_partial_payments_covering_one_installment():
     scheduled_pmt = loan.get_original_schedule()[0].payment_amount
 
     loan.record_payment(Money("1000.00"), datetime(2025, 1, 20, tzinfo=timezone.utc))
-    assert loan._next_unpaid_due_date() == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 2, 1)
 
     loan.record_payment(scheduled_pmt, datetime(2025, 2, 1, tzinfo=timezone.utc))
-    assert loan._next_unpaid_due_date() == datetime(2025, 3, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 3, 1)
 
 
 def test_large_payment_covers_two_installments():
@@ -473,9 +479,9 @@ def test_large_payment_covers_two_installments():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -485,7 +491,7 @@ def test_large_payment_covers_two_installments():
 
     loan.record_payment(two_installments, datetime(2025, 2, 1, tzinfo=timezone.utc))
     assert loan._covered_due_date_count() >= 2
-    assert loan._next_unpaid_due_date() == datetime(2025, 4, 1, tzinfo=timezone.utc)
+    assert loan._next_unpaid_due_date() == date(2025, 4, 1)
 
 
 def test_three_consecutive_anticipations():
@@ -494,9 +500,9 @@ def test_three_consecutive_anticipations():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -523,9 +529,9 @@ def test_schedule_rebuild_after_partial_projects_from_correct_due_date():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -533,7 +539,7 @@ def test_schedule_rebuild_after_partial_projects_from_correct_due_date():
     loan.record_payment(Money("1000.00"), datetime(2025, 1, 20, tzinfo=timezone.utc))
     schedule = loan.get_amortization_schedule()
 
-    assert schedule[1].due_date == datetime(2025, 2, 1, tzinfo=timezone.utc)
+    assert schedule[1].due_date == date(2025, 2, 1)
 
 
 def test_schedule_rebuild_after_overpayment_skips_covered_dates():
@@ -542,9 +548,9 @@ def test_schedule_rebuild_after_overpayment_skips_covered_dates():
         Money("10000.00"),
         InterestRate("5% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
-            datetime(2025, 4, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
@@ -556,7 +562,7 @@ def test_schedule_rebuild_after_overpayment_skips_covered_dates():
     schedule = loan.get_amortization_schedule()
 
     assert len(schedule) == 2
-    assert schedule[1].due_date == datetime(2025, 4, 1, tzinfo=timezone.utc)
+    assert schedule[1].due_date == date(2025, 4, 1)
 
 
 # --- Schedule values: pay_installment vs anticipate_payment ---
@@ -569,9 +575,9 @@ def test_pay_installment_on_due_date_projected_schedule_matches_original():
     remaining schedule should have the same PMT as the original.
     """
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     loan = Loan(
         Money("10000.00"),
@@ -604,9 +610,9 @@ def test_anticipate_payment_schedule_with_concrete_values():
       - New projected PMT: $3,356.31 (lower than original $3,360.16)
     """
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     loan = Loan(
         Money("10000.00"),
@@ -641,7 +647,7 @@ def test_anticipate_payment_schedule_with_concrete_values():
 def test_anticipate_payment_projected_pmt_lower_than_original(principal, annual_rate, num_payments, days_early):
     """anticipate_payment always results in a lower projected PMT than the original schedule."""
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    due_dates = [disbursement + timedelta(days=30 * (i + 1)) for i in range(num_payments)]
+    due_dates = [(disbursement + timedelta(days=30 * (i + 1))).date() for i in range(num_payments)]
     rate_str = f"{annual_rate}% a"
     loan = Loan(
         Money(str(principal)),
@@ -668,9 +674,9 @@ def test_anticipate_vs_installment_ending_balance_comparison():
     principal than pay_installment because less went to interest.
     """
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
     principal = Money("10000.00")

--- a/tests/loan/test_payments.py
+++ b/tests/loan/test_payments.py
@@ -1,6 +1,6 @@
 """Tests for Loan payment recording, full/partial payment scenarios."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -10,7 +10,7 @@ from money_warp import InterestRate, Loan, Money, Warp
 def test_loan_record_payment_updates_balance():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     loan.record_payment(Money("5000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc))
@@ -22,7 +22,7 @@ def test_loan_record_payment_updates_balance():
 def test_loan_record_payment_creates_interest_and_principal_items():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
@@ -40,7 +40,7 @@ def test_loan_record_payment_creates_interest_and_principal_items():
 def test_loan_record_payment_updates_last_payment_date():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
@@ -55,7 +55,7 @@ def test_loan_record_payment_updates_last_payment_date():
 def test_loan_record_payment_multiple_payments():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     loan.record_payment(Money("3000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc))
@@ -67,7 +67,7 @@ def test_loan_record_payment_multiple_payments():
 def test_loan_record_payment_overpayment_zeros_balance():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     loan.record_payment(Money("15000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc))
@@ -79,7 +79,7 @@ def test_loan_record_payment_overpayment_zeros_balance():
 def test_loan_record_payment_negative_amount_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -90,7 +90,7 @@ def test_loan_record_payment_negative_amount_raises_error():
 def test_loan_record_payment_zero_amount_raises_error():
     principal = Money("10000.00")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -144,25 +144,31 @@ def test_loan_balance_zero_when_payments_recorded_beyond_real_time():
     principal = Money("1000.00")
     rate = InterestRate("5% a")
     due_dates = [
-        datetime(2025, 11, 1, tzinfo=timezone.utc),
-        datetime(2025, 12, 1, tzinfo=timezone.utc),
-        datetime(2026, 1, 1, tzinfo=timezone.utc),
-        datetime(2026, 2, 1, tzinfo=timezone.utc),
-        datetime(2026, 3, 1, tzinfo=timezone.utc),
-        datetime(2026, 4, 1, tzinfo=timezone.utc),
-        datetime(2026, 5, 1, tzinfo=timezone.utc),
-        datetime(2026, 6, 1, tzinfo=timezone.utc),
-        datetime(2026, 7, 1, tzinfo=timezone.utc),
-        datetime(2026, 8, 1, tzinfo=timezone.utc),
-        datetime(2026, 9, 1, tzinfo=timezone.utc),
-        datetime(2026, 10, 1, tzinfo=timezone.utc),
+        date(2025, 11, 1),
+        date(2025, 12, 1),
+        date(2026, 1, 1),
+        date(2026, 2, 1),
+        date(2026, 3, 1),
+        date(2026, 4, 1),
+        date(2026, 5, 1),
+        date(2026, 6, 1),
+        date(2026, 7, 1),
+        date(2026, 8, 1),
+        date(2026, 9, 1),
+        date(2026, 10, 1),
     ]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 10, 2, tzinfo=timezone.utc))
 
     schedule = loan.get_amortization_schedule()
     for entry in schedule:
-        loan.record_payment(entry.payment_amount, entry.due_date)
+        payment_dt = datetime(
+            entry.due_date.year,
+            entry.due_date.month,
+            entry.due_date.day,
+            tzinfo=timezone.utc,
+        )
+        loan.record_payment(entry.payment_amount, payment_dt)
 
     with Warp(loan, due_dates[-1]) as warped_loan:
         assert warped_loan.current_balance <= Money("0.01")

--- a/tests/loan/test_same_time_payments.py
+++ b/tests/loan/test_same_time_payments.py
@@ -1,6 +1,6 @@
 """Tests for multiple payments recorded at the exact same datetime."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -14,8 +14,8 @@ def two_installment_loan():
         Money("10000.00"),
         InterestRate("6% a"),
         [
-            datetime(2025, 2, 1, tzinfo=timezone.utc),
-            datetime(2025, 3, 1, tzinfo=timezone.utc),
+            date(2025, 2, 1),
+            date(2025, 3, 1),
         ],
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )

--- a/tests/loan/test_schedule.py
+++ b/tests/loan/test_schedule.py
@@ -1,6 +1,6 @@
 """Tests for Loan amortization schedule generation and edge cases."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from money_warp import InterestRate, Loan, Money
 
@@ -8,7 +8,7 @@ from money_warp import InterestRate, Loan, Money
 def test_loan_get_amortization_schedule_structure():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1), date(2024, 3, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     schedule = loan.get_amortization_schedule()
@@ -22,14 +22,14 @@ def test_loan_get_amortization_schedule_structure():
 def test_loan_get_amortization_schedule_entries():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     schedule = loan.get_amortization_schedule()
 
     entry = schedule[0]
     assert entry.payment_number == 1
-    assert entry.due_date == datetime(2024, 2, 1, tzinfo=timezone.utc)
+    assert entry.due_date == date(2024, 2, 1)
     assert entry.beginning_balance == principal
     assert entry.payment_amount > Money.zero()
     assert entry.principal_payment > Money.zero()
@@ -40,7 +40,7 @@ def test_loan_get_amortization_schedule_entries():
 def test_loan_single_payment_zero_interest():
     principal = Money("10000.00")
     rate = InterestRate("0% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     schedule = loan.get_amortization_schedule()
@@ -53,7 +53,7 @@ def test_loan_single_payment_zero_interest():
 def test_loan_very_small_principal():
     principal = Money("0.01")
     rate = InterestRate("5% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     cash_flow = loan.generate_expected_cash_flow()
@@ -65,7 +65,7 @@ def test_loan_very_small_principal():
 def test_loan_high_interest_rate():
     principal = Money("10000.00")
     rate = InterestRate("50% a")
-    due_dates = [datetime(2024, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2024, 2, 1)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     schedule = loan.get_amortization_schedule()
@@ -79,7 +79,7 @@ def test_loan_many_payments():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
     # Create monthly payments for 2 years
-    due_dates = [datetime(2024, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i) for i in range(1, 25)]
+    due_dates = [date(2024, 1, 1) + timedelta(days=30 * i) for i in range(1, 25)]
 
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
     cash_flow = loan.generate_expected_cash_flow()

--- a/tests/loan/test_settlement.py
+++ b/tests/loan/test_settlement.py
@@ -1,11 +1,16 @@
 """Tests for Settlement — the result of applying a payment to a loan."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
 
 from money_warp import InterestRate, Loan, Money, Settlement, SettlementAllocation, Warp
+
+
+def _payment_datetime(d: date) -> datetime:
+    """Calendar due date as UTC midnight — record_payment requires datetime."""
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
 
 
 @pytest.fixture
@@ -14,9 +19,9 @@ def simple_loan():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
     due_dates = [
-        datetime(2025, 2, 1, tzinfo=timezone.utc),
-        datetime(2025, 3, 1, tzinfo=timezone.utc),
-        datetime(2025, 4, 1, tzinfo=timezone.utc),
+        date(2025, 2, 1),
+        date(2025, 3, 1),
+        date(2025, 4, 1),
     ]
     return Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc))
 
@@ -51,9 +56,9 @@ def test_settlement_payment_amount_matches_input(simple_loan):
 
 
 def test_settlement_payment_date_matches_input(simple_loan):
-    date = datetime(2025, 2, 1, tzinfo=timezone.utc)
-    settlement = simple_loan.record_payment(Money("5000"), date)
-    assert settlement.payment_date == date
+    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    settlement = simple_loan.record_payment(Money("5000"), payment_dt)
+    assert settlement.payment_date == payment_dt
 
 
 def test_settlement_components_sum_to_payment_amount(simple_loan):
@@ -101,7 +106,7 @@ def test_settlement_allocation_is_settlement_allocation_type(simple_loan):
 
 def test_exact_payment_covers_single_installment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    settlement = simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    settlement = simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     assert len(settlement.allocations) == 1
     assert settlement.allocations[0].installment_number == 1
@@ -110,7 +115,7 @@ def test_exact_payment_covers_single_installment(simple_loan):
 
 def test_exact_payment_principal_allocated_matches_expected(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    settlement = simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    settlement = simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     expected_principal = schedule[0].principal_payment
     assert abs(settlement.allocations[0].principal_allocated.raw_amount - expected_principal.raw_amount) < Decimal(
@@ -172,8 +177,8 @@ def test_full_repayment_in_one_payment(simple_loan):
 
 def test_second_payment_allocates_to_next_installment(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
-    settlement2 = simple_loan.record_payment(schedule[1].payment_amount, schedule[1].due_date)
+    simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
+    settlement2 = simple_loan.record_payment(schedule[1].payment_amount, _payment_datetime(schedule[1].due_date))
 
     assert settlement2.allocations[0].installment_number == 2
 
@@ -184,7 +189,7 @@ def test_second_payment_allocates_to_next_installment(simple_loan):
 def test_late_payment_settlement_includes_fine():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2025, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2025, 2, 1)]
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc))
 
     late_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
@@ -201,7 +206,7 @@ def test_late_payment_settlement_includes_fine():
 def test_late_payment_settlement_includes_mora():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2025, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2025, 2, 1)]
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc))
 
     late_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
@@ -217,7 +222,7 @@ def test_late_payment_settlement_includes_mora():
 def test_late_payment_fine_allocated_to_installment():
     principal = Money("10000.00")
     rate = InterestRate("6% a")
-    due_dates = [datetime(2025, 2, 1, tzinfo=timezone.utc)]
+    due_dates = [date(2025, 2, 1)]
     loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc))
 
     late_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
@@ -236,7 +241,7 @@ def test_late_payment_fine_allocated_to_installment():
 def test_settlements_property_returns_all_settlements(simple_loan):
     schedule = simple_loan.get_original_schedule()
     for entry in schedule:
-        simple_loan.record_payment(entry.payment_amount, entry.due_date)
+        simple_loan.record_payment(entry.payment_amount, _payment_datetime(entry.due_date))
 
     assert len(simple_loan.settlements) == 3
 
@@ -247,7 +252,7 @@ def test_settlements_property_empty_before_any_payment(simple_loan):
 
 def test_settlements_property_matches_record_payment_results(simple_loan):
     schedule = simple_loan.get_original_schedule()
-    returned = simple_loan.record_payment(schedule[0].payment_amount, schedule[0].due_date)
+    returned = simple_loan.record_payment(schedule[0].payment_amount, _payment_datetime(schedule[0].due_date))
 
     from_property = simple_loan.settlements[0]
 
@@ -262,7 +267,7 @@ def test_settlements_property_matches_record_payment_results(simple_loan):
 def test_settlements_respect_warp_time(simple_loan):
     schedule = simple_loan.get_original_schedule()
     for entry in schedule:
-        simple_loan.record_payment(entry.payment_amount, entry.due_date)
+        simple_loan.record_payment(entry.payment_amount, _payment_datetime(entry.due_date))
 
     with Warp(simple_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         assert len(warped.settlements) == 1
@@ -274,7 +279,7 @@ def test_settlements_respect_warp_time(simple_loan):
 def test_installments_is_fully_paid_respects_warp(simple_loan):
     schedule = simple_loan.get_original_schedule()
     for entry in schedule:
-        simple_loan.record_payment(entry.payment_amount, entry.due_date)
+        simple_loan.record_payment(entry.payment_amount, _payment_datetime(entry.due_date))
 
     with Warp(simple_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         assert warped.installments[0].is_fully_paid is True

--- a/tests/loan/test_tvm.py
+++ b/tests/loan/test_tvm.py
@@ -1,6 +1,6 @@
 """Tests for Loan present value and IRR (time value of money) methods."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from money_warp import InterestRate, Loan, Money, Rate, Warp
 
@@ -9,7 +9,7 @@ def test_loan_present_value_with_own_rate():
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc), datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15), date(2024, 2, 15)],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )
 
@@ -28,7 +28,7 @@ def test_loan_present_value_with_different_rate():
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc), datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15), date(2024, 2, 15)],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )
 
@@ -46,7 +46,7 @@ def test_loan_present_value_with_custom_valuation_date():
     loan = Loan(
         Money("5000"),
         InterestRate("4% annual"),
-        [datetime(2024, 6, 1, tzinfo=timezone.utc), datetime(2024, 12, 1, tzinfo=timezone.utc)],
+        [date(2024, 6, 1), date(2024, 12, 1)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -63,7 +63,7 @@ def test_loan_present_value_uses_current_time_by_default():
     loan = Loan(
         Money("1000"),
         InterestRate("3% annual"),
-        [datetime(2024, 12, 31, tzinfo=timezone.utc)],
+        [date(2024, 12, 31)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -80,7 +80,7 @@ def test_loan_present_value_with_time_machine():
     loan = Loan(
         Money("2000"),
         InterestRate("4% annual"),
-        [datetime(2024, 6, 1, tzinfo=timezone.utc), datetime(2024, 12, 1, tzinfo=timezone.utc)],
+        [date(2024, 6, 1), date(2024, 12, 1)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -104,9 +104,9 @@ def test_loan_present_value_different_discount_rates():
         Money("10000"),
         InterestRate("6% annual"),
         [
-            datetime(2024, 6, 1, tzinfo=timezone.utc),
-            datetime(2025, 6, 1, tzinfo=timezone.utc),
-            datetime(2026, 6, 1, tzinfo=timezone.utc),
+            date(2024, 6, 1),
+            date(2025, 6, 1),
+            date(2026, 6, 1),
         ],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -124,7 +124,7 @@ def test_loan_irr_basic():
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc), datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15), date(2024, 2, 15)],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )
 
@@ -144,7 +144,7 @@ def test_loan_irr_with_time_machine_for_valuation():
     loan = Loan(
         Money("5000"),
         InterestRate("4% annual"),
-        [datetime(2024, 6, 1, tzinfo=timezone.utc), datetime(2024, 12, 1, tzinfo=timezone.utc)],
+        [date(2024, 6, 1), date(2024, 12, 1)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -162,7 +162,7 @@ def test_loan_irr_with_custom_guess():
     loan = Loan(
         Money("2000"),
         InterestRate("6% annual"),
-        [datetime(2024, 6, 1, tzinfo=timezone.utc), datetime(2024, 12, 1, tzinfo=timezone.utc)],
+        [date(2024, 6, 1), date(2024, 12, 1)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -179,7 +179,7 @@ def test_loan_irr_with_time_machine():
     loan = Loan(
         Money("3000"),
         InterestRate("7% annual"),
-        [datetime(2024, 6, 1, tzinfo=timezone.utc), datetime(2024, 12, 1, tzinfo=timezone.utc)],
+        [date(2024, 6, 1), date(2024, 12, 1)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -203,7 +203,7 @@ def test_loan_irr_multiple_payments():
     loan = Loan(
         Money("12000"),
         InterestRate("5.5% annual"),
-        [datetime(2024, i, 1) for i in range(1, 7)],  # 6 monthly payments
+        [date(2024, i, 1) for i in range(1, 7)],  # 6 monthly payments
         datetime(2023, 12, 1, tzinfo=timezone.utc),
     )
 

--- a/tests/tax/test_grossup.py
+++ b/tests/tax/test_grossup.py
@@ -1,6 +1,6 @@
 """Tests for the grossup function (financed tax calculation)."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -34,9 +34,9 @@ def disbursement_date():
 @pytest.fixture
 def three_due_dates():
     return [
-        datetime(2024, 2, 1, tzinfo=timezone.utc),
-        datetime(2024, 3, 1, tzinfo=timezone.utc),
-        datetime(2024, 4, 1, tzinfo=timezone.utc),
+        date(2024, 2, 1),
+        date(2024, 3, 1),
+        date(2024, 4, 1),
     ]
 
 
@@ -111,7 +111,7 @@ def test_grossup_single_installment(standard_iof, interest_rate, disbursement_da
     result = grossup(
         requested_amount=Money("10000"),
         interest_rate=interest_rate,
-        due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 2, 1)],
         disbursement_date=disbursement_date,
         scheduler=PriceScheduler,
         taxes=[standard_iof],
@@ -124,7 +124,7 @@ def test_grossup_small_amount(standard_iof, interest_rate, disbursement_date):
     result = grossup(
         requested_amount=Money("100"),
         interest_rate=interest_rate,
-        due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 2, 1)],
         disbursement_date=disbursement_date,
         scheduler=PriceScheduler,
         taxes=[standard_iof],
@@ -137,7 +137,7 @@ def test_grossup_large_amount(standard_iof, interest_rate, disbursement_date):
     result = grossup(
         requested_amount=Money("1000000"),
         interest_rate=interest_rate,
-        due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc), datetime(2024, 3, 1, tzinfo=timezone.utc)],
+        due_dates=[date(2024, 2, 1), date(2024, 3, 1)],
         disbursement_date=disbursement_date,
         scheduler=PriceScheduler,
         taxes=[standard_iof],
@@ -151,7 +151,7 @@ def test_grossup_raises_on_zero_requested_amount(standard_iof, interest_rate, di
         grossup(
             requested_amount=Money("0"),
             interest_rate=interest_rate,
-            due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc)],
+            due_dates=[date(2024, 2, 1)],
             disbursement_date=disbursement_date,
             scheduler=PriceScheduler,
             taxes=[standard_iof],
@@ -163,7 +163,7 @@ def test_grossup_raises_on_negative_requested_amount(standard_iof, interest_rate
         grossup(
             requested_amount=Money("-1000"),
             interest_rate=interest_rate,
-            due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc)],
+            due_dates=[date(2024, 2, 1)],
             disbursement_date=disbursement_date,
             scheduler=PriceScheduler,
             taxes=[standard_iof],
@@ -175,7 +175,7 @@ def test_grossup_raises_on_empty_taxes(interest_rate, disbursement_date):
         grossup(
             requested_amount=Money("10000"),
             interest_rate=interest_rate,
-            due_dates=[datetime(2024, 2, 1, tzinfo=timezone.utc)],
+            due_dates=[date(2024, 2, 1)],
             disbursement_date=disbursement_date,
             scheduler=PriceScheduler,
             taxes=[],
@@ -266,7 +266,7 @@ def test_grossup_loan_forwards_grace_period(standard_iof, interest_rate, three_d
 
 def test_grossup_loan_converges_for_21_terms_with_iof():
     disbursement_date = datetime(2124, 8, 8, tzinfo=timezone.utc)
-    first_payment = datetime(2124, 8, 17, tzinfo=timezone.utc)
+    first_payment = date(2124, 8, 17)
     rate = InterestRate(0.0399, CompoundingFrequency.MONTHLY)
     taxes = [IOF(daily_rate="0.0082%", additional_rate="0.38%")]
     due_dates = [first_payment + relativedelta(months=i) for i in range(21)]
@@ -290,7 +290,7 @@ def test_grossup_loan_converges_for_21_terms_with_iof():
 @settings(max_examples=200, deadline=None)
 def test_grossup_principal_is_cent_aligned(amount, num_terms, monthly_rate, days_to_first):
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    first_payment = disbursement_date + relativedelta(days=days_to_first)
+    first_payment = disbursement_date.date() + relativedelta(days=days_to_first)
     due_dates = [first_payment + relativedelta(months=i) for i in range(num_terms)]
     rate = InterestRate(monthly_rate, CompoundingFrequency.MONTHLY)
     taxes = [IOF(daily_rate="0.0082%", additional_rate="0.38%")]
@@ -316,7 +316,7 @@ def test_grossup_principal_is_cent_aligned(amount, num_terms, monthly_rate, days
 @settings(max_examples=200, deadline=None)
 def test_grossup_loan_net_at_least_requested(amount, num_terms, monthly_rate, days_to_first):
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    first_payment = disbursement_date + relativedelta(days=days_to_first)
+    first_payment = disbursement_date.date() + relativedelta(days=days_to_first)
     due_dates = [first_payment + relativedelta(months=i) for i in range(num_terms)]
     rate = InterestRate(monthly_rate, CompoundingFrequency.MONTHLY)
     taxes = [IOF(daily_rate="0.0082%", additional_rate="0.38%")]

--- a/tests/tax/test_iof.py
+++ b/tests/tax/test_iof.py
@@ -1,6 +1,6 @@
 """Tests for IOF (Imposto sobre Operações Financeiras) tax calculation."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -31,7 +31,7 @@ def single_installment_schedule(disbursement_date):
     return PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
 
@@ -42,9 +42,9 @@ def three_installment_schedule(disbursement_date):
         Money("10000"),
         InterestRate("2% monthly"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date,
     )
@@ -103,7 +103,7 @@ def test_iof_single_installment_manual_calculation(disbursement_date):
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     result = iof.calculate(schedule, disbursement_date)
@@ -130,9 +130,9 @@ def test_iof_later_installments_have_higher_daily_component(disbursement_date):
         Money("10000"),
         InterestRate("2% monthly"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date,
     )
@@ -147,7 +147,7 @@ def test_iof_max_daily_days_caps_days(disbursement_date):
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     result_capped = iof_capped.calculate(schedule, disbursement_date)
@@ -160,9 +160,9 @@ def test_iof_with_inverted_price_scheduler(standard_iof, disbursement_date):
         Money("10000"),
         InterestRate("2% monthly"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date,
     )
@@ -177,9 +177,9 @@ def test_iof_with_inverted_price_has_equal_principal_payments(disbursement_date)
         Money("9000"),
         InterestRate("2% monthly"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
-            datetime(2024, 4, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
+            date(2024, 4, 1),
         ],
         disbursement_date,
     )
@@ -217,7 +217,7 @@ def test_iof_zero_rates_produce_zero_tax(daily_rate, additional_rate, disburseme
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     result = iof.calculate(schedule, disbursement_date)
@@ -256,7 +256,7 @@ def test_individual_iof_calculate_produces_positive_result(disbursement_date):
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     result = iof.calculate(schedule, disbursement_date)
@@ -295,7 +295,7 @@ def test_corporate_iof_calculate_produces_positive_result(disbursement_date):
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     result = iof.calculate(schedule, disbursement_date)
@@ -306,7 +306,7 @@ def test_corporate_iof_lower_daily_than_individual(disbursement_date):
     schedule = PriceScheduler.generate_schedule(
         Money("10000"),
         InterestRate("2% monthly"),
-        [datetime(2024, 2, 1, tzinfo=timezone.utc)],
+        [date(2024, 2, 1)],
         disbursement_date,
     )
     individual_result = IndividualIOF().calculate(schedule, disbursement_date)

--- a/tests/test_inverted_price_scheduler.py
+++ b/tests/test_inverted_price_scheduler.py
@@ -1,6 +1,6 @@
 """Tests for InvertedPriceScheduler (Constant Amortization System)."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -15,9 +15,9 @@ def basic_loan_params():
         "principal": Money("10000.00"),
         "interest_rate": InterestRate("5% annual"),
         "due_dates": [
-            datetime(2024, 1, 15, tzinfo=timezone.utc),
-            datetime(2024, 2, 15, tzinfo=timezone.utc),
-            datetime(2024, 3, 15, tzinfo=timezone.utc),
+            date(2024, 1, 15),
+            date(2024, 2, 15),
+            date(2024, 3, 15),
         ],
         "disbursement_date": datetime(2023, 12, 16, tzinfo=timezone.utc),
     }
@@ -115,7 +115,7 @@ def test_inverted_price_scheduler_vs_price_scheduler_interest_comparison(basic_l
 # Edge case tests
 def test_inverted_price_scheduler_single_payment(basic_loan_params):
     single_payment_params = basic_loan_params.copy()
-    single_payment_params["due_dates"] = [datetime(2024, 1, 15, tzinfo=timezone.utc)]
+    single_payment_params["due_dates"] = [date(2024, 1, 15)]
 
     schedule = InvertedPriceScheduler.generate_schedule(**single_payment_params)
 
@@ -128,7 +128,7 @@ def test_inverted_price_scheduler_zero_interest_rate():
     schedule = InvertedPriceScheduler.generate_schedule(
         Money("1000"),
         InterestRate("0% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc), datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15), date(2024, 2, 15)],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )
 
@@ -144,9 +144,9 @@ def test_inverted_price_scheduler_irregular_payment_dates():
         Money("3000"),
         InterestRate("6% annual"),
         [
-            datetime(2024, 1, 10, tzinfo=timezone.utc),  # 25 days from disbursement
-            datetime(2024, 2, 20, tzinfo=timezone.utc),  # 41 days from previous
-            datetime(2024, 4, 5, tzinfo=timezone.utc),  # 45 days from previous
+            date(2024, 1, 10),  # 25 days from disbursement
+            date(2024, 2, 20),  # 41 days from previous
+            date(2024, 4, 5),  # 45 days from previous
         ],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )
@@ -167,7 +167,7 @@ def test_inverted_price_scheduler_high_precision_calculations():
     schedule = InvertedPriceScheduler.generate_schedule(
         Money("12345.67"),
         InterestRate("4.321% annual"),
-        [datetime(2024, i, 1, tzinfo=timezone.utc) for i in range(1, 13)],  # 12 monthly payments
+        [date(2024, i, 1) for i in range(1, 13)],  # 12 monthly payments
         datetime(2023, 12, 1, tzinfo=timezone.utc),
     )
 

--- a/tests/test_irr.py
+++ b/tests/test_irr.py
@@ -1,6 +1,6 @@
 """Tests for Internal Rate of Return (IRR) calculations."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -79,7 +79,7 @@ def test_irr_with_time_machine_for_specific_date(simple_investment):
     loan = Loan(
         Money("1000"),
         InterestRate("10% annual"),
-        [datetime(2024, 12, 31, tzinfo=timezone.utc)],
+        [date(2024, 12, 31)],
         datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 

--- a/tests/test_present_value.py
+++ b/tests/test_present_value.py
@@ -1,6 +1,6 @@
 """Tests for present value calculations."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -234,9 +234,9 @@ def test_present_value_with_time_machine_philosophy():
         Money("10000"),
         InterestRate("5% annual"),
         [
-            datetime(2024, 1, 15, tzinfo=timezone.utc),
-            datetime(2024, 2, 15, tzinfo=timezone.utc),
-            datetime(2024, 3, 15, tzinfo=timezone.utc),
+            date(2024, 1, 15),
+            date(2024, 2, 15),
+            date(2024, 3, 15),
         ],
         datetime(2023, 12, 16, tzinfo=timezone.utc),
     )

--- a/tests/test_price_scheduler_validation.py
+++ b/tests/test_price_scheduler_validation.py
@@ -1,6 +1,6 @@
 """Validation tests for PriceScheduler against known loan calculation principles."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -19,7 +19,7 @@ def test_price_scheduler_reference_values():
 
     # 10 payments, 1 day apart each
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [datetime(2024, 1, i + 2, tzinfo=timezone.utc) for i in range(10)]  # Jan 2, 3, 4, ..., 11
+    due_dates = [date(2024, 1, i + 2) for i in range(10)]  # Jan 2, 3, 4, ..., 11
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
 
@@ -73,7 +73,8 @@ def test_price_scheduler_zero_interest_validation():
 
     # 12 monthly payments
     start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [start_date + timedelta(days=30 * i) for i in range(1, 13)]
+    anchor = date(2024, 1, 1)
+    due_dates = [anchor + timedelta(days=30 * i) for i in range(1, 13)]
     disbursement_date = start_date
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
@@ -98,7 +99,7 @@ def test_price_scheduler_single_payment_validation():
 
     # Single payment after 1 year
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [datetime(2024, 12, 31, tzinfo=timezone.utc)]  # 365 days later
+    due_dates = [date(2024, 12, 31)]  # 365 days later
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
 
@@ -125,7 +126,8 @@ def test_price_scheduler_short_term_validation():
 
     # 6 monthly payments
     start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [start_date + timedelta(days=30 * i) for i in range(1, 7)]
+    anchor = date(2024, 1, 1)
+    due_dates = [anchor + timedelta(days=30 * i) for i in range(1, 7)]
     disbursement_date = start_date
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
@@ -155,10 +157,10 @@ def test_price_scheduler_irregular_schedule_validation():
     # Irregular payment schedule
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
     due_dates = [
-        datetime(2024, 2, 15, tzinfo=timezone.utc),  # 45 days
-        datetime(2024, 4, 1, tzinfo=timezone.utc),  # 45 days later
-        datetime(2024, 6, 1, tzinfo=timezone.utc),  # 61 days later
-        datetime(2024, 8, 15, tzinfo=timezone.utc),  # 75 days later
+        date(2024, 2, 15),  # 45 days
+        date(2024, 4, 1),  # 45 days later
+        date(2024, 6, 1),  # 61 days later
+        date(2024, 8, 15),  # 75 days later
     ]
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
@@ -190,7 +192,8 @@ def test_price_scheduler_high_precision_validation():
 
     # 24 monthly payments
     start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [start_date + timedelta(days=30 * i) for i in range(1, 25)]
+    anchor = date(2024, 1, 1)
+    due_dates = [anchor + timedelta(days=30 * i) for i in range(1, 25)]
     disbursement_date = start_date
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)
@@ -221,7 +224,8 @@ def test_price_scheduler_parametrized_validation(principal_amount, annual_rate, 
 
     # Generate monthly payment schedule
     start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    due_dates = [start_date + timedelta(days=30 * i) for i in range(1, num_payments + 1)]
+    anchor = date(2024, 1, 1)
+    due_dates = [anchor + timedelta(days=30 * i) for i in range(1, num_payments + 1)]
     disbursement_date = start_date
 
     schedule = PriceScheduler.generate_schedule(principal, rate, due_dates, disbursement_date)

--- a/tests/test_temporal_cashflow.py
+++ b/tests/test_temporal_cashflow.py
@@ -1,7 +1,7 @@
 """Tests for temporal CashFlowItem behavior (resolve, update, delete, Warp)."""
 
 import copy
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from money_warp import (
     CashFlow,
@@ -146,8 +146,8 @@ def test_warp_overrides_time_context():
         Money("10000"),
         InterestRate("5% annual"),
         [
-            datetime(2024, 2, 1, tzinfo=timezone.utc),
-            datetime(2024, 3, 1, tzinfo=timezone.utc),
+            date(2024, 2, 1),
+            date(2024, 3, 1),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -13,9 +13,9 @@ def sample_loan():
     principal = Money("10000.00")
     interest_rate = InterestRate("5% annual")
     due_dates = [
-        datetime(2024, 1, 15, tzinfo=timezone.utc),
-        datetime(2024, 2, 15, tzinfo=timezone.utc),
-        datetime(2024, 3, 15, tzinfo=timezone.utc),
+        date(2024, 1, 15),
+        date(2024, 2, 15),
+        date(2024, 3, 15),
     ]
     return Loan(principal, interest_rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
 
@@ -77,13 +77,13 @@ def test_warp_different_loans_concurrently_allowed():
     loan_a = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15)],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
     loan_b = Loan(
         Money("5000"),
         InterestRate("8% annual"),
-        [datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 2, 15)],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -171,9 +171,9 @@ def test_warp_to_past_ignores_future_payments():
         Money("10000"),
         InterestRate("5% annual"),
         [
-            datetime(2024, 1, 15, tzinfo=timezone.utc),
-            datetime(2024, 2, 15, tzinfo=timezone.utc),
-            datetime(2024, 3, 15, tzinfo=timezone.utc),
+            date(2024, 1, 15),
+            date(2024, 2, 15),
+            date(2024, 3, 15),
         ],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
     )
@@ -200,7 +200,7 @@ def test_warp_to_future_keeps_all_past_payments():
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 15, tzinfo=timezone.utc), datetime(2024, 2, 15, tzinfo=timezone.utc)],
+        [date(2024, 1, 15), date(2024, 2, 15)],
         disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
         fine_rate=InterestRate("0% annual"),
     )
@@ -218,7 +218,7 @@ def test_warp_string_representation():
     loan = Loan(
         Money("1000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 1, tzinfo=timezone.utc)],
+        [date(2024, 1, 1)],
         disbursement_date=datetime(2023, 12, 1, tzinfo=timezone.utc),
     )
     warp = Warp(loan, "2030-01-15")
@@ -232,7 +232,7 @@ def test_warp_repr_representation():
     loan = Loan(
         Money("1000"),
         InterestRate("5% annual"),
-        [datetime(2024, 1, 1, tzinfo=timezone.utc)],
+        [date(2024, 1, 1)],
         disbursement_date=datetime(2023, 12, 1, tzinfo=timezone.utc),
     )
     warp = Warp(loan, "2030-01-15")


### PR DESCRIPTION
## Summary
- Change `due_dates` from `List[datetime]` to `List[date]` across the entire codebase -- Loan, schedulers, grossup, taxes, SA bridge
- Due dates represent calendar dates, not moments in time; this makes the API semantically correct
- `disbursement_date` and `payment_date` remain `datetime` (actual timestamps)

## Changes
- Added `to_date()` and `to_datetime()` conversion helpers to `tz.py`
- `PaymentScheduleEntry.due_date`, `Installment.due_date`, `TaxInstallmentDetail.due_date` are now `date`
- `Loan.fines_applied` keys changed from `datetime` to `date`
- Added `Loan._actual_payment_datetimes` to preserve full timestamps for settlements
- SA bridge `_parse_due_dates()` now returns `List[date]`
- Scheduler day-arithmetic uses `disbursement_date.date()` for mixed-type subtraction
- CashFlowItem creation uses `to_datetime()` to convert schedule dates to timestamps

## Test plan
- [x] All 1623 existing tests pass (`poetry run pytest`)
- [x] 59 files updated (10 source, 32 test, 16 docs + 1 README)
- [x] No lint errors introduced

## Docs
- Updated `knowledge/loan.md`, `knowledge/tax.md`, `knowledge/ext.md`, `knowledge/architecture.md`, `knowledge/tz.md`, `knowledge/date_utils.md`
- Updated `README.md` quick example
- Updated all `docs/examples/` files