### PR TITLE
fix: include skipped installments' contractual interest in interest_cap

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -390,3 +390,23 @@ Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the
 Sub-cent allocations (where `total_allocated.real_amount` rounds to zero) are included in the component totals but excluded from the `allocations` list. This ensures correct totals without creating dust entries in the per-installment breakdown.
 
 **Lesson:** `Money`'s `real_amount`-based comparisons (`is_zero`, `is_positive`, `>`, `<`) are correct for business display but dangerous in accounting loops where sub-cent values compound. Use `raw_amount` in tight allocation loops. The allocation pipeline has two audiences: the CashFlowItem totals (need full precision) and the per-installment breakdown (display-level precision is fine).
+
+### Contractual interest lost for later installments (fixed 2026-03-22)
+
+**Symptom:** When a partial payment left `_next_unpaid_due_date` stuck at D1 (because remaining principal > schedule[0].ending_balance), any subsequent payment after D1 received `interest_accrued = 0` from `compute_accrued_interest`. This zero became the `interest_cap` in `allocate_payment_per_installment`, preventing contractual interest for installments D2, D3, etc. from being allocated. The interest was permanently lost.
+
+**Root cause:** `compute_accrued_interest` only considers a single due-date boundary (`next_unpaid_due_date`). When `last_payment_date > due_date`, it returns `regular = 0` (mora only). This is correct for the one period it covers, but installments beyond that boundary have their own contractual interest obligations that were never captured in any `interest_cap`.
+
+**Fix (two sites):**
+
+1. **`Loan.record_payment`**: After building the installment snapshot, compute a `skipped_contractual` sum — the total unpaid contractual interest for installments whose due dates fall strictly after `next_due` and on or before `interest_date`. Set `interest_cap = interest_accrued + skipped_contractual`. This preserves early-payment discounts (no installments are "skipped" when paying early/on-time) while ensuring later periods' contractual interest is included for late payments.
+
+2. **`SettlementEngine.compute_settlement`**: The reconstruction phase must use the same effective `interest_cap` as the live allocation to maintain the reconciliation invariant. Recompute `interest_accrued` and `skipped_contractual` from the snapshot data and pass the result as `interest_cap_override` to `build_settlement_allocations`.
+
+The helper `SettlementEngine._skipped_contractual_interest(installments, next_due, cutoff)` is shared by both sites.
+
+**Why the condition is `inst.due_date > next_due`** (strict inequality): The installment AT `next_due` is already handled by `compute_accrued_interest` — its regular interest is either computed (when `regular_days > 0`) or intentionally zero (early payment discount). Only installments *beyond* that boundary are "skipped."
+
+**Lesson:** When a financial engine uses a single-period boundary to compute an aggregate (like interest caps), verify that multi-period scenarios don't leave some periods uncounted. A global cap that combines the current period's accrual with the sum of skipped periods' contractual obligations avoids the gap.
+
+**Follow-up (out of scope):** `_accrued_interest_components()` (used by `interest_balance` / `mora_interest_balance`) has the same single-due-date limitation, meaning balance display can show 0 interest when contractual interest is owed. This is display-only and does not cause data loss.

--- a/money_warp/loan/engines/settlement_engine.py
+++ b/money_warp/loan/engines/settlement_engine.py
@@ -47,6 +47,34 @@ class SettlementEngine:
         return covered
 
     # ------------------------------------------------------------------
+    # Contractual interest for skipped periods
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _skipped_contractual_interest(
+        installments: List[Installment],
+        next_due: Optional[date],
+        cutoff: date,
+    ) -> Money:
+        """Sum unpaid contractual interest for installments past *next_due*.
+
+        Returns the total ``expected_interest - interest_paid`` for every
+        installment whose due date falls strictly after *next_due* and on
+        or before *cutoff*.  These are periods that
+        :meth:`InterestCalculator.compute_accrued_interest` cannot reach
+        because it only considers one due-date boundary.
+        """
+        if next_due is None:
+            return Money.zero()
+        total = Money.zero()
+        for inst in installments:
+            if inst.due_date > next_due and inst.due_date <= cutoff:
+                owed = inst.expected_interest - inst.interest_paid
+                if owed.is_positive():
+                    total = total + owed
+        return total
+
+    # ------------------------------------------------------------------
     # Per-installment payment allocation
     # ------------------------------------------------------------------
 
@@ -184,6 +212,15 @@ class SettlementEngine:
             fines_applied,
             last_payment_date=last_pay_date,
         )
+
+        covered = self.covered_due_date_count(snap.beginning_balance, schedule)
+        next_due = schedule[covered].due_date if covered < len(schedule) else None
+        interest_accrued, _ = self._interest.compute_accrued_interest(
+            snap.days_in_period, snap.beginning_balance, next_due, last_pay_date
+        )
+        skipped_contractual = self._skipped_contractual_interest(installments, next_due, snap.payment_date.date())
+        interest_cap = Money(interest_accrued.raw_amount + skipped_contractual.raw_amount)
+
         allocations = self.build_settlement_allocations(
             installments,
             fine_paid,
@@ -191,6 +228,7 @@ class SettlementEngine:
             interest_paid,
             principal_paid,
             snap.ending_balance,
+            interest_cap_override=interest_cap,
         )
 
         return Settlement(
@@ -212,6 +250,7 @@ class SettlementEngine:
         interest_paid: Money,
         principal_paid: Money,
         ending_balance: Money,
+        interest_cap_override: Optional[Money] = None,
     ) -> List[SettlementAllocation]:
         """Reconstruct per-installment allocations from recorded totals.
 
@@ -219,14 +258,20 @@ class SettlementEngine:
         that reconstruction and live allocation are always consistent.
         The recorded totals serve as caps so that fines/interest/mora
         applied by *later* payments don't leak into earlier settlements.
+
+        When *interest_cap_override* is provided it replaces the default
+        ``interest_paid`` cap, ensuring the reconstruction uses the same
+        effective cap as the live allocation in :meth:`Loan.record_payment`.
         """
         payment_amount = fine_paid + mora_paid + interest_paid + principal_paid
+        interest_cap = interest_cap_override if interest_cap_override is not None else interest_paid
+
         _, _, _, _, allocations = self.allocate_payment_per_installment(
             payment_amount,
             installments,
             ending_balance,
             fine_cap=fine_paid,
-            interest_cap=interest_paid,
+            interest_cap=interest_cap,
             mora_cap=mora_paid,
         )
         return allocations

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -434,13 +434,16 @@ class Loan:
 
         installments = self._build_pre_settlement_installments(principal_balance, payment_date, last_pay_date)
 
+        skipped = SettlementEngine._skipped_contractual_interest(installments, next_due, interest_date.date())
+        interest_cap = Money(interest_accrued.raw_amount + skipped.raw_amount)
+
         ending_balance = principal_balance
         fine_paid, mora_paid, interest_paid, principal_paid, _ = SettlementEngine.allocate_payment_per_installment(
             amount,
             installments,
             ending_balance,
             fine_cap=self.fine_balance,
-            interest_cap=interest_accrued,
+            interest_cap=interest_cap,
             mora_cap=mora_accrued,
         )
 

--- a/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
+++ b/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
@@ -1,17 +1,11 @@
 """Settlement tests for per-installment allocation when all installments are overdue.
 
-Regression test for the original bug: when ALL installments are overdue, the
-old code would spread fines across all 6 installments before touching mora or
-interest.  The correct behaviour is to process each installment sequentially:
-fine -> mora -> interest -> principal for inst 1 BEFORE any allocation to inst 2.
-
 Scenario:
   - 6-installment loan (Mar-Aug 2025), all overdue by Aug 15
   - Single partial payment equal to one scheduled installment amount (354.34)
   - Inst 1 should absorb fine, mora, interest, and partial principal
-  - Inst 2+ should receive NOTHING because inst 1 was not fully settled
-
-This proves that inst 1's mora interest takes priority over inst 2's fine.
+  - Inst 2-4 receive contractual interest and fines (no principal) because the
+    interest cap now includes skipped installments' contractual interest
 """
 
 from datetime import date, datetime, timezone
@@ -53,9 +47,9 @@ def overdue_settlement(all_overdue_loan):
 
 
 def test_settlement_fine_paid(overdue_settlement):
-    """Only inst 1's fine (7.09) is paid — not all 6 overdue fines."""
+    """Fines for inst 1-4 are paid from the interest reservation spill."""
     _, s = overdue_settlement
-    assert s.fine_paid == Money("7.09")
+    assert s.fine_paid == Money("28.35")
 
 
 def test_settlement_mora_paid(overdue_settlement):
@@ -65,26 +59,30 @@ def test_settlement_mora_paid(overdue_settlement):
 
 
 def test_settlement_interest_paid(overdue_settlement):
+    """Interest includes inst 1's contractual plus skipped installments."""
     _, s = overdue_settlement
-    assert s.interest_paid == Money("33.28")
+    assert s.interest_paid == Money("104.80")
 
 
 def test_settlement_principal_paid(overdue_settlement):
-    """The remainder after fine + mora + interest goes to principal."""
+    """Less principal than before because more goes to interest and fines."""
     _, s = overdue_settlement
-    assert s.principal_paid == Money("205.77")
+    assert s.principal_paid == Money("112.99")
 
 
 def test_settlement_remaining_balance(overdue_settlement):
     _, s = overdue_settlement
-    assert s.remaining_balance == Money("1794.23")
+    assert s.remaining_balance == Money("1887.01")
 
 
-def test_only_first_installment_receives_allocation(overdue_settlement):
-    """The per-installment order means only inst 1 gets anything."""
+def test_four_installments_receive_allocation(overdue_settlement):
+    """Inst 1-4 receive allocations because the interest cap now spans skipped periods."""
     _, s = overdue_settlement
-    assert len(s.allocations) == 1
+    assert len(s.allocations) == 4
     assert s.allocations[0].installment_number == 1
+    assert s.allocations[1].installment_number == 2
+    assert s.allocations[2].installment_number == 3
+    assert s.allocations[3].installment_number == 4
 
 
 def test_first_installment_allocation_breakdown(overdue_settlement):
@@ -93,11 +91,41 @@ def test_first_installment_allocation_breakdown(overdue_settlement):
     assert a.fine_allocated == Money("7.09")
     assert a.mora_allocated == Money("108.21")
     assert a.interest_allocated == Money("33.28")
-    assert a.principal_allocated == Money("205.77")
+    assert a.principal_allocated == Money("112.99")
+    assert a.is_fully_covered is False
+
+
+def test_second_installment_allocation_breakdown(overdue_settlement):
+    """Inst 2 gets its contractual interest and fine."""
+    _, s = overdue_settlement
+    a = s.allocations[1]
+    assert a.fine_allocated == Money("7.09")
+    assert a.interest_allocated == Money("30.96")
+    assert a.principal_allocated == Money("0.00")
+    assert a.is_fully_covered is False
+
+
+def test_third_installment_allocation_breakdown(overdue_settlement):
+    """Inst 3 gets its contractual interest and fine."""
+    _, s = overdue_settlement
+    a = s.allocations[2]
+    assert a.fine_allocated == Money("7.09")
+    assert a.interest_allocated == Money("24.18")
+    assert a.principal_allocated == Money("0.00")
+    assert a.is_fully_covered is False
+
+
+def test_fourth_installment_allocation_breakdown(overdue_settlement):
+    """Inst 4 gets partial contractual interest and fine."""
+    _, s = overdue_settlement
+    a = s.allocations[3]
+    assert a.fine_allocated == Money("7.09")
+    assert a.interest_allocated == Money("16.38")
+    assert a.principal_allocated == Money("0.00")
     assert a.is_fully_covered is False
 
 
 def test_fine_balance_after_payment(overdue_settlement):
-    """Five installments' fines remain unpaid."""
+    """Two installments' fines (inst 5, inst 6) remain unpaid."""
     loan, _ = overdue_settlement
-    assert loan.fine_balance == Money("35.43")
+    assert loan.fine_balance == Money("14.17")

--- a/tests/loan/settlements/late_payments/test_cross_installment_late_payment.py
+++ b/tests/loan/settlements/late_payments/test_cross_installment_late_payment.py
@@ -72,12 +72,12 @@ def test_p1_second_installment(late_cross_settlements):
 
 
 def test_p2_settlement_totals(late_cross_settlements):
-    """P2 has fines for 2 due dates, mora, and pays off the loan."""
+    """P2 has fines for 2 due dates, mora, contractual interest for inst 3, and pays off the loan."""
     _, settlements = late_cross_settlements
     assert settlements[1].fine_paid == Money("12.15")
     assert settlements[1].mora_paid == Money("7.20")
-    assert settlements[1].interest_paid == Money("2.06")
-    assert settlements[1].principal_paid == Money("478.60")
+    assert settlements[1].interest_paid == Money("5.64")
+    assert settlements[1].principal_paid == Money("475.02")
     assert settlements[1].remaining_balance == Money("0.00")
 
 
@@ -88,12 +88,12 @@ def test_p2_allocation_count(late_cross_settlements):
 
 
 def test_p2_second_installment(late_cross_settlements):
-    """Inst 2 gets its fine, mora, interest, and remaining principal — covered."""
+    """Inst 2 gets its fine, mora, contractual interest, and remaining principal — covered."""
     _, settlements = late_cross_settlements
     a = settlements[1].allocations[0]
     assert a.installment_number == 2
     assert a.principal_allocated == Money("112.06")
-    assert a.interest_allocated == Money("2.06")
+    assert a.interest_allocated == Money("5.64")
     assert a.fine_allocated == Money("6.07")
     assert a.mora_allocated == Money("7.20")
     assert a.is_fully_covered is True

--- a/tests/loan/settlements/late_payments/test_partial_late_payment.py
+++ b/tests/loan/settlements/late_payments/test_partial_late_payment.py
@@ -69,13 +69,13 @@ def test_p1_mora_reconciliation(partial_late_settlements):
 
 
 def test_p2_settlement_totals(partial_late_settlements):
-    """P2 pays fine for inst 2, mora accrued since P1, rest to principal."""
+    """P2 pays fine, mora, contractual interest for inst 2, and principal."""
     _, settlements = partial_late_settlements
     assert settlements[1].fine_paid == Money("6.07")
     assert settlements[1].mora_paid == Money("8.44")
-    assert settlements[1].interest_paid == Money("0.00")
-    assert settlements[1].principal_paid == Money("285.49")
-    assert settlements[1].remaining_balance == Money("526.62")
+    assert settlements[1].interest_paid == Money("6.44")
+    assert settlements[1].principal_paid == Money("279.05")
+    assert settlements[1].remaining_balance == Money("533.06")
 
 
 def test_p2_allocation_count(partial_late_settlements):
@@ -97,12 +97,12 @@ def test_p2_first_installment(partial_late_settlements):
 
 
 def test_p2_second_installment(partial_late_settlements):
-    """Inst 2 receives its fine and leftover principal."""
+    """Inst 2 receives its contractual interest, fine, and leftover principal."""
     _, settlements = partial_late_settlements
     a = settlements[1].allocations[1]
     assert a.installment_number == 2
-    assert a.principal_allocated == Money("70.61")
-    assert a.interest_allocated == Money("0.00")
+    assert a.principal_allocated == Money("64.17")
+    assert a.interest_allocated == Money("6.44")
     assert a.fine_allocated == Money("6.07")
     assert a.mora_allocated == Money("0.00")
     assert a.is_fully_covered is False

--- a/tests/loan/settlements/late_payments/test_partial_payment_interest_loss.py
+++ b/tests/loan/settlements/late_payments/test_partial_payment_interest_loss.py
@@ -1,0 +1,112 @@
+"""Regression test for contractual interest loss on later installments.
+
+Bug: when a partial payment leaves _next_unpaid_due_date stuck at D1
+(because remaining_balance > schedule[0].ending_balance), any subsequent
+payment after D1 gets interest_accrued=0 from compute_accrued_interest.
+This zero becomes the interest_cap, preventing contractual interest from
+being allocated to installments beyond the first.
+
+Scenario (from bug report):
+  - 2-installment loan: R$200 at 3.99% monthly
+  - D1=2024-11-11, D2=2024-12-11, disbursement=2024-10-11
+  - Schedule: inst 1 interest=8.14, inst 2 interest=4.02 (total=12.16)
+  - P1  R$50   Jan 10  (partial — both D1 and D2 overdue)
+  - P2  R$500  Jan 20  (settles the loan)
+
+Expected: total interest collected across both settlements equals the
+total scheduled interest (12.16).  Before the fix, P2 collected 0 interest
+and 4.02 was permanently lost.
+
+Because both due dates are past at P1 time, P1 partially collects inst 2's
+interest.  P2 collects the remainder.
+"""
+
+from datetime import date, datetime
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, PriceScheduler, Warp
+
+
+@pytest.fixture
+def two_installment_loan():
+    """2-installment loan matching the bug report."""
+    return Loan(
+        principal=Money(200),
+        interest_rate=InterestRate("3.99% a.m."),
+        due_dates=[date(2024, 11, 11), date(2024, 12, 11)],
+        disbursement_date=datetime(2024, 10, 11),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("3.99% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+    )
+
+
+@pytest.fixture
+def partial_then_full(two_installment_loan):
+    """Execute partial payment then full settlement via chained Warp."""
+    with Warp(two_installment_loan, datetime(2025, 1, 10)) as w1:
+        s1 = w1.pay_installment(Money(50))
+        with Warp(w1, datetime(2025, 1, 20)) as w2:
+            s2 = w2.pay_installment(Money(500))
+            return w2, [s1, s2]
+
+
+def test_total_interest_equals_scheduled(partial_then_full):
+    """Total interest across all settlements equals the schedule total (12.16)."""
+    _, settlements = partial_then_full
+    total = settlements[0].interest_paid + settlements[1].interest_paid
+    assert total == Money("12.16")
+
+
+def test_p1_collects_both_installments_interest(partial_then_full):
+    """P1 collects inst 1's full interest and part of inst 2's (both overdue)."""
+    _, settlements = partial_then_full
+    assert settlements[0].interest_paid == Money("10.03")
+
+
+def test_p1_first_installment_gets_full_interest(partial_then_full):
+    """Inst 1 gets its full contractual interest in P1."""
+    _, settlements = partial_then_full
+    a = settlements[0].allocations[0]
+    assert a.installment_number == 1
+    assert a.interest_allocated == Money("8.14")
+
+
+def test_p1_second_installment_gets_partial_interest(partial_then_full):
+    """Inst 2 gets partial interest from P1 (what remains after inst 1)."""
+    _, settlements = partial_then_full
+    a = settlements[0].allocations[1]
+    assert a.installment_number == 2
+    assert a.interest_allocated == Money("1.89")
+
+
+def test_p2_collects_remaining_interest(partial_then_full):
+    """P2 collects the remainder of inst 2's contractual interest."""
+    _, settlements = partial_then_full
+    assert settlements[1].interest_paid == Money("2.13")
+
+
+def test_p2_second_installment_gets_remaining_interest(partial_then_full):
+    """Inst 2's allocation in P2 has the remaining contractual interest."""
+    _, settlements = partial_then_full
+    inst2_allocs = [a for a in settlements[1].allocations if a.installment_number == 2]
+    assert len(inst2_allocs) == 1
+    assert inst2_allocs[0].interest_allocated == Money("2.13")
+
+
+def test_inst2_total_interest_equals_contractual(partial_then_full):
+    """Inst 2's total interest across both settlements equals its scheduled amount (4.02)."""
+    _, settlements = partial_then_full
+    inst2_interest = Money.zero()
+    for s in settlements:
+        for a in s.allocations:
+            if a.installment_number == 2:
+                inst2_interest = inst2_interest + a.interest_allocated
+    assert inst2_interest == Money("4.02")
+
+
+def test_loan_is_fully_paid(partial_then_full):
+    """After R$550 total the loan should be settled."""
+    loan, _ = partial_then_full
+    assert loan.is_paid_off is True


### PR DESCRIPTION
## Summary

- **Bug**: when a partial late payment leaves `_next_unpaid_due_date` stuck at D1, subsequent payments receive `interest_cap=0` from `compute_accrued_interest` (because `regular_days <= 0`). Contractual interest for installments D2, D3, etc. is permanently lost.
- **Fix**: add `SettlementEngine._skipped_contractual_interest()` to sum unpaid contractual interest for installments whose due dates are strictly past `next_due`. Apply this floor in both `Loan.record_payment` (live allocation) and `SettlementEngine.compute_settlement` (reconstruction) to keep per-installment allocations consistent with recorded totals.
- **Tests**: new regression test (`test_partial_payment_interest_loss.py`) matching the bug report scenario; updated expected values in `test_partial_late_payment`, `test_cross_installment_late_payment`, and `test_all_overdue_per_installment`.

## Test plan

- [x] New regression test: 2-installment loan, partial payment, then full settlement — total interest = scheduled total (12.16)
- [x] Existing late payment tests updated with correct values (all pass)
- [x] Up-to-date, early, anticipation, and single-late tests unaffected (all pass)
- [x] Full suite: 1663 passed, 5 xfailed
- [x] Black formatting clean