### PR TITLE
fix: mora allocation reconciliation in pay_installment settlements

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -230,7 +230,7 @@ Computed properties:
 Field semantics:
 - `expected_payment`, `expected_principal`, `expected_interest` come from the original schedule.
 - `expected_fine` comes from `Loan.fines_applied` for the installment's due date.
-- `expected_mora` is computed by the Loan: for covered installments it equals `mora_paid`; for the first uncovered overdue installment it is the accrued mora from the due date to `self.now()` using `_compute_accrued_interest`; for all other installments it is zero.
+- `expected_mora` is computed by the Loan: for covered installments it equals the sum of prior `mora_allocated` values; for the first uncovered overdue installment it is prior `mora_allocated` **plus** newly accrued mora (from last payment to `self.now()`) via `_compute_accrued_interest`; for all other installments it is zero. The cumulative form ensures `Installment.allocate` correctly computes `mora_owed = expected_mora - mora_paid` even when the same installment receives mora across multiple settlements.
 - `*_paid` fields are aggregated totals from all settlement allocations attributed to this installment.
 - `allocations` is the reverse view of Settlement: all `SettlementAllocation`s that touched this installment.
 - Created via `Installment.from_schedule_entry(entry, allocations, expected_mora, expected_fine)`.
@@ -246,6 +246,7 @@ Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_pa
 - `allocations` shows per-installment detail: which installments the payment covered and how much principal/interest/mora/fine went to each.
 - All three payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) return a `Settlement`.
 - The `settlements` property reconstructs all settlements by querying the cash flow. Warp-aware: only includes settlements with `payment_date <= self.now()`.
+- **Reconciliation invariant:** For every settlement, each component total must equal the sum of its per-installment allocations: `settlement.X_paid == sum(a.X_allocated for a in settlement.allocations)` for X in {principal, interest, mora, fine}.
 
 #### Per-Installment Allocation
 
@@ -332,3 +333,15 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 **Fix:** Replaced datetime-based grouping with positional offset tracking. `record_payment` now records `len(self._all_payments)` into `_payment_item_offsets` before calling `_allocate_payment`. `_extract_payment_items` slices `_all_payments` by `[offsets[i]:offsets[i+1]]` instead of walking by datetime. This is simpler, faster (O(items-in-this-payment) vs O(all-items-up-to-this-payment)), and correct regardless of datetime values.
 
 **Lesson:** Don't use a value that can be non-unique (datetime) as a grouping boundary when a positional invariant (sequential append order) already provides an unambiguous one.
+
+### Mora under-distributed across allocations (fixed 2026-03-19)
+
+**Symptom:** `settlement.mora_paid` was consistently higher than `sum(a.mora_allocated for a in settlement.allocations)`. The difference was always positive and exactly equalled the mora allocated to the same installment in prior settlements.
+
+**Root cause:** `_build_installments_snapshot` computed `expected_mora` for the first uncovered installment (`i == covered`) using only the newly accrued mora for the current period. It did not include mora already attributed from prior settlements. When `Installment.allocate` ran `mora_owed = expected_mora - mora_paid`, the `mora_paid` (cumulative from prior allocations) was subtracted from a non-cumulative `expected_mora`, producing an artificially low `mora_owed` and leaving mora unallocated.
+
+**Trigger condition:** Two or more consecutive late payments where the same installment remains uncovered (partial late payments).
+
+**Fix:** `expected_mora = prior_mora + accrued_mora` — sum the mora already allocated from prior settlements before adding the newly accrued amount. This makes the `i == covered` branch cumulative, matching the pattern already used for fully-covered installments (`i < covered`).
+
+**Lesson:** When a derived quantity (expected_mora) participates in a subtraction against a cumulative counter (mora_paid), the derived quantity must also be cumulative. Mixing period-level and cumulative values in the same expression produces silent under-distribution.

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1194,12 +1194,14 @@ class Loan:
 
             expected_fine = self.fines_applied.get(entry.due_date, Money.zero())
 
+            prior_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
+
             if i < covered:
-                expected_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
+                expected_mora = prior_mora
             elif i == covered and entry.due_date < as_of_date.date():
                 if last_payment_date is not None:
                     total_days = (as_of_date - last_payment_date).days
-                    _, expected_mora = self._compute_accrued_interest(
+                    _, accrued_mora = self._compute_accrued_interest(
                         total_days,
                         principal_balance,
                         entry.due_date,
@@ -1207,12 +1209,13 @@ class Loan:
                     )
                 else:
                     days_overdue = (as_of_date.date() - entry.due_date).days
-                    _, expected_mora = self._compute_accrued_interest(
+                    _, accrued_mora = self._compute_accrued_interest(
                         days_overdue,
                         principal_balance,
                         entry.due_date,
                         to_datetime(entry.due_date),
                     )
+                expected_mora = prior_mora + accrued_mora
             else:
                 expected_mora = Money.zero()
 

--- a/tests/loan/settlements/late_payments/test_partial_late_payment.py
+++ b/tests/loan/settlements/late_payments/test_partial_late_payment.py
@@ -1,0 +1,125 @@
+"""Settlement tests for consecutive partial late payments on the same installment.
+
+Scenario: 2 partial late payments where installment 1 remains uncovered after P1,
+so both payments allocate mora to the same installment. This is the trigger
+condition for the mora reconciliation bug (expected_mora must include prior
+mora allocations, not just the current-period accrual).
+
+Payment timeline:
+  P1  R$100  Feb 16  (15 days late — partial, inst 1 stays uncovered)
+  P2  R$300  Mar 15  (inst 1 still first uncovered, has prior mora)
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from money_warp import Money, Warp
+
+
+@pytest.fixture
+def partial_late_settlements(loan_with_fine):
+    """Execute 2 partial late payments via chained Warp contexts."""
+    with Warp(loan_with_fine, datetime(2025, 2, 16, tzinfo=timezone.utc)) as w1:
+        s1 = w1.pay_installment(Money("100.00"))
+        with Warp(w1, datetime(2025, 3, 15, tzinfo=timezone.utc)) as w2:
+            s2 = w2.pay_installment(Money("300.00"))
+            return w2, [s1, s2]
+
+
+# --- Payment 1: R$100 on Feb 16 (partial late) ---
+
+
+def test_p1_settlement_totals(partial_late_settlements):
+    """P1 pays fine, mora, interest; remainder goes to principal."""
+    _, settlements = partial_late_settlements
+    assert settlements[0].fine_paid == Money("6.07")
+    assert settlements[0].mora_paid == Money("5.19")
+    assert settlements[0].interest_paid == Money("10.63")
+    assert settlements[0].principal_paid == Money("78.11")
+    assert settlements[0].remaining_balance == Money("812.11")
+
+
+def test_p1_allocation_count(partial_late_settlements):
+    """P1 only touches installment 1 (partial coverage)."""
+    _, settlements = partial_late_settlements
+    assert len(settlements[0].allocations) == 1
+
+
+def test_p1_first_installment(partial_late_settlements):
+    """Inst 1 absorbs all of P1 but is NOT fully covered."""
+    _, settlements = partial_late_settlements
+    a = settlements[0].allocations[0]
+    assert a.installment_number == 1
+    assert a.principal_allocated == Money("78.11")
+    assert a.interest_allocated == Money("10.63")
+    assert a.fine_allocated == Money("6.07")
+    assert a.mora_allocated == Money("5.19")
+    assert a.is_fully_covered is False
+
+
+def test_p1_mora_reconciliation(partial_late_settlements):
+    """P1 mora totals reconcile with per-installment allocations."""
+    _, settlements = partial_late_settlements
+    s = settlements[0]
+    assert s.mora_paid == Money(sum(a.mora_allocated.raw_amount for a in s.allocations))
+
+
+# --- Payment 2: R$300 on Mar 15 (inst 1 still uncovered, has prior mora) ---
+
+
+def test_p2_settlement_totals(partial_late_settlements):
+    """P2 pays fine for inst 2, mora accrued since P1, rest to principal."""
+    _, settlements = partial_late_settlements
+    assert settlements[1].fine_paid == Money("6.07")
+    assert settlements[1].mora_paid == Money("8.44")
+    assert settlements[1].interest_paid == Money("0.00")
+    assert settlements[1].principal_paid == Money("285.49")
+    assert settlements[1].remaining_balance == Money("526.62")
+
+
+def test_p2_allocation_count(partial_late_settlements):
+    """P2 touches 2 installments (finishes inst 1, starts inst 2)."""
+    _, settlements = partial_late_settlements
+    assert len(settlements[1].allocations) == 2
+
+
+def test_p2_first_installment(partial_late_settlements):
+    """Inst 1 receives the new mora and remaining principal — now fully covered."""
+    _, settlements = partial_late_settlements
+    a = settlements[1].allocations[0]
+    assert a.installment_number == 1
+    assert a.principal_allocated == Money("214.88")
+    assert a.interest_allocated == Money("0.00")
+    assert a.fine_allocated == Money("0.00")
+    assert a.mora_allocated == Money("8.44")
+    assert a.is_fully_covered is True
+
+
+def test_p2_second_installment(partial_late_settlements):
+    """Inst 2 receives its fine and leftover principal."""
+    _, settlements = partial_late_settlements
+    a = settlements[1].allocations[1]
+    assert a.installment_number == 2
+    assert a.principal_allocated == Money("70.61")
+    assert a.interest_allocated == Money("0.00")
+    assert a.fine_allocated == Money("6.07")
+    assert a.mora_allocated == Money("0.00")
+    assert a.is_fully_covered is False
+
+
+def test_p2_mora_reconciliation(partial_late_settlements):
+    """P2 mora totals reconcile — the core invariant this scenario guards."""
+    _, settlements = partial_late_settlements
+    s = settlements[1]
+    assert s.mora_paid == Money(sum(a.mora_allocated.raw_amount for a in s.allocations))
+
+
+def test_p2_all_components_reconcile(partial_late_settlements):
+    """Every settlement component equals the sum of its per-installment allocations."""
+    _, settlements = partial_late_settlements
+    s = settlements[1]
+    assert s.fine_paid == Money(sum(a.fine_allocated.raw_amount for a in s.allocations))
+    assert s.interest_paid == Money(sum(a.interest_allocated.raw_amount for a in s.allocations))
+    assert s.mora_paid == Money(sum(a.mora_allocated.raw_amount for a in s.allocations))
+    assert s.principal_paid == Money(sum(a.principal_allocated.raw_amount for a in s.allocations))


### PR DESCRIPTION
## Summary
- Fix `_build_installments_snapshot` so `expected_mora` for the first uncovered installment includes prior mora allocations alongside newly accrued mora, restoring the reconciliation invariant `settlement.mora_paid == sum(a.mora_allocated)`
- Add regression test covering consecutive partial late payments on the same installment — the trigger condition for the bug
- Update `knowledge/loan.md` with the fix, the reconciliation invariant, and the key learning

## Changes
- **`money_warp/loan/loan.py`** — In `_build_installments_snapshot`, the `elif i == covered` branch now computes `prior_mora` from existing allocations and sets `expected_mora = prior_mora + accrued_mora` (cumulative), matching the pattern already used for fully-covered installments (`i < covered`). Previously it only used the current-period accrual, causing `Installment.allocate` to under-distribute mora when the same installment received mora across multiple settlements.
- **`tests/loan/settlements/late_payments/test_partial_late_payment.py`** — New test file with a 2-payment scenario (R$100 on Feb 16, R$300 on Mar 15) where installment 1 stays uncovered after P1. Asserts exact allocation values for both payments and verifies all four reconciliation invariants (fine, interest, mora, principal) on P2.
- **`knowledge/loan.md`** — Updated `expected_mora` field semantics, added the settlement reconciliation invariant to the Settlement section, added Key Learnings entry.

## Test plan
- [x] All existing tests pass (`poetry run pytest` — 1633 passed, 5 xfailed)
- [x] New `test_partial_late_payment.py` passes (10 tests)
- [x] Verified the bug reproduces on `main` (mora_paid=8.44 vs sum=3.25, difference=5.19)
- [x] Verified the fix resolves it (all four invariants hold)

## Docs
- `knowledge/loan.md` updated with fix details and reconciliation invariant