### PR TITLE
fix: allocate payments per-installment instead of per-component across loan

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -71,11 +71,14 @@ These are distinct concepts:
 
 ### Payment Allocation
 
-All payment methods allocate funds in strict priority order:
+All payment methods allocate funds **per-installment** in strict sequential order. Within each installment, the priority is:
 
-1. **Outstanding fines** first
-2. **Accrued interest** (daily-compounded since last payment, up to `interest_date`; split into regular + mora when late)
-3. **Principal** remainder
+1. **Fine** for this installment
+2. **Mora interest** for this installment
+3. **Regular interest** for this installment
+4. **Principal** for this installment
+
+Installment 1 is fully addressed before installment 2 receives anything. This means inst 1's mora interest is paid before inst 2's fine — the allocation order applies *within* each installment, not across all installments at once.
 
 Interest days and principal balance are pre-computed at the top of `record_payment` using `payment_date` as the filter for existing payments, before any internal state is mutated.
 
@@ -240,7 +243,7 @@ Field semantics:
 - `*_paid` fields are aggregated totals from all settlement allocations attributed to this installment.
 - `allocations` is the reverse view of Settlement: all `SettlementAllocation`s that touched this installment.
 - Created via `Installment.from_schedule_entry(entry, allocations, expected_mora, expected_fine)`.
-- `allocate(fine, mora, interest, principal)` — distributes four component pools against remaining obligations, returns `(SettlementAllocation, remaining_fine, remaining_mora, remaining_interest, remaining_principal)`. Used by `_build_settlement_allocations` to walk through installments in order.
+- `allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` — allocates from a single remaining payment amount in priority order (fine → mora → interest → principal). Each component is capped by both the installment's remaining obligation and the running cap. Returns `(SettlementAllocation, updated_remaining, updated_fine_remaining, updated_mora_remaining, updated_interest_remaining)`. Used by `SettlementEngine.allocate_payment_per_installment` to walk through installments in order.
 - `PaymentScheduleEntry` remains the internal scheduler data structure. `Installment` is the public-facing API.
 
 ### Settlement (`loan.settlements`, returned by payment methods)
@@ -256,12 +259,16 @@ Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_pa
 
 #### Per-Installment Allocation
 
-Each component (fine, mora, interest, principal) is distributed as a **separate pool** across installments in order. The four pools come from `_allocate_payment` (loan-level totals). Each installment's `allocate()` method caps each component at the installment's remaining obligation for that component:
+Payments are allocated **per-installment in strict sequential order**. Within each installment the priority is fine → mora → interest → principal. Installment 1's obligations are fully addressed before installment 2 receives anything.
 
-1. Build an installment snapshot (`_build_installments_snapshot`) reflecting all prior settlement allocations — avoids circular dependency with `self.settlements`.
-2. For each installment in order, `Installment.allocate(fine_pool, mora_pool, interest_pool, principal_pool)` takes what's owed per component, returns the allocation and remaining pools.
-3. Fully-paid installments consume nothing and are skipped.
-4. When the loan is fully paid off (ending_balance ≈ 0), installments whose principal is fully covered are marked `is_fully_covered` even if their scheduled interest wasn't allocated from this specific payment.
+The allocation is performed by `SettlementEngine.allocate_payment_per_installment(amount, installments, ending_balance, fine_cap, interest_cap, mora_cap)`. The caps bound the total that may be allocated to each non-principal category — during live allocation they come from loan-level accrual (preserving early-payment discounts); during reconstruction they match recorded CashFlowItem totals.
+
+1. Build an installment snapshot (`_build_pre_settlement_installments`) reflecting all prior settlement allocations — avoids circular dependency with `self.settlements`.
+2. For each installment in order, `Installment.allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` processes fine → mora → interest → principal sequentially, each capped by both the installment's remaining obligation and the running cap.
+3. Principal allocation is further capped by reserving funds for later installments' interest and mora: `available_for_principal = remaining - (interest_remaining + mora_remaining)`.
+4. After the installment loop, any remaining cap amounts (interest/mora spill from schedule rounding) are attributed to their respective totals, not to principal.
+5. Sub-cent allocations (< 0.01) are included in the component totals for precision but excluded from the `allocations` list to avoid dust entries.
+6. When the loan is fully paid off (ending_balance ≈ 0), installments whose principal is fully covered are marked `is_fully_covered`.
 
 The `settlements` property maintains a running `allocations_by_number` dict so each settlement sees the cumulative allocation state from prior settlements.
 
@@ -361,3 +368,25 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 **Fix:** `expected_mora = prior_mora + accrued_mora` — sum the mora already allocated from prior settlements before adding the newly accrued amount. This makes the `i == covered` branch cumulative, matching the pattern already used for fully-covered installments (`i < covered`).
 
 **Lesson:** When a derived quantity (expected_mora) participates in a subtraction against a cumulative counter (mora_paid), the derived quantity must also be cumulative. Mixing period-level and cumulative values in the same expression produces silent under-distribution.
+
+### Payment allocation order was loan-level, not per-installment (fixed 2026-03-20)
+
+**Symptom:** When all 6 installments were overdue and the borrower made a partial payment (R$ 382.97), fines were spread across all 6 installments first (R$ 45.90), then mora interest (R$ 250.49), then regular interest (R$ 86.62) — leaving nothing for principal. The payment "disappeared" into penalties without retiring any principal.
+
+**Root cause:** The allocation logic treated each component (fine, mora, interest, principal) as a **separate pool** distributed across all installments. This meant installment 6's fine was paid before installment 1's mora interest, violating the intended priority.
+
+**Fix:** Rewrote allocation to be strictly **per-installment sequential**. `SettlementEngine.allocate_payment_per_installment` walks installments in order. Within each, `Installment.allocate_from_payment` applies fine → mora → interest → principal. Only after inst 1 is fully addressed does inst 2 receive anything. Running caps (`fine_remaining`, `mora_remaining`, `interest_remaining`) prevent over-allocation beyond loan-level accruals. The same method is used for both live allocation and reconstruction (ensuring consistency).
+
+**Lesson:** When allocation priority is defined as "fine before mora before interest before principal," clarify whether that order applies *across the loan* or *within each installment*. The per-installment interpretation is correct for Brazilian lending: installment 1's mora interest is more urgent than installment 2's fine.
+
+### Sub-cent precision loss in allocation loop (fixed 2026-03-20)
+
+**Symptom:** After making all scheduled payments on a 12-installment loan, the balance was R$ 5.17 instead of zero. SA integration tests showed a ~0.001 discrepancy between Python replay and stored settlement balances, cascading to ~0.01 per settlement.
+
+**Root cause:** `Money.is_zero()` and `Money.is_positive()` use `real_amount` (rounded to 2 decimal places). When the PriceScheduler rounds interest to 2dp but accrued interest has full precision, the difference (e.g., 0.00132) creates a sub-cent remainder. The allocation loop's `remaining.is_zero()` check treated this as zero and broke early. The spill logic's `remaining.is_positive()` also treated it as non-positive. The sub-cent amount was silently lost — not attributed to interest, principal, or anything. Over 12 installments the losses compounded to R$ 5.17.
+
+**Fix:** Use `raw_amount` comparisons in the allocation loop: `not remaining.raw_amount` instead of `remaining.is_zero()`, `remaining.raw_amount > 0` instead of `remaining.is_positive()`, and `allocation.total_allocated.raw_amount <= 0` instead of `not allocation.total_allocated.is_positive()`. This preserves full precision for accounting while keeping `Money`'s 2dp semantics for business display.
+
+Sub-cent allocations (where `total_allocated.real_amount` rounds to zero) are included in the component totals but excluded from the `allocations` list. This ensures correct totals without creating dust entries in the per-installment breakdown.
+
+**Lesson:** `Money`'s `real_amount`-based comparisons (`is_zero`, `is_positive`, `>`, `<`) are correct for business display but dangerous in accounting loops where sub-cent values compound. Use `raw_amount` in tight allocation loops. The allocation pipeline has two audiences: the CashFlowItem totals (need full precision) and the per-installment breakdown (display-level precision is fine).

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -50,39 +50,55 @@ class Installment:
         """Whether this installment has been fully settled (within rounding tolerance)."""
         return self.balance <= _COVERAGE_TOLERANCE
 
-    def allocate(
+    def allocate_from_payment(
         self,
-        available_fine: Money,
-        available_mora: Money,
-        available_interest: Money,
-        available_principal: Money,
+        remaining: Money,
+        fine_remaining: Money,
+        mora_remaining: Money,
+        interest_remaining: Money,
     ) -> Tuple[SettlementAllocation, Money, Money, Money, Money]:
-        """Allocate available component pools against this installment.
+        """Allocate from a single payment amount in priority order.
 
-        Each component is distributed independently, capped by both the
-        remaining obligation for that component and the available pool.
+        Processes fine -> mora -> interest -> principal sequentially,
+        each capped by both the installment's remaining obligation and
+        the corresponding running cap.
+
+        The running caps prevent over-allocation: during live allocation
+        they reflect the loan-level accrual (e.g. the interest discount
+        for early payments); during reconstruction they match the
+        recorded CashFlowItem totals.
 
         Args:
-            available_fine: Remaining fine pool from the payment.
-            available_mora: Remaining mora pool from the payment.
-            available_interest: Remaining interest pool from the payment.
-            available_principal: Remaining principal pool from the payment.
+            remaining: Unallocated portion of the payment.
+            fine_remaining: Remaining fine cap across all installments.
+            mora_remaining: Remaining mora cap across all installments.
+            interest_remaining: Remaining interest cap across all installments.
 
         Returns:
-            A tuple of (SettlementAllocation, remaining_fine, remaining_mora,
-            remaining_interest, remaining_principal).
+            ``(SettlementAllocation, updated_remaining,
+            updated_fine_remaining, updated_mora_remaining,
+            updated_interest_remaining)``.
         """
         fine_owed = self.expected_fine - self.fine_paid
-        fine_alloc = Money(min(fine_owed.raw_amount, available_fine.raw_amount))
+        fine_alloc = Money(min(fine_owed.raw_amount, remaining.raw_amount, fine_remaining.raw_amount))
+        remaining = remaining - fine_alloc
+        fine_remaining = fine_remaining - fine_alloc
 
         mora_owed = self.expected_mora - self.mora_paid
-        mora_alloc = Money(min(mora_owed.raw_amount, available_mora.raw_amount))
+        mora_alloc = Money(min(mora_owed.raw_amount, remaining.raw_amount, mora_remaining.raw_amount))
+        remaining = remaining - mora_alloc
+        mora_remaining = mora_remaining - mora_alloc
 
         interest_owed = self.expected_interest - self.interest_paid
-        interest_alloc = Money(min(interest_owed.raw_amount, available_interest.raw_amount))
+        interest_alloc = Money(min(interest_owed.raw_amount, remaining.raw_amount, interest_remaining.raw_amount))
+        remaining = remaining - interest_alloc
+        interest_remaining = interest_remaining - interest_alloc
 
         principal_owed = self.expected_principal - self.principal_paid
-        principal_alloc = Money(min(principal_owed.raw_amount, available_principal.raw_amount))
+        reserved = interest_remaining + mora_remaining
+        available_for_principal = remaining - reserved if remaining.raw_amount > reserved.raw_amount else Money.zero()
+        principal_alloc = Money(min(principal_owed.raw_amount, available_for_principal.raw_amount))
+        remaining = remaining - principal_alloc
 
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
         is_covered = total >= (self.balance - _COVERAGE_TOLERANCE)
@@ -95,13 +111,7 @@ class Installment:
             fine_allocated=fine_alloc,
             is_fully_covered=is_covered,
         )
-        return (
-            allocation,
-            available_fine - fine_alloc,
-            available_mora - mora_alloc,
-            available_interest - interest_alloc,
-            available_principal - principal_alloc,
-        )
+        return allocation, remaining, fine_remaining, mora_remaining, interest_remaining
 
     @classmethod
     def from_schedule_entry(

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -432,7 +432,9 @@ class Loan:
         """
         Record an actual payment made on the loan with automatic allocation.
 
-        Payment allocation priority: Fines -> Interest -> Principal
+        Payment allocation priority (per installment):
+        Fine -> Mora Interest -> Interest -> Principal.
+        Installment 1 is fully addressed before installment 2.
 
         Args:
             amount: Total payment amount (positive value)
@@ -463,23 +465,27 @@ class Loan:
         except ValueError:
             next_due = None
 
-        (
-            settlement_num,
-            fine_paid,
-            interest_paid,
-            mora_paid,
-            principal_paid,
-            ending_balance,
-        ) = self._ledger.allocate_payment(
-            amount,
-            payment_date,
-            days,
-            principal_balance,
-            description,
-            self._interest,
-            self.fine_balance,
-            due_date=next_due,
-            last_payment_date=last_pay_date,
+        interest_accrued, mora_accrued = self._compute_accrued_interest(
+            days, principal_balance, next_due, last_pay_date
+        )
+
+        installments = self._build_pre_settlement_installments(
+            principal_balance, payment_date, last_pay_date
+        )
+
+        ending_balance = principal_balance
+        fine_paid, mora_paid, interest_paid, principal_paid, _ = (
+            SettlementEngine.allocate_payment_per_installment(
+                amount, installments, ending_balance,
+                fine_cap=self.fine_balance,
+                interest_cap=interest_accrued,
+                mora_cap=mora_accrued,
+            )
+        )
+
+        settlement_num, ending_balance = self._ledger.record_allocation(
+            fine_paid, mora_paid, interest_paid, principal_paid,
+            payment_date, days, principal_balance, description,
         )
 
         allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
@@ -489,6 +495,33 @@ class Loan:
                 allocs_by_number.setdefault(a.installment_number, []).append(a)
 
         return self._compute_settlement(settlement_num - 1, allocs_by_number)
+
+    def _build_pre_settlement_installments(
+        self,
+        principal_balance: Money,
+        payment_date: datetime,
+        last_payment_date: Optional[datetime],
+    ) -> List[Installment]:
+        """Build an installment snapshot reflecting all prior settlements.
+
+        Called *before* a new payment is recorded so that
+        :meth:`SettlementEngine.allocate_payment_per_installment` can
+        determine per-installment obligations.
+        """
+        allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+        for i in range(self._ledger.settlement_count):
+            prev = self._compute_settlement(i, allocs_by_number)
+            for a in prev.allocations:
+                allocs_by_number.setdefault(a.installment_number, []).append(a)
+
+        return self._settlements_engine.build_installments_snapshot(
+            allocs_by_number,
+            principal_balance,
+            payment_date,
+            self.get_original_schedule(),
+            self.fines_applied,
+            last_payment_date=last_payment_date,
+        )
 
     def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
         """

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -469,23 +469,27 @@ class Loan:
             days, principal_balance, next_due, last_pay_date
         )
 
-        installments = self._build_pre_settlement_installments(
-            principal_balance, payment_date, last_pay_date
-        )
+        installments = self._build_pre_settlement_installments(principal_balance, payment_date, last_pay_date)
 
         ending_balance = principal_balance
-        fine_paid, mora_paid, interest_paid, principal_paid, _ = (
-            SettlementEngine.allocate_payment_per_installment(
-                amount, installments, ending_balance,
-                fine_cap=self.fine_balance,
-                interest_cap=interest_accrued,
-                mora_cap=mora_accrued,
-            )
+        fine_paid, mora_paid, interest_paid, principal_paid, _ = SettlementEngine.allocate_payment_per_installment(
+            amount,
+            installments,
+            ending_balance,
+            fine_cap=self.fine_balance,
+            interest_cap=interest_accrued,
+            mora_cap=mora_accrued,
         )
 
         settlement_num, ending_balance = self._ledger.record_allocation(
-            fine_paid, mora_paid, interest_paid, principal_paid,
-            payment_date, days, principal_balance, description,
+            fine_paid,
+            mora_paid,
+            interest_paid,
+            principal_paid,
+            payment_date,
+            days,
+            principal_balance,
+            description,
         )
 
         allocs_by_number: Dict[int, List[SettlementAllocation]] = {}

--- a/money_warp/loan/payment_ledger.py
+++ b/money_warp/loan/payment_ledger.py
@@ -1,14 +1,13 @@
 """Payment recording and querying over a shared CashFlow."""
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 from ..cash_flow import CashFlow, CashFlowItem
 from ..money import Money
 from ..scheduler import PaymentScheduleEntry
 from ..time_context import TimeContext
-from .interest_calculator import InterestCalculator
 
 _ITEM_CATEGORIES = ("fine", "interest", "mora_interest", "principal")
 
@@ -160,36 +159,34 @@ class PaymentLedger:
         return days, principal_balance, last_pay_date
 
     # ------------------------------------------------------------------
-    # Payment allocation  (replaces Loan._allocate_payment)
+    # Payment recording
     # ------------------------------------------------------------------
 
-    def allocate_payment(
+    def record_allocation(
         self,
-        amount: Money,
+        fine_paid: Money,
+        mora_paid: Money,
+        interest_paid: Money,
+        principal_paid: Money,
         payment_date: datetime,
         days: int,
         principal_balance: Money,
-        description: Optional[str],
-        interest_calc: InterestCalculator,
-        fine_balance: Money,
-        due_date: Optional[date] = None,
-        last_payment_date: Optional[datetime] = None,
-    ) -> Tuple[int, Money, Money, Money, Money, Money]:
-        """Allocate a payment and write tagged CashFlowItems to the shared CashFlow.
+        description: Optional[str] = None,
+    ) -> Tuple[int, Money]:
+        """Write pre-computed allocation totals as tagged CashFlowItems.
 
-        Returns (settlement_number, fine_paid, interest_paid, mora_paid,
-        principal_paid, ending_balance).
+        This is a pure recording method — all allocation decisions have
+        already been made by
+        :meth:`SettlementEngine.allocate_payment_per_installment`.
+
+        Returns ``(settlement_number, ending_balance)``.
         """
         self._settlement_count += 1
         settlement_num = self._settlement_count
         tag = f"settlement:{settlement_num}"
-
-        remaining = amount
         label = description or f"Payment on {payment_date.date()}"
 
-        fine_paid = Money.zero()
-        if fine_balance.is_positive() and remaining.is_positive():
-            fine_paid = Money(min(fine_balance.raw_amount, remaining.raw_amount))
+        if fine_paid.is_positive():
             self._cf.add_item(
                 CashFlowItem(
                     fine_paid,
@@ -199,53 +196,30 @@ class PaymentLedger:
                     time_context=self._time_ctx,
                 )
             )
-            remaining = remaining - fine_paid
 
-        interest_paid = Money.zero()
-        mora_paid = Money.zero()
-        if remaining.is_positive() and principal_balance.is_positive() and days > 0:
-            regular_accrued, mora_accrued = interest_calc.compute_accrued_interest(
-                days, principal_balance, due_date, last_payment_date
+        if interest_paid.is_positive():
+            self._cf.add_item(
+                CashFlowItem(
+                    interest_paid,
+                    payment_date,
+                    f"Interest portion - {label}",
+                    frozenset({"interest", tag}),
+                    time_context=self._time_ctx,
+                )
             )
-            total_accrued = regular_accrued + mora_accrued
-            total_interest_to_pay = Money(min(total_accrued.raw_amount, remaining.raw_amount))
 
-            if total_interest_to_pay.is_positive():
-                if total_interest_to_pay >= total_accrued:
-                    regular_amount, mora_amount = regular_accrued, mora_accrued
-                else:
-                    regular_amount = Money(min(regular_accrued.raw_amount, total_interest_to_pay.raw_amount))
-                    mora_amount = total_interest_to_pay - regular_amount
+        if mora_paid.is_positive():
+            self._cf.add_item(
+                CashFlowItem(
+                    mora_paid,
+                    payment_date,
+                    f"Mora interest - {label}",
+                    frozenset({"mora_interest", tag}),
+                    time_context=self._time_ctx,
+                )
+            )
 
-                if regular_amount.is_positive():
-                    self._cf.add_item(
-                        CashFlowItem(
-                            regular_amount,
-                            payment_date,
-                            f"Interest portion - {label}",
-                            frozenset({"interest", tag}),
-                            time_context=self._time_ctx,
-                        )
-                    )
-                    interest_paid = regular_amount
-
-                if mora_amount.is_positive():
-                    self._cf.add_item(
-                        CashFlowItem(
-                            mora_amount,
-                            payment_date,
-                            f"Mora interest - {label}",
-                            frozenset({"mora_interest", tag}),
-                            time_context=self._time_ctx,
-                        )
-                    )
-                    mora_paid = mora_amount
-
-                remaining = remaining - interest_paid - mora_paid
-
-        principal_paid = Money.zero()
-        if remaining.is_positive():
-            principal_paid = remaining
+        if principal_paid.is_positive():
             self._cf.add_item(
                 CashFlowItem(
                     principal_paid,
@@ -269,4 +243,4 @@ class PaymentLedger:
             )
         )
 
-        return settlement_num, fine_paid, interest_paid, mora_paid, principal_paid, ending_balance
+        return settlement_num, ending_balance

--- a/money_warp/loan/settlement_engine.py
+++ b/money_warp/loan/settlement_engine.py
@@ -95,10 +95,11 @@ class SettlementEngine:
             if not remaining.raw_amount:
                 break
 
-            allocation, remaining, fine_remaining, mora_remaining, interest_remaining = (
-                inst.allocate_from_payment(
-                    remaining, fine_remaining, mora_remaining, interest_remaining,
-                )
+            allocation, remaining, fine_remaining, mora_remaining, interest_remaining = inst.allocate_from_payment(
+                remaining,
+                fine_remaining,
+                mora_remaining,
+                interest_remaining,
             )
 
             if allocation.total_allocated.raw_amount <= 0:

--- a/money_warp/loan/settlement_engine.py
+++ b/money_warp/loan/settlement_engine.py
@@ -47,6 +47,100 @@ class SettlementEngine:
         return covered
 
     # ------------------------------------------------------------------
+    # Per-installment payment allocation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def allocate_payment_per_installment(
+        amount: Money,
+        installments: List[Installment],
+        ending_balance: Money,
+        fine_cap: Money,
+        interest_cap: Money,
+        mora_cap: Money,
+    ) -> tuple:
+        """Allocate a payment across installments in priority order.
+
+        Each installment is processed sequentially.  Within each
+        installment the priority is fine -> mora -> interest -> principal.
+        Installment 1's obligations are fully addressed before
+        installment 2 receives anything.
+
+        *fine_cap*, *interest_cap*, and *mora_cap* bound the total
+        amount that may be allocated to each category.  During live
+        allocation these come from the loan-level accrual (preserving
+        the early-payment discount).  During reconstruction they match
+        the recorded CashFlowItem totals.
+
+        Any payment remainder after all installment obligations are met
+        is attributed to principal (overpayment).
+
+        Returns:
+            ``(fine_total, mora_total, interest_total, principal_total,
+            allocations)`` where *allocations* is a list of
+            :class:`SettlementAllocation`.
+        """
+        loan_fully_paid = ending_balance <= _COVERAGE_TOLERANCE
+        remaining = amount
+        fine_remaining = fine_cap
+        mora_remaining = mora_cap
+        interest_remaining = interest_cap
+        fine_total = Money.zero()
+        mora_total = Money.zero()
+        interest_total = Money.zero()
+        principal_total = Money.zero()
+        allocations: List[SettlementAllocation] = []
+
+        for inst in installments:
+            if not remaining.raw_amount:
+                break
+
+            allocation, remaining, fine_remaining, mora_remaining, interest_remaining = (
+                inst.allocate_from_payment(
+                    remaining, fine_remaining, mora_remaining, interest_remaining,
+                )
+            )
+
+            if allocation.total_allocated.raw_amount <= 0:
+                continue
+
+            fine_total = fine_total + allocation.fine_allocated
+            mora_total = mora_total + allocation.mora_allocated
+            interest_total = interest_total + allocation.interest_allocated
+            principal_total = principal_total + allocation.principal_allocated
+
+            if not allocation.total_allocated.is_positive():
+                continue
+
+            if loan_fully_paid and not allocation.is_fully_covered:
+                principal_owed = inst.expected_principal - inst.principal_paid
+                if allocation.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
+                    allocation = SettlementAllocation(
+                        installment_number=allocation.installment_number,
+                        principal_allocated=allocation.principal_allocated,
+                        interest_allocated=allocation.interest_allocated,
+                        mora_allocated=allocation.mora_allocated,
+                        fine_allocated=allocation.fine_allocated,
+                        is_fully_covered=True,
+                    )
+
+            allocations.append(allocation)
+
+        if remaining.raw_amount > 0:
+            mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
+            remaining = remaining - mora_spill
+            mora_total = mora_total + mora_spill
+
+            interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
+            remaining = remaining - interest_spill
+            interest_total = interest_total + interest_spill
+
+            if remaining.raw_amount > 0:
+                principal_total = principal_total + remaining
+
+        return fine_total, mora_total, interest_total, principal_total, allocations
+
+    # ------------------------------------------------------------------
     # Settlement construction
     # ------------------------------------------------------------------
 
@@ -118,52 +212,22 @@ class SettlementEngine:
         principal_paid: Money,
         ending_balance: Money,
     ) -> List[SettlementAllocation]:
-        """Distribute a payment's components across installments."""
-        loan_fully_paid = ending_balance <= _COVERAGE_TOLERANCE
-        remaining_fine = fine_paid
-        remaining_mora = mora_paid
-        remaining_interest = interest_paid
-        remaining_principal = principal_paid
+        """Reconstruct per-installment allocations from recorded totals.
 
-        allocations: List[SettlementAllocation] = []
-        for inst in installments:
-            if (
-                remaining_fine.is_zero()
-                and remaining_mora.is_zero()
-                and remaining_interest.is_zero()
-                and remaining_principal.is_zero()
-            ):
-                break
-
-            allocation, remaining_fine, remaining_mora, remaining_interest, remaining_principal = inst.allocate(
-                remaining_fine,
-                remaining_mora,
-                remaining_interest,
-                remaining_principal,
-            )
-            total = (
-                allocation.principal_allocated
-                + allocation.interest_allocated
-                + allocation.mora_allocated
-                + allocation.fine_allocated
-            )
-            if not total.is_positive():
-                continue
-
-            if loan_fully_paid and not allocation.is_fully_covered:
-                principal_owed = inst.expected_principal - inst.principal_paid
-                if allocation.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
-                    allocation = SettlementAllocation(
-                        installment_number=allocation.installment_number,
-                        principal_allocated=allocation.principal_allocated,
-                        interest_allocated=allocation.interest_allocated,
-                        mora_allocated=allocation.mora_allocated,
-                        fine_allocated=allocation.fine_allocated,
-                        is_fully_covered=True,
-                    )
-
-            allocations.append(allocation)
-
+        Uses the same :meth:`allocate_payment_per_installment` logic so
+        that reconstruction and live allocation are always consistent.
+        The recorded totals serve as caps so that fines/interest/mora
+        applied by *later* payments don't leak into earlier settlements.
+        """
+        payment_amount = fine_paid + mora_paid + interest_paid + principal_paid
+        _, _, _, _, allocations = self.allocate_payment_per_installment(
+            payment_amount,
+            installments,
+            ending_balance,
+            fine_cap=fine_paid,
+            interest_cap=interest_paid,
+            mora_cap=mora_paid,
+        )
         return allocations
 
     def build_installments_snapshot(

--- a/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
+++ b/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
@@ -6,7 +6,7 @@ interest.  The correct behaviour is to process each installment sequentially:
 fine -> mora -> interest -> principal for inst 1 BEFORE any allocation to inst 2.
 
 Scenario:
-  - 6-installment loan (Mar–Aug 2025), all overdue by Aug 15
+  - 6-installment loan (Mar-Aug 2025), all overdue by Aug 15
   - Single partial payment equal to one scheduled installment amount (354.34)
   - Inst 1 should absorb fine, mora, interest, and partial principal
   - Inst 2+ should receive NOTHING because inst 1 was not fully settled

--- a/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
+++ b/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
@@ -1,0 +1,103 @@
+"""Settlement tests for per-installment allocation when all installments are overdue.
+
+Regression test for the original bug: when ALL installments are overdue, the
+old code would spread fines across all 6 installments before touching mora or
+interest.  The correct behaviour is to process each installment sequentially:
+fine -> mora -> interest -> principal for inst 1 BEFORE any allocation to inst 2.
+
+Scenario:
+  - 6-installment loan (Mar–Aug 2025), all overdue by Aug 15
+  - Single partial payment equal to one scheduled installment amount (354.34)
+  - Inst 1 should absorb fine, mora, interest, and partial principal
+  - Inst 2+ should receive NOTHING because inst 1 was not fully settled
+
+This proves that inst 1's mora interest takes priority over inst 2's fine.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, MoraStrategy, Warp
+
+
+@pytest.fixture
+def all_overdue_loan():
+    """6-installment loan where every due date is past."""
+    return Loan(
+        Money("2000"),
+        InterestRate("24% annual"),
+        [
+            date(2025, 3, 1),
+            date(2025, 4, 1),
+            date(2025, 5, 1),
+            date(2025, 6, 1),
+            date(2025, 7, 1),
+            date(2025, 8, 1),
+        ],
+        disbursement_date=datetime(2025, 2, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("2% annual"),
+        grace_period_days=0,
+        mora_interest_rate=InterestRate("12% annual"),
+        mora_strategy=MoraStrategy.COMPOUND,
+    )
+
+
+@pytest.fixture
+def overdue_settlement(all_overdue_loan):
+    """Pay one scheduled installment amount when everything is overdue."""
+    payment_date = datetime(2025, 8, 15, tzinfo=timezone.utc)
+    with Warp(all_overdue_loan, payment_date) as warped:
+        settlement = warped.record_payment(Money("354.34"), payment_date)
+        return warped, settlement
+
+
+def test_settlement_fine_paid(overdue_settlement):
+    """Only inst 1's fine (7.09) is paid — not all 6 overdue fines."""
+    _, s = overdue_settlement
+    assert s.fine_paid == Money("7.09")
+
+
+def test_settlement_mora_paid(overdue_settlement):
+    """Full accrued mora goes to inst 1."""
+    _, s = overdue_settlement
+    assert s.mora_paid == Money("108.21")
+
+
+def test_settlement_interest_paid(overdue_settlement):
+    _, s = overdue_settlement
+    assert s.interest_paid == Money("33.28")
+
+
+def test_settlement_principal_paid(overdue_settlement):
+    """The remainder after fine + mora + interest goes to principal."""
+    _, s = overdue_settlement
+    assert s.principal_paid == Money("205.77")
+
+
+def test_settlement_remaining_balance(overdue_settlement):
+    _, s = overdue_settlement
+    assert s.remaining_balance == Money("1794.23")
+
+
+def test_only_first_installment_receives_allocation(overdue_settlement):
+    """The per-installment order means only inst 1 gets anything."""
+    _, s = overdue_settlement
+    assert len(s.allocations) == 1
+    assert s.allocations[0].installment_number == 1
+
+
+def test_first_installment_allocation_breakdown(overdue_settlement):
+    _, s = overdue_settlement
+    a = s.allocations[0]
+    assert a.fine_allocated == Money("7.09")
+    assert a.mora_allocated == Money("108.21")
+    assert a.interest_allocated == Money("33.28")
+    assert a.principal_allocated == Money("205.77")
+    assert a.is_fully_covered is False
+
+
+def test_fine_balance_after_payment(overdue_settlement):
+    """Five installments' fines remain unpaid."""
+    loan, _ = overdue_settlement
+    assert loan.fine_balance == Money("35.43")

--- a/tests/loan/settlements/test_allocation_completeness.py
+++ b/tests/loan/settlements/test_allocation_completeness.py
@@ -185,7 +185,6 @@ def test_multiple_sequential_payments_all_fully_allocated(
         )
 
         with Warp(loan, due_date_dt) as warped:
-
             amount = Money(
                 str((warped.current_balance.raw_amount * Decimal(str(fractions[i]))).quantize(Decimal("0.01")))
             )


### PR DESCRIPTION
## Summary

- **Rewrote payment allocation to be strictly per-installment sequential.** Previously, each component (fine, mora, interest, principal) was distributed as a separate pool across all installments — installment 6's fine was paid before installment 1's mora. Now, within each installment the priority is fine → mora → interest → principal, and installment N is fully addressed before installment N+1 receives anything.
- **Fixed sub-cent precision loss** in the allocation loop by using `raw_amount` comparisons instead of `Money`'s 2dp-rounded `is_zero()`/`is_positive()`, which silently dropped sub-cent remainders that compounded to ~R$5 over 12 installments.
- **Unified live allocation and reconstruction** — `build_settlement_allocations` now delegates to the same `allocate_payment_per_installment` method, ensuring consistency between `record_payment` and the `settlements` property.

### Key changes

| File | What changed |
|---|---|
| `installment.py` | Replaced `allocate()` (four separate pools) with `allocate_from_payment()` (single remaining amount, per-installment priority) |
| `settlement_engine.py` | Added `allocate_payment_per_installment()` static method; `build_settlement_allocations` now delegates to it |
| `payment_ledger.py` | Simplified `record_allocation` to just record pre-computed totals (returns `(num, ending_balance)` only) |
| `loan.py` | Updated `record_payment` to call `allocate_payment_per_installment` first, then hand totals to ledger; added `_build_pre_settlement_installments` |
| `knowledge/loan.md` | Documented the design change and two key learnings |

## Test plan

- [x] New regression test `test_all_overdue_per_installment.py` — 6-installment loan, all overdue, partial payment goes to inst 1 only
- [x] All 1652 existing tests pass (including SA integration, hypothesis, and all settlement scenarios)