### PR TITLE
refactor: simplify Loan by removing thin delegation methods

### DIFF
--- a/docs/examples/time_machine.md
+++ b/docs/examples/time_machine.md
@@ -33,7 +33,7 @@ with Warp(loan, datetime(2024, 1, 20)) as past_loan:
     print(f"Balance on Jan 20: {past_loan.current_balance}")
     # Balance on Jan 20: 9,500.00 (approximately, only first payment applied)
     
-    print(f"Payments made by Jan 20: {len(past_loan._actual_payments)}")
+    print(f"Payments made by Jan 20: {len(past_loan._ledger.actual_payment_items)}")
     # Payments made by Jan 20: 2 (interest + principal portions of first payment)
     
     # Time-dependent calculations use the warped date
@@ -54,7 +54,7 @@ with Warp(loan, datetime(2025, 6, 15)) as future_loan:
     print(f"Balance in June 2025: {future_loan.current_balance}")
     # Balance in June 2025: 8,200.00 (same as present, no new payments)
     
-    print(f"All payments made: {len(future_loan._actual_payments)}")
+    print(f"All payments made: {len(future_loan._ledger.actual_payment_items)}")
     # All payments made: 6 (all 3 payments × 2 components each)
     
     # Time calculations from the future perspective
@@ -130,7 +130,7 @@ for analysis_date in analysis_dates:
     with Warp(loan, analysis_date) as snapshot:
         print(f"\n=== Analysis as of {analysis_date.strftime('%B %Y')} ===")
         print(f"Outstanding balance: {snapshot.current_balance}")
-        print(f"Payments made: {len(snapshot._actual_payments) // 2}")  # Divide by 2 for payment count
+        print(f"Payments made: {len(snapshot._ledger.actual_payment_items) // 2}")  # Divide by 2 for payment count
         print(f"Days since last payment: {snapshot.days_since_last_payment()}")
 ```
 

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -169,7 +169,7 @@ The mora rate is applied independently to the outstanding principal. Regular int
 
 With the same rates, COMPOUND always produces more mora than SIMPLE because it applies the mora rate to a larger base. When `mora_interest_rate` equals `interest_rate` and strategy is `COMPOUND`, the result is identical to a single continuous compounding period — preserving the original behaviour before the mora strategy feature was introduced.
 
-The `interest_balance` and `mora_interest_balance` properties respect `mora_interest_rate` and `mora_strategy`. When the borrower is past the next unpaid due date, `_accrued_interest_components()` splits interest into regular and mora via `_compute_accrued_interest`. `current_balance = principal_balance + interest_balance + mora_interest_balance + fine_balance`.
+The `interest_balance` and `mora_interest_balance` properties respect `mora_interest_rate` and `mora_strategy`. When the borrower is past the next unpaid due date, `_accrued_interest_components()` splits interest into regular and mora via `InterestCalculator.compute_accrued_interest`. `current_balance = principal_balance + interest_balance + mora_interest_balance + fine_balance`.
 
 ## Balance Properties
 
@@ -239,7 +239,7 @@ Computed properties:
 Field semantics:
 - `expected_payment`, `expected_principal`, `expected_interest` come from the original schedule.
 - `expected_fine` comes from `Loan.fines_applied` for the installment's due date.
-- `expected_mora` is computed by the Loan: for covered installments it equals the sum of prior `mora_allocated` values; for the first uncovered overdue installment it is prior `mora_allocated` **plus** newly accrued mora (from last payment to `self.now()`) via `_compute_accrued_interest`; for all other installments it is zero. The cumulative form ensures `Installment.allocate` correctly computes `mora_owed = expected_mora - mora_paid` even when the same installment receives mora across multiple settlements.
+- `expected_mora` is computed by the Loan: for covered installments it equals the sum of prior `mora_allocated` values; for the first uncovered overdue installment it is prior `mora_allocated` **plus** newly accrued mora (from last payment to `self.now()`) via `InterestCalculator.compute_accrued_interest`; for all other installments it is zero. The cumulative form ensures `Installment.allocate` correctly computes `mora_owed = expected_mora - mora_paid` even when the same installment receives mora across multiple settlements.
 - `*_paid` fields are aggregated totals from all settlement allocations attributed to this installment.
 - `allocations` is the reverse view of Settlement: all `SettlementAllocation`s that touched this installment.
 - Created via `Installment.from_schedule_entry(entry, allocations, expected_mora, expected_fine)`.
@@ -248,7 +248,7 @@ Field semantics:
 
 ### Settlement (`loan.settlements`, returned by payment methods)
 
-A frozen dataclass capturing how a single payment was allocated. Reconstructed from the cash flow (`_all_payments` and `_actual_schedule_entries`) rather than stored as separate state.
+A frozen dataclass capturing how a single payment was allocated. Reconstructed from the cash flow (via `PaymentLedger`) rather than stored as separate state.
 
 Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations: List[SettlementAllocation]`.
 
@@ -297,9 +297,9 @@ Both methods are time-aware: inside a `Warp` context they reflect the warped dat
 
 **Symptom:** After paying all scheduled installments, a residual balance of ~$103.36 persisted on a $10,000 loan.
 
-**Root cause:** `record_payment` computed interest days via `self.days_since_last_payment(payment_date)`, which filtered `_all_payments` by `self.now()` (real wall-clock time). When installments were recorded sequentially for future dates, previously-recorded future payments were invisible, leading to inflated day counts, too much interest, too little principal, and a non-zero residual.
+**Root cause:** `record_payment` computed interest days via `self.days_since_last_payment(payment_date)`, which filtered payments by `self.now()` (real wall-clock time). When installments were recorded sequentially for future dates, previously-recorded future payments were invisible, leading to inflated day counts, too much interest, too little principal, and a non-zero residual.
 
-**Fix:** Pre-compute `days` and `principal_balance` at the top of `record_payment` using `payment_date` as the filter, before step 1 modifies `_all_payments`.
+**Fix:** Pre-compute `days` and `principal_balance` at the top of `record_payment` using `payment_date` as the filter, before step 1 modifies the payment ledger.
 
 **Lesson:** Any method that reads loan state and then mutates it must snapshot the relevant values first. Time-dependent queries inside mutation methods must use the payment's own date, not wall-clock time.
 
@@ -311,7 +311,7 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 
 **Symptom:** `_next_unpaid_due_date()` and `get_amortization_schedule()` would miscount covered due dates when partial payments, overpayments, or multiple anticipations were made.
 
-**Root cause:** The original implementation used `len(self._actual_schedule_entries)` to determine how many due dates were covered — assuming one `record_payment` call = one installment. This broke with partial payments (inflated count) and large overpayments (undercounted).
+**Root cause:** The original implementation used the number of schedule entries to determine how many due dates were covered — assuming one `record_payment` call = one installment. This broke with partial payments (inflated count) and large overpayments (undercounted).
 
 **Fix:** `_covered_due_date_count()` compares the remaining principal (from the last actual entry) against the original schedule's `ending_balance` milestones. A due date is covered when remaining principal is at or below that entry's ending balance.
 
@@ -323,7 +323,7 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 
 **Root cause:** `PaymentScheduleEntry` carried an `is_actual: bool` field that leaked an internal implementation detail into the data model. No business logic depended on the flag — it only served test filtering.
 
-**Fix:** Removed `is_actual` from `PaymentScheduleEntry` entirely. The merged schedule is a clean, ordered list: past entries (from `_actual_schedule_entries`) come first by construction, followed by projected entries. Tests use positional indexing (`schedule[0]` for the recorded payment, `schedule[1:]` for projected) instead of filtering.
+**Fix:** Removed `is_actual` from `PaymentScheduleEntry` entirely. The merged schedule is a clean, ordered list: past entries (from `PaymentLedger.actual_schedule_entries()`) come first by construction, followed by projected entries. Tests use positional indexing (`schedule[0]` for the recorded payment, `schedule[1:]` for projected) instead of filtering.
 
 **Lesson:** Don't tag data with internal metadata that consumers must filter. If ordering already encodes the distinction, a flag is redundant. Keep data structures minimal — the fewer fields, the simpler the API.
 
@@ -351,9 +351,9 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 
 **Symptom:** When `disbursement_date` had a non-midnight time component (e.g. 19:53), the first installment was never marked `is_fully_covered` even when the payment was large enough to cover it. The settlement interest was consistently lower than the scheduled interest by about one day's worth.
 
-**Root cause:** The scheduler computes `days_in_period` using date subtraction (`(due_date - prev_date).days`), but `_compute_interest_snapshot` used datetime subtraction (`(interest_date - last_pay_date).days`). Python's `timedelta.days` truncates: `(April 12 00:00 - March 6 19:53).days == 36`, while `(April 12 - March 6).days == 37`. The 1-day shortfall meant settlement interest was less than the schedule expected, so `Installment.allocate` could not fully cover the first installment's interest obligation.
+**Root cause:** The scheduler computes `days_in_period` using date subtraction (`(due_date - prev_date).days`), but `PaymentLedger.compute_interest_snapshot` used datetime subtraction (`(interest_date - last_pay_date).days`). Python's `timedelta.days` truncates: `(April 12 00:00 - March 6 19:53).days == 36`, while `(April 12 - March 6).days == 37`. The 1-day shortfall meant settlement interest was less than the schedule expected, so `Installment.allocate` could not fully cover the first installment's interest obligation.
 
-**Fix:** Use `.date()` on both operands in all three day-count calculations: `_compute_interest_snapshot`, `_build_installments_snapshot` (mora days), and `days_since_last_payment`. This aligns with the scheduler's calendar-day convention. Financial day counting operates on dates, not timestamps.
+**Fix:** Use `.date()` on both operands in all three day-count calculations: `compute_interest_snapshot`, `_build_installments_snapshot` (mora days), and `days_since_last_payment`. This aligns with the scheduler's calendar-day convention. Financial day counting operates on dates, not timestamps.
 
 **Lesson:** When one subsystem counts days using dates and another uses datetimes, the results will diverge whenever a timestamp has a non-midnight time. Normalize to the same type (`.date()`) at every day-count boundary.
 

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -147,26 +147,6 @@ class Loan:
         self._tax_cache: Optional[Dict[str, TaxResult]] = None
 
     @property
-    def _all_payments(self) -> List:
-        """All payment entries (backward-compat, delegates to ledger)."""
-        return self._ledger.all_payment_items
-
-    @property
-    def _actual_payments(self) -> List:
-        """Payment entries visible at the current time (backward-compat)."""
-        return self._ledger.actual_payment_items
-
-    @property
-    def _actual_schedule_entries(self) -> List[PaymentScheduleEntry]:
-        """Schedule entries derived from ledger snapshots (backward-compat)."""
-        return self._ledger.actual_schedule_entries()
-
-    @property
-    def _actual_payment_datetimes(self) -> List[datetime]:
-        """Payment datetimes derived from ledger snapshots (backward-compat)."""
-        return self._ledger.actual_payment_datetimes()
-
-    @property
     def principal_balance(self) -> Money:
         """Get the current principal balance (original principal minus principal payments)."""
         return self._ledger.principal_balance(self.principal)
@@ -185,7 +165,7 @@ class Loan:
                 due_date = self._next_unpaid_due_date()
             except ValueError:
                 due_date = None
-            return self._compute_accrued_interest(days, principal_bal, due_date, self.last_payment_date)
+            return self._interest.compute_accrued_interest(days, principal_bal, due_date, self.last_payment_date)
 
         return Money.zero(), Money.zero()
 
@@ -239,7 +219,7 @@ class Loan:
     @property
     def fine_balance(self) -> Money:
         """Unpaid fine amount (total fines applied minus fines paid)."""
-        return self._fines.fine_balance(self._actual_payments)
+        return self._fines.fine_balance(self._ledger.actual_payment_items)
 
     @property
     def tax_amounts(self) -> Dict[str, TaxResult]:
@@ -278,12 +258,9 @@ class Loan:
         """Hook called by Warp after overriding TimeContext."""
         self.calculate_late_fines()
 
-    @tz_aware
-    def days_since_last_payment(self, as_of_date: Optional[datetime] = None) -> int:
-        """Get the number of days since the last payment as of a given date (defaults to current time)."""
-        if as_of_date is None:
-            as_of_date = self.now()
-        return (as_of_date.date() - self.last_payment_date.date()).days
+    def days_since_last_payment(self) -> int:
+        """Get the number of days since the last payment (Warp-aware via TimeContext)."""
+        return (self.now().date() - self.last_payment_date.date()).days
 
     def get_expected_payment_amount(self, due_date: date) -> Money:
         """Get the expected payment amount for a specific due date from the original schedule."""
@@ -297,7 +274,7 @@ class Loan:
     def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
         """Calculate and apply late payment fines for any new late payments."""
         return self._fines.calculate_late_fines(
-            self.due_dates, self.get_original_schedule(), self._all_payments, as_of=as_of_date
+            self.due_dates, self.get_original_schedule(), self._ledger.all_payment_items, as_of=as_of_date
         )
 
     @tz_aware
@@ -404,22 +381,6 @@ class Loan:
 
         return CashFlow(items)
 
-    def _compute_interest_snapshot(self, payment_date: datetime, interest_date: datetime) -> tuple:
-        """Delegate to PaymentLedger."""
-        return self._ledger.compute_interest_snapshot(
-            payment_date, interest_date, self.principal, self.disbursement_date
-        )
-
-    def _compute_accrued_interest(
-        self,
-        days: int,
-        principal_balance: Money,
-        due_date: Optional[date],
-        last_payment_date: Optional[datetime],
-    ) -> tuple:
-        """Delegate to InterestCalculator."""
-        return self._interest.compute_accrued_interest(days, principal_balance, due_date, last_payment_date)
-
     @tz_aware
     def record_payment(
         self,
@@ -458,14 +419,16 @@ class Loan:
 
         self.calculate_late_fines(payment_date)
 
-        days, principal_balance, last_pay_date = self._compute_interest_snapshot(payment_date, interest_date)
+        days, principal_balance, last_pay_date = self._ledger.compute_interest_snapshot(
+            payment_date, interest_date, self.principal, self.disbursement_date
+        )
 
         try:
             next_due = self._next_unpaid_due_date()
         except ValueError:
             next_due = None
 
-        interest_accrued, mora_accrued = self._compute_accrued_interest(
+        interest_accrued, mora_accrued = self._interest.compute_accrued_interest(
             days, principal_balance, next_due, last_pay_date
         )
 
@@ -493,12 +456,17 @@ class Loan:
         )
 
         allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+        schedule = self.get_original_schedule()
         for i in range(settlement_num - 1):
-            prev = self._compute_settlement(i, allocs_by_number)
+            prev = self._settlements_engine.compute_settlement(
+                i, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
+            )
             for a in prev.allocations:
                 allocs_by_number.setdefault(a.installment_number, []).append(a)
 
-        return self._compute_settlement(settlement_num - 1, allocs_by_number)
+        return self._settlements_engine.compute_settlement(
+            settlement_num - 1, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
+        )
 
     def _build_pre_settlement_installments(
         self,
@@ -513,8 +481,11 @@ class Loan:
         determine per-installment obligations.
         """
         allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+        schedule = self.get_original_schedule()
         for i in range(self._ledger.settlement_count):
-            prev = self._compute_settlement(i, allocs_by_number)
+            prev = self._settlements_engine.compute_settlement(
+                i, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
+            )
             for a in prev.allocations:
                 allocs_by_number.setdefault(a.installment_number, []).append(a)
 
@@ -619,21 +590,6 @@ class Loan:
                     item.delete(effective_date)
                     break
 
-    def _compute_settlement(
-        self,
-        entry_index: int,
-        allocations_by_number: Dict[int, List[SettlementAllocation]],
-    ) -> Settlement:
-        """Delegate to SettlementEngine."""
-        return self._settlements_engine.compute_settlement(
-            entry_index,
-            allocations_by_number,
-            self._ledger,
-            self.get_original_schedule(),
-            self.fines_applied,
-            self.disbursement_date,
-        )
-
     @property
     def settlements(self) -> List[Settlement]:
         """All settlements made on this loan (Warp-aware)."""
@@ -704,7 +660,7 @@ class Loan:
                 )
             )
 
-        for payment in self._actual_payments:
+        for payment in self._ledger.actual_payment_items:
             items.append(
                 CashFlowItem(
                     -payment.amount,
@@ -744,10 +700,10 @@ class Loan:
         Returns:
             PaymentSchedule with past entries followed by projected future entries
         """
-        if not self._actual_schedule_entries:
+        if not self._ledger.actual_schedule_entries():
             return self.get_original_schedule()
 
-        actual_entries = list(self._actual_schedule_entries)
+        actual_entries = list(self._ledger.actual_schedule_entries())
         covered = self._covered_due_date_count()
 
         remaining_due_dates = self.due_dates[covered:]
@@ -758,7 +714,7 @@ class Loan:
         if remaining_principal.is_zero() or remaining_principal.is_negative():
             return PaymentSchedule(entries=actual_entries)
 
-        last_payment_date = self._actual_payment_datetimes[-1]
+        last_payment_date = self._ledger.actual_payment_datetimes()[-1]
         projected_schedule = self.scheduler.generate_schedule(
             remaining_principal,
             self.interest_rate,

--- a/notebooks/simple_loan_demo.ipynb
+++ b/notebooks/simple_loan_demo.ipynb
@@ -11,17 +11,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "✅ Setup complete!\n"
-          ]
-        }
-      ],
       "source": [
         "import sys\n",
         "import os\n",
@@ -60,56 +50,20 @@
         "chart_output = widgets.Output()\n",
         "\n",
         "print('✅ Setup complete!')"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "✅ Setup complete!\n"
+          ]
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "f905e5ef892348298a70430def0de7f6",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "VBox(children=(HTML(value='<h3>🏦 Loan Parameters</h3>'), HBox(children=(FloatText(value=10000.0, description='…"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ece75a8d05a7451c9f109e2eedeb5a5e",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "VBox(children=(HTML(value='<h3>⏰ Time Machine</h3>'), IntSlider(value=0, description='Time Machine:', disabled…"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9c14571590a44ca4994fe36321ea8345",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "VBox(children=(HTML(value='<h3>📊 Chart</h3>'), Output()))"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
       "source": [
         "def create_loan(b):\n",
         "    global current_loan, time_dates\n",
@@ -240,7 +194,7 @@
         "        interest = warped_loan.interest_balance\n",
         "        mora = warped_loan.mora_interest_balance\n",
         "        total_owed = warped_loan.current_balance\n",
-        "        days = warped_loan.days_since_last_payment(current_time)\n",
+        "        days = warped_loan.days_since_last_payment()\n",
         "        \n",
         "        print(f'📅 {current_time.strftime(\"%Y-%m-%d\")} | 💰 Actual Balance: ${total_owed.real_amount:,.2f}')\n",
         "        print(f'🏦 Principal Balance: ${principal_balance.real_amount:,.2f}')\n",
@@ -255,7 +209,7 @@
         "        all_entries = []\n",
         "        \n",
         "        # Add all payments\n",
-        "        for payment in warped_loan._all_payments:\n",
+        "        for payment in warped_loan._ledger.all_payment_items:\n",
         "            if payment.datetime <= current_time:\n",
         "                category = getattr(payment, 'category', 'payment')\n",
         "                if category == 'fine':\n",
@@ -399,6 +353,48 @@
         "    widgets.HTML('<h3>📊 Chart</h3>'),\n",
         "    chart_output\n",
         "]))"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "f905e5ef892348298a70430def0de7f6",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "VBox(children=(HTML(value='<h3>🏦 Loan Parameters</h3>'), HBox(children=(FloatText(value=10000.0, description='…"
+            ]
+          }
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "ece75a8d05a7451c9f109e2eedeb5a5e",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "VBox(children=(HTML(value='<h3>⏰ Time Machine</h3>'), IntSlider(value=0, description='Time Machine:', disabled…"
+            ]
+          }
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "9c14571590a44ca4994fe36321ea8345",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "VBox(children=(HTML(value='<h3>📊 Chart</h3>'), Output()))"
+            ]
+          }
+        }
       ]
     }
   ],

--- a/test_notebook_functionality.py
+++ b/test_notebook_functionality.py
@@ -67,7 +67,7 @@ def test_payment_recording(loan):
     print(f"   Balance Reduction: ${(initial_balance - new_balance).real_amount:,.2f}")
 
     # Check payment history
-    payments = loan._actual_payments
+    payments = loan._ledger.actual_payment_items
     print(f"   Payment History: {len(payments)} payments")
     for payment in payments:
         print(

--- a/tests/loan/test_balance.py
+++ b/tests/loan/test_balance.py
@@ -35,8 +35,8 @@ def test_loan_days_since_last_payment_initial():
     disbursement_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
     loan = Loan(principal, rate, due_dates, disbursement_date)
-    check_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
-    assert loan.days_since_last_payment(check_date) == 14
+    with Warp(loan, datetime(2024, 1, 15, tzinfo=timezone.utc)) as warped:
+        assert warped.days_since_last_payment() == 14
 
 
 def test_loan_days_since_last_payment_defaults_to_now():

--- a/tests/loan/test_fines.py
+++ b/tests/loan/test_fines.py
@@ -235,7 +235,7 @@ def test_loan_record_payment_allocates_to_fines_first():
     loan.record_payment(payment_amount, datetime(2024, 2, 6, tzinfo=timezone.utc))
 
     # Check that payment went to fines
-    fine_payments = [p for p in loan._actual_payments if "fine" in p.category]
+    fine_payments = [p for p in loan._ledger.actual_payment_items if "fine" in p.category]
     assert len(fine_payments) == 1
     assert fine_payments[0].amount == payment_amount
 
@@ -262,8 +262,8 @@ def test_loan_record_payment_allocates_fines_then_principal():
     loan.record_payment(payment_amount, datetime(2024, 2, 6, tzinfo=timezone.utc))
 
     # Check allocations
-    fine_payments = [p for p in loan._actual_payments if "fine" in p.category]
-    principal_payments = [p for p in loan._actual_payments if "principal" in p.category]
+    fine_payments = [p for p in loan._ledger.actual_payment_items if "fine" in p.category]
+    principal_payments = [p for p in loan._ledger.actual_payment_items if "principal" in p.category]
 
     assert len(fine_payments) == 1
     assert fine_payments[0].amount == total_fines
@@ -385,9 +385,9 @@ def test_pay_installment_late_triggers_fines_and_extra_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("11000.00"))
-        fine_items = [p for p in warped._all_payments if "fine" in p.category]
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        fine_items = [p for p in warped._ledger.all_payment_items if "fine" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert len(fine_items) == 1
     assert fine_items[0].amount > Money.zero()
@@ -429,7 +429,7 @@ def test_late_overpayment_fine_equals_two_percent_of_scheduled_payment():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        fine_items = [p for p in warped._all_payments if "fine" in p.category]
+        fine_items = [p for p in warped._ledger.all_payment_items if "fine" in p.category]
 
     assert fine_items[0].amount == expected_fine
 
@@ -453,7 +453,9 @@ def test_late_overpayment_total_interest_for_45_days():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        interest_items = [p for p in warped._all_payments if not p.category.isdisjoint({"interest", "mora_interest"})]
+        interest_items = [
+            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
+        ]
         total_interest = sum((p.amount for p in interest_items), Money.zero())
 
     assert total_interest == Money(expected_total)
@@ -481,7 +483,7 @@ def test_late_overpayment_principal_is_remainder_after_fine_and_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        principal_items = [p for p in warped._all_payments if "principal" in p.category]
+        principal_items = [p for p in warped._ledger.all_payment_items if "principal" in p.category]
 
     assert principal_items[0].amount == Money(expected_principal)
 
@@ -509,7 +511,7 @@ def test_late_overpayment_ending_balance_in_actual_entry():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        entry = warped._actual_schedule_entries[-1]
+        entry = warped._ledger.actual_schedule_entries()[-1]
 
     assert entry.ending_balance == Money(expected_ending)
 

--- a/tests/loan/test_mora_interest.py
+++ b/tests/loan/test_mora_interest.py
@@ -19,8 +19,8 @@ def test_late_payment_produces_separate_mora_interest_item():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert len(interest_items) == 1
     assert len(mora_items) == 1
@@ -42,8 +42,8 @@ def test_mora_interest_equals_difference_between_total_and_regular():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert interest_items[0].amount == Money(regular_interest)
     assert mora_items[0].amount == Money(expected_mora)
@@ -62,7 +62,7 @@ def test_regular_interest_matches_scheduled_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
 
     assert interest_items[0].amount == scheduled_interest
 
@@ -87,7 +87,9 @@ def test_total_interest_on_late_payment_matches_manual_calculation(late_days):
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        all_interest = [p for p in warped._all_payments if not p.category.isdisjoint({"interest", "mora_interest"})]
+        all_interest = [
+            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
+        ]
         total_interest = sum((p.amount for p in all_interest), Money.zero())
 
     assert total_interest == Money(expected_total)
@@ -104,8 +106,8 @@ def test_on_time_payment_produces_no_mora_interest_item():
 
     with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert len(interest_items) == 1
     assert len(mora_items) == 0
@@ -122,7 +124,7 @@ def test_early_payment_produces_no_mora_interest_item():
 
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert len(mora_items) == 0
 
@@ -142,7 +144,7 @@ def test_on_time_interest_unchanged():
 
     with Warp(loan, due_date) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
 
     assert interest_items[0].amount == Money(expected_interest)
 
@@ -196,8 +198,8 @@ def test_on_time_payment_unaffected_by_custom_mora_rate():
 
     with Warp(loan, due_date) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert interest_items[0].amount == Money(expected_interest)
     assert len(mora_items) == 0
@@ -233,7 +235,7 @@ def test_mora_with_custom_rate_compound_strategy():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert mora_items[0].amount == Money(expected_mora)
 
@@ -262,7 +264,7 @@ def test_mora_with_custom_rate_simple_strategy():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_items = [p for p in warped._all_payments if "mora_interest" in p.category]
+        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
 
     assert mora_items[0].amount == Money(expected_mora)
 
@@ -295,11 +297,11 @@ def test_simple_vs_compound_mora_compound_produces_more():
 
     with Warp(loan_compound, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_compound = [p for p in warped._all_payments if "mora_interest" in p.category][0].amount
+        mora_compound = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category][0].amount
 
     with Warp(loan_simple, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_simple = [p for p in warped._all_payments if "mora_interest" in p.category][0].amount
+        mora_simple = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category][0].amount
 
     assert mora_compound > mora_simple
 
@@ -326,7 +328,7 @@ def test_regular_interest_unchanged_regardless_of_mora_rate():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
 
     assert interest_items[0].amount == Money(expected_regular)
 
@@ -377,7 +379,9 @@ def test_total_interest_with_custom_mora_rate_matches_manual(mora_rate_str, stra
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        all_interest = [p for p in warped._all_payments if not p.category.isdisjoint({"interest", "mora_interest"})]
+        all_interest = [
+            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
+        ]
         total_interest = sum((p.amount for p in all_interest), Money.zero())
 
     assert total_interest == Money(expected_total)

--- a/tests/loan/test_payment_methods.py
+++ b/tests/loan/test_payment_methods.py
@@ -22,7 +22,7 @@ def test_pay_installment_uses_now_as_payment_date():
 
     with Warp(loan, datetime(2025, 1, 20, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("5000.00"))
-        assert warped._all_payments[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
+        assert warped._ledger.all_payment_items[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
 
 
 def test_pay_installment_charges_interest_to_due_date():
@@ -36,7 +36,7 @@ def test_pay_installment_charges_interest_to_due_date():
     # pay_installment on Jan 15 should charge interest for 31 days (to Feb 1 due date)
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("5000.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
         assert len(interest_items) == 1
 
         daily_rate = InterestRate("6% a").to_daily().as_decimal()
@@ -55,13 +55,13 @@ def test_pay_installment_no_discount_vs_anticipate_discount():
     loan1 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan1, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped1:
         warped1.pay_installment(Money("5000.00"))
-        installment_interest = [p for p in warped1._all_payments if "interest" in p.category]
+        installment_interest = [p for p in warped1._ledger.all_payment_items if "interest" in p.category]
 
     # anticipate_payment: interest for 14 days (disbursement to payment date)
     loan2 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan2, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped2:
         warped2.anticipate_payment(Money("5000.00"))
-        anticipate_interest = [p for p in warped2._all_payments if "interest" in p.category]
+        anticipate_interest = [p for p in warped2._ledger.all_payment_items if "interest" in p.category]
 
     assert installment_interest[0].amount > anticipate_interest[0].amount
 
@@ -77,12 +77,12 @@ def test_pay_installment_more_principal_with_anticipate():
     loan1 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan1, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped1:
         warped1.pay_installment(payment)
-        installment_principal = [p for p in warped1._all_payments if "principal" in p.category]
+        installment_principal = [p for p in warped1._ledger.all_payment_items if "principal" in p.category]
 
     loan2 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan2, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped2:
         warped2.anticipate_payment(payment)
-        anticipate_principal = [p for p in warped2._all_payments if "principal" in p.category]
+        anticipate_principal = [p for p in warped2._ledger.all_payment_items if "principal" in p.category]
 
     assert anticipate_principal[0].amount > installment_principal[0].amount
 
@@ -100,7 +100,7 @@ def test_anticipate_payment_uses_now_as_payment_date():
 
     with Warp(loan, datetime(2025, 1, 20, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        assert warped._all_payments[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
+        assert warped._ledger.all_payment_items[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
 
 
 def test_anticipate_payment_charges_interest_only_for_elapsed_days():
@@ -113,7 +113,7 @@ def test_anticipate_payment_charges_interest_only_for_elapsed_days():
 
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        interest_items = [p for p in warped._all_payments if "interest" in p.category]
+        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
 
         daily_rate = InterestRate("6% a").to_daily().as_decimal()
         expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
@@ -193,7 +193,7 @@ def test_record_payment_with_explicit_interest_date():
         interest_date=datetime(2025, 2, 1, tzinfo=timezone.utc),
     )
 
-    interest_items = [p for p in loan._all_payments if "interest" in p.category]
+    interest_items = [p for p in loan._ledger.all_payment_items if "interest" in p.category]
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
     assert interest_items[0].amount == Money(expected_interest)
@@ -209,7 +209,7 @@ def test_record_payment_interest_date_defaults_to_payment_date():
 
     loan.record_payment(Money("5000.00"), payment_date=datetime(2025, 1, 15, tzinfo=timezone.utc))
 
-    interest_items = [p for p in loan._all_payments if "interest" in p.category]
+    interest_items = [p for p in loan._ledger.all_payment_items if "interest" in p.category]
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
     assert interest_items[0].amount == Money(expected_interest)
@@ -688,11 +688,11 @@ def test_anticipate_vs_installment_ending_balance_comparison():
     loan_installment = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan_installment, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(scheduled_pmt)
-        installment_remaining = warped._actual_schedule_entries[-1].ending_balance
+        installment_remaining = warped._ledger.actual_schedule_entries()[-1].ending_balance
 
     loan_anticipate = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan_anticipate, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(scheduled_pmt)
-        anticipate_remaining = warped._actual_schedule_entries[-1].ending_balance
+        anticipate_remaining = warped._ledger.actual_schedule_entries()[-1].ending_balance
 
     assert anticipate_remaining < installment_remaining

--- a/tests/loan/test_payments.py
+++ b/tests/loan/test_payments.py
@@ -29,11 +29,11 @@ def test_loan_record_payment_creates_interest_and_principal_items():
     loan.record_payment(Money("5000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc))
 
     # Should have created interest and principal payment items
-    assert len(loan._actual_payments) == 2
+    assert len(loan._ledger.actual_payment_items) == 2
 
     # Check categories
-    assert any("interest" in p.category for p in loan._actual_payments)
-    assert any("principal" in p.category for p in loan._actual_payments)
+    assert any("interest" in p.category for p in loan._ledger.actual_payment_items)
+    assert any("principal" in p.category for p in loan._ledger.actual_payment_items)
 
 
 def test_loan_record_payment_updates_last_payment_date():

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -125,10 +125,10 @@ def test_warp_filters_future_payments(sample_loan):
 
     with Warp(sample_loan, target_date) as warped_loan:
         # Should only have the first payment
-        assert len(warped_loan._actual_payments) == 2  # Interest + principal portions of first payment
+        assert len(warped_loan._ledger.actual_payment_items) == 2  # Interest + principal portions of first payment
 
         # All payments should be before or on target date
-        for payment in warped_loan._actual_payments:
+        for payment in warped_loan._ledger.actual_payment_items:
             assert payment.datetime <= target_date
 
 
@@ -186,10 +186,10 @@ def test_warp_to_past_ignores_future_payments():
     # Warp to middle date
     with Warp(loan, datetime(2024, 2, 5, tzinfo=timezone.utc)) as warped_loan:
         # Should only have first payment (2 items: interest + principal)
-        assert len(warped_loan._actual_payments) == 2
+        assert len(warped_loan._ledger.actual_payment_items) == 2
 
         # Check that it's the first payment
-        payment_dates = [p.datetime for p in warped_loan._actual_payments]
+        payment_dates = [p.datetime for p in warped_loan._ledger.actual_payment_items]
         assert all(d == datetime(2024, 1, 10, tzinfo=timezone.utc) for d in payment_dates)
 
 
@@ -210,7 +210,7 @@ def test_warp_to_future_keeps_all_past_payments():
 
     # Warp to future date — both past payments must be visible (5 items: 2 + 3)
     with Warp(loan, datetime(2025, 1, 1, tzinfo=timezone.utc)) as warped_loan:
-        assert len(warped_loan._actual_payments) == 5
+        assert len(warped_loan._ledger.actual_payment_items) == 5
 
 
 # String representations


### PR DESCRIPTION
## Summary
- Remove 7 private methods from `Loan` that only forwarded to `_ledger`, `_interest`, or `_settlements_engine` with no added logic
- Remove `as_of_date` parameter from `days_since_last_payment()` — callers now use `Warp` for time travel, consistent with every other time-dependent method
- Net reduction of ~42 lines of code

## Changes
- **loan.py**: Removed `_all_payments`, `_actual_payments`, `_actual_schedule_entries`, `_actual_payment_datetimes`, `_compute_interest_snapshot`, `_compute_accrued_interest`, `_compute_settlement`. Inlined all call sites. Simplified `days_since_last_payment()` to always use `self.now()`.
- **Tests**: Replaced all `loan._all_payments` / `loan._actual_payments` / `loan._actual_schedule_entries` references with `loan._ledger.all_payment_items` / `loan._ledger.actual_payment_items` / `loan._ledger.actual_schedule_entries()`. Rewrote `days_since_last_payment` test to use `Warp`.
- **Docs/Knowledge**: Updated `time_machine.md`, `loan.md`, and notebook to reflect removed methods.

## Test plan
- [x] All 1652 existing tests pass (`poetry run pytest`)
- [x] Black formatting passes
- [x] No linter errors introduced