### PR TITLE
refactor: move loan engine modules into engines/ subpackage

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -1,11 +1,11 @@
 # Loan
 
-The `Loan` class is a facade that models a personal loan with daily-compounding interest, configurable schedulers, late-payment fines, and mora interest. It delegates to five focused components:
+The `Loan` class is a facade that models a personal loan with daily-compounding interest, configurable schedulers, late-payment fines, and mora interest. It delegates to five focused components, four of which live in the `engines/` subpackage:
 
-- **`InterestCalculator`** (`interest_calculator.py`) — stateless interest math (regular + mora split). Holds `interest_rate`, `mora_interest_rate`, `mora_strategy`.
-- **`FineTracker`** (`fine_tracker.py`) — fine state (`fines_applied: Dict[date, Money]`) and late-payment detection. Named constants for tolerance and window days.
-- **`PaymentLedger`** (`payment_ledger.py`) — records payments as tagged CashFlowItems in a shared `CashFlow`. Category tags like `{"interest", "settlement:1"}` replace offset-based grouping. Stores lightweight `SettlementSnapshot` per settlement (payment_date, days_in_period, beginning_balance, ending_balance).
-- **`SettlementEngine`** (`settlement_engine.py`) — pure computation of `Settlement` and `Installment` objects from ledger queries and the original schedule.
+- **`InterestCalculator`** (`engines/interest_calculator.py`) — stateless interest math (regular + mora split). Holds `interest_rate`, `mora_interest_rate`, `mora_strategy`.
+- **`FineTracker`** (`engines/fine_tracker.py`) — fine state (`fines_applied: Dict[date, Money]`) and late-payment detection. Named constants for tolerance and window days.
+- **`PaymentLedger`** (`engines/payment_ledger.py`) — records payments as tagged CashFlowItems in a shared `CashFlow`. Category tags like `{"interest", "settlement:1"}` replace offset-based grouping. Stores lightweight `SettlementSnapshot` per settlement (payment_date, days_in_period, beginning_balance, ending_balance).
+- **`SettlementEngine`** (`engines/settlement_engine.py`) — pure computation of `Settlement` and `Installment` objects from ledger queries and the original schedule.
 - **TVM functions** (`tvm.py`) — standalone `loan_present_value`, `loan_irr`, `loan_calculate_anticipation`. Eliminates circular imports between `loan` and `present_value`.
 
 ## Constructor Parameters

--- a/money_warp/loan/__init__.py
+++ b/money_warp/loan/__init__.py
@@ -1,8 +1,8 @@
 """Loan module for personal loan modeling with flexible payment schedules."""
 
-from .fine_tracker import FineTracker
+from .engines.fine_tracker import FineTracker
+from .engines.interest_calculator import InterestCalculator, MoraStrategy
 from .installment import Installment
-from .interest_calculator import InterestCalculator, MoraStrategy
 from .loan import Loan
 from .settlement import AnticipationResult, Settlement, SettlementAllocation
 

--- a/money_warp/loan/engines/__init__.py
+++ b/money_warp/loan/engines/__init__.py
@@ -1,0 +1,15 @@
+"""Computational engines for loan payment processing."""
+
+from .fine_tracker import FineTracker
+from .interest_calculator import InterestCalculator, MoraStrategy
+from .payment_ledger import PaymentLedger, SettlementSnapshot
+from .settlement_engine import SettlementEngine
+
+__all__ = [
+    "FineTracker",
+    "InterestCalculator",
+    "MoraStrategy",
+    "PaymentLedger",
+    "SettlementEngine",
+    "SettlementSnapshot",
+]

--- a/money_warp/loan/engines/fine_tracker.py
+++ b/money_warp/loan/engines/fine_tracker.py
@@ -3,11 +3,11 @@
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional
 
-from ..interest_rate import InterestRate
-from ..money import Money
-from ..scheduler import PaymentSchedule
-from ..time_context import TimeContext
-from ..tz import to_datetime
+from ...interest_rate import InterestRate
+from ...money import Money
+from ...scheduler import PaymentSchedule
+from ...time_context import TimeContext
+from ...tz import to_datetime
 
 _PAYMENT_CATEGORIES = frozenset({"principal", "interest", "fine"})
 _TOLERANCE = Money("0.01")

--- a/money_warp/loan/engines/interest_calculator.py
+++ b/money_warp/loan/engines/interest_calculator.py
@@ -4,8 +4,8 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Optional, Tuple
 
-from ..interest_rate import InterestRate
-from ..money import Money
+from ...interest_rate import InterestRate
+from ...money import Money
 
 
 class MoraStrategy(Enum):

--- a/money_warp/loan/engines/payment_ledger.py
+++ b/money_warp/loan/engines/payment_ledger.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
-from ..cash_flow import CashFlow, CashFlowItem
-from ..money import Money
-from ..scheduler import PaymentScheduleEntry
-from ..time_context import TimeContext
+from ...cash_flow import CashFlow, CashFlowItem
+from ...money import Money
+from ...scheduler import PaymentScheduleEntry
+from ...time_context import TimeContext
 
 _ITEM_CATEGORIES = ("fine", "interest", "mora_interest", "principal")
 

--- a/money_warp/loan/engines/settlement_engine.py
+++ b/money_warp/loan/engines/settlement_engine.py
@@ -3,13 +3,13 @@
 from datetime import date, datetime
 from typing import Dict, List, Optional
 
-from ..money import Money
-from ..scheduler import PaymentSchedule
-from ..tz import to_datetime
-from .installment import Installment
+from ...money import Money
+from ...scheduler import PaymentSchedule
+from ...tz import to_datetime
+from ..installment import Installment
+from ..settlement import Settlement, SettlementAllocation
 from .interest_calculator import InterestCalculator
 from .payment_ledger import PaymentLedger
-from .settlement import Settlement, SettlementAllocation
 
 _COVERAGE_TOLERANCE = Money("0.01")
 

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -11,12 +11,12 @@ from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, Pr
 from ..tax.base import BaseTax, TaxResult
 from ..time_context import TimeContext
 from ..tz import to_datetime, tz_aware
-from .fine_tracker import FineTracker, _get_expected_payment
+from .engines.fine_tracker import FineTracker, _get_expected_payment
+from .engines.interest_calculator import InterestCalculator, MoraStrategy
+from .engines.payment_ledger import PaymentLedger
+from .engines.settlement_engine import SettlementEngine
 from .installment import Installment
-from .interest_calculator import InterestCalculator, MoraStrategy
-from .payment_ledger import PaymentLedger
 from .settlement import AnticipationResult, Settlement, SettlementAllocation
-from .settlement_engine import SettlementEngine
 from .tvm import loan_calculate_anticipation, loan_irr, loan_present_value
 
 


### PR DESCRIPTION
## Summary
- Move `fine_tracker.py`, `interest_calculator.py`, `payment_ledger.py`, and `settlement_engine.py` into a new `money_warp/loan/engines/` subpackage for better organization
- Update all relative imports in moved files, `loan/__init__.py`, and `loan/loan.py`
- Add `engines/__init__.py` with public symbol re-exports

## Changes
- Created `money_warp/loan/engines/__init__.py` re-exporting `FineTracker`, `InterestCalculator`, `MoraStrategy`, `PaymentLedger`, `SettlementEngine`, `SettlementSnapshot`
- Adjusted relative imports: `..module` → `...module` for parent-package refs in moved files; `..installment` / `..settlement` for sibling loan-level modules referenced from `settlement_engine.py`
- Updated `knowledge/loan.md` to reflect new file paths

## Test plan
- [x] All 1652 existing tests pass (`poetry run pytest`)
- [x] Zero linter errors on edited files
- [x] Public API unchanged — `from money_warp.loan import FineTracker` still works