### PR TITLE
fix: use date arithmetic for day-count in settlement interest calculation

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -334,6 +334,16 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 
 **Lesson:** Don't use a value that can be non-unique (datetime) as a grouping boundary when a positional invariant (sequential append order) already provides an unambiguous one.
 
+### Day-count mismatch with non-midnight disbursement (fixed 2026-03-20)
+
+**Symptom:** When `disbursement_date` had a non-midnight time component (e.g. 19:53), the first installment was never marked `is_fully_covered` even when the payment was large enough to cover it. The settlement interest was consistently lower than the scheduled interest by about one day's worth.
+
+**Root cause:** The scheduler computes `days_in_period` using date subtraction (`(due_date - prev_date).days`), but `_compute_interest_snapshot` used datetime subtraction (`(interest_date - last_pay_date).days`). Python's `timedelta.days` truncates: `(April 12 00:00 - March 6 19:53).days == 36`, while `(April 12 - March 6).days == 37`. The 1-day shortfall meant settlement interest was less than the schedule expected, so `Installment.allocate` could not fully cover the first installment's interest obligation.
+
+**Fix:** Use `.date()` on both operands in all three day-count calculations: `_compute_interest_snapshot`, `_build_installments_snapshot` (mora days), and `days_since_last_payment`. This aligns with the scheduler's calendar-day convention. Financial day counting operates on dates, not timestamps.
+
+**Lesson:** When one subsystem counts days using dates and another uses datetimes, the results will diverge whenever a timestamp has a non-midnight time. Normalize to the same type (`.date()`) at every day-count boundary.
+
 ### Mora under-distributed across allocations (fixed 2026-03-19)
 
 **Symptom:** `settlement.mora_paid` was consistently higher than `sum(a.mora_allocated for a in settlement.allocations)`. The difference was always positive and exactly equalled the mora allocated to the same installment in prior settlements.

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -295,7 +295,7 @@ class Loan:
         """Get the number of days since the last payment as of a given date (defaults to current time)."""
         if as_of_date is None:
             as_of_date = self.now()
-        return (as_of_date - self.last_payment_date).days
+        return (as_of_date.date() - self.last_payment_date.date()).days
 
     def get_expected_payment_amount(self, due_date: date) -> Money:
         """
@@ -618,7 +618,7 @@ class Loan:
         """
         prior_items = [p for p in self._all_payments if p.datetime <= payment_date]
         last_pay_date = prior_items[-1].datetime if prior_items else self.disbursement_date
-        days = (interest_date - last_pay_date).days
+        days = (interest_date.date() - last_pay_date.date()).days
 
         principal_balance = self.principal
         for p in self._all_payments:
@@ -1200,7 +1200,7 @@ class Loan:
                 expected_mora = prior_mora
             elif i == covered and entry.due_date < as_of_date.date():
                 if last_payment_date is not None:
-                    total_days = (as_of_date - last_payment_date).days
+                    total_days = (as_of_date.date() - last_payment_date.date()).days
                     _, accrued_mora = self._compute_accrued_interest(
                         total_days,
                         principal_balance,

--- a/tests/loan/settlements/up_to_date_payments/test_nonmidnight_disbursement.py
+++ b/tests/loan/settlements/up_to_date_payments/test_nonmidnight_disbursement.py
@@ -1,0 +1,104 @@
+"""Settlement tests for a loan with non-midnight disbursement time.
+
+Regression: when disbursement_date has a non-midnight time component
+(e.g. 19:53), the settlement engine used datetime subtraction to count
+accrual days while the scheduler used date subtraction.  This caused a
+1-day shortfall in interest, preventing the first installment from being
+marked as fully covered.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, Warp
+
+
+@pytest.fixture
+def nonmidnight_loan():
+    """4-installment loan disbursed at 19:53 UTC (non-midnight)."""
+    return Loan(
+        Money("1011.02"),
+        InterestRate("180.96% a.a."),
+        [
+            date(2026, 4, 12),
+            date(2026, 5, 12),
+            date(2026, 6, 12),
+            date(2026, 7, 12),
+        ],
+        disbursement_date=datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("15% a.m."),
+    )
+
+
+def test_schedule_first_period_is_37_days(nonmidnight_loan):
+    """The schedule counts 37 calendar days from March 6 to April 12."""
+    schedule = nonmidnight_loan.get_original_schedule()
+    assert schedule[0].days_in_period == 37
+
+
+def test_settlement_interest_matches_schedule(nonmidnight_loan):
+    """Settlement interest for the first installment matches the schedule."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    assert settlement.interest_paid == Money("111.62")
+    assert settlement.allocations[0].interest_allocated == Money("111.62")
+
+    schedule = nonmidnight_loan.get_original_schedule()
+    assert schedule[0].interest_payment == Money("111.62")
+
+
+def test_first_installment_fully_covered(nonmidnight_loan):
+    """First installment is fully covered despite non-midnight disbursement."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    first = settlement.allocations[0]
+    assert first.principal_allocated == Money("206.14")
+    assert first.interest_allocated == Money("111.62")
+    assert first.mora_allocated == Money("0.00")
+    assert first.fine_allocated == Money("0.00")
+    assert first.is_fully_covered is True
+
+
+def test_settlement_totals(nonmidnight_loan):
+    """Settlement-level totals for the 800 payment."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    assert settlement.interest_paid == Money("111.62")
+    assert settlement.mora_paid == Money("0.00")
+    assert settlement.fine_paid == Money("0.00")
+    assert settlement.principal_paid == Money("688.38")
+    assert settlement.remaining_balance == Money("322.64")
+
+
+def test_allocation_count(nonmidnight_loan):
+    """Payment of 800 touches 3 of the 4 installments."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    assert len(settlement.allocations) == 3
+
+
+def test_second_installment_allocation(nonmidnight_loan):
+    """Second installment receives full scheduled principal, not fully covered."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    second = settlement.allocations[1]
+    assert second.principal_allocated == Money("246.43")
+    assert second.interest_allocated == Money("0.00")
+    assert second.is_fully_covered is False
+
+
+def test_third_installment_allocation(nonmidnight_loan):
+    """Third installment receives remaining principal."""
+    with Warp(nonmidnight_loan, datetime(2026, 3, 6, 19, 53, 0, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("800"))
+
+    third = settlement.allocations[2]
+    assert third.principal_allocated == Money("235.81")
+    assert third.interest_allocated == Money("0.00")
+    assert third.is_fully_covered is False


### PR DESCRIPTION
## Summary
- Fix day-count mismatch between the scheduler (date subtraction) and the settlement engine (datetime subtraction) that caused 1-day interest shortfall when `disbursement_date` has a non-midnight time component
- The first installment was never marked `is_fully_covered` in this scenario because settlement interest was lower than scheduled interest

## Changes
- Use `.date()` on both operands in `_compute_interest_snapshot`, `_build_installments_snapshot`, and `days_since_last_payment` to align with the scheduler's calendar-day convention
- Add 7 regression tests with a non-midnight disbursement (19:53 UTC) verifying exact allocation values and `is_fully_covered` on the first installment
- Update `knowledge/loan.md` with the fix details

## Test plan
- [x] All 1640 existing tests pass (no regressions — existing fixtures use midnight disbursement)
- [x] 7 new tests in `test_nonmidnight_disbursement.py` verify the fix
- [x] `pre-commit run --all-files` passes (ruff + black)