### PR TITLE
refactor: cashflow emergence -- derive all loan state from a single CashFlow

### DIFF
--- a/docs/examples/fines.md
+++ b/docs/examples/fines.md
@@ -194,35 +194,27 @@ print(loan.is_payment_late(date(2024, 2, 1), datetime(2024, 2, 9)))  # True
 
 Note: the grace period only affects **fines**. Mora interest always accrues for every day past the due date, regardless of the grace period.
 
-## Tracking Payments in Cash Flows
+## Tracking Fines and Mora via Settlements
 
-All cash flow items use explicit category prefixes. Expected schedule items use `expected_`, actual recorded payments use `actual_`:
+Settlements are derived views that show how each payment was allocated. Use `loan.settlements` to inspect fine and mora detail:
 
 ```python
-actual_cf = loan.get_actual_cash_flow()
-
-# Query fine events (positive = applied, negative = paid)
-fines = actual_cf.query.filter_by(category="fine").all()
-for fine in fines:
-    print(f"{fine.datetime}: {fine.amount} — {fine.description}")
-
-# Query mora interest payments
-mora = actual_cf.query.happened.filter_by(category="mora_interest").all()
-for item in mora:
-    print(f"{item.datetime}: {item.amount} — {item.description}")
+for s in loan.settlements:
+    print(f"{s.payment_date.date()}: fine={s.fine_paid}, mora={s.mora_paid}")
+    for a in s.allocations:
+        print(f"  inst {a.installment_number}: fine={a.fine_allocated}, mora={a.mora_allocated}")
 ```
 
-### Cash Flow Categories
+The raw cashflow (`loan.cashflow`) contains expected schedule items and undifferentiated payment items. The breakdown into fine, interest, mora, and principal is a derived view available through `loan.settlements`.
+
+### CashFlow Categories
 
 | Category | Kind | Meaning |
 |---|---|---|
 | `"disbursement"` | EXPECTED | Loan disbursement |
 | `"interest"` | EXPECTED | Scheduled interest payment |
 | `"principal"` | EXPECTED | Scheduled principal payment |
-| `"interest"` | HAPPENED | Regular interest paid (up to due date) |
-| `"mora_interest"` | HAPPENED | Mora interest paid (beyond due date) |
-| `"principal"` | HAPPENED | Principal paid |
-| `"fine"` | HAPPENED | Fine paid or applied (distinguished by sign) |
+| `"payment"` | HAPPENED | Actual payment (allocation is derived via `loan.settlements`) |
 
 ## Installments & Settlements
 

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -110,12 +110,13 @@ loan.record_payment(Money("500.00"), datetime(2024, 3, 1), "Extra payment")  # P
 print(f"Current balance: {loan.current_balance}")
 print(f"Days since last payment: {loan.days_since_last_payment()}")
 
-# Compare expected vs actual cash flow
-actual_cf = loan.get_actual_cash_flow()
-actual_payments = actual_cf.query.happened.filter_by(
-    predicate=lambda e: not e.category.isdisjoint({"interest", "principal"})
-)
-print(f"Total actual payments so far: {actual_payments.sum_amounts()}")
+# Inspect raw cashflow (expected schedule + actual payments)
+payments = loan.cashflow.query.happened.filter_by(category="payment").all()
+print(f"Payments recorded: {len(payments)}")
+
+# Inspect derived settlements for allocation detail
+for s in loan.settlements:
+    print(f"{s.payment_date.date()}: principal={s.principal_paid}, interest={s.interest_paid}")
 ```
 
 ## Cash Flow Analysis

--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -98,7 +98,7 @@ Equality between `CashFlowItem` and `CashFlowEntry` uses Python's reflected-equa
 - **`SettlementEngine`** — pure computation of settlements and installments from ledger data.
 - **`tvm.py`** — standalone functions for PV, IRR, and anticipation (eliminates circular imports).
 
-The shared `CashFlow` in the `PaymentLedger` is the single source of truth for payment data. Schedule generation (`generate_expected_cash_flow`, `get_original_schedule`, `get_amortization_schedule`) and cash-flow assembly (`get_actual_cash_flow`) stay in `Loan`.
+`Loan.cashflow` is the single source of truth — expected schedule items and actual payment items live in one `CashFlow`. All derived state (settlements, installments, balances, fines) is computed on demand via a forward pass. Schedule generation (`generate_expected_cash_flow`, `get_original_schedule`, `get_amortization_schedule`) stays in `Loan`.
 
 ### Flexible Scheduling via Due Dates
 

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -1,12 +1,37 @@
 # Loan
 
-The `Loan` class is a facade that models a personal loan with daily-compounding interest, configurable schedulers, late-payment fines, and mora interest. It delegates to five focused components, four of which live in the `engines/` subpackage:
+The `Loan` class models a personal loan where **everything emerges from the CashFlow**. A single `CashFlow` instance is the source of truth — it contains both expected items (the amortization schedule) and actual payments. Settlements, installment views, balances, and fines are all derived on demand by a forward pass over the cashflow. Nothing is decomposed or stored at payment time.
+
+## Architecture
+
+The Loan delegates computation to two focused modules in `engines/`:
 
 - **`InterestCalculator`** (`engines/interest_calculator.py`) — stateless interest math (regular + mora split). Holds `interest_rate`, `mora_interest_rate`, `mora_strategy`.
-- **`FineTracker`** (`engines/fine_tracker.py`) — fine state (`fines_applied: Dict[date, Money]`) and late-payment detection. Named constants for tolerance and window days.
-- **`PaymentLedger`** (`engines/payment_ledger.py`) — records payments as tagged CashFlowItems in a shared `CashFlow`. Category tags like `{"interest", "settlement:1"}` replace offset-based grouping. Stores lightweight `SettlementSnapshot` per settlement (payment_date, days_in_period, beginning_balance, ending_balance).
-- **`SettlementEngine`** (`engines/settlement_engine.py`) — pure computation of `Settlement` and `Installment` objects from ledger queries and the original schedule.
-- **TVM functions** (`tvm.py`) — standalone `loan_present_value`, `loan_irr`, `loan_calculate_anticipation`. Eliminates circular imports between `loan` and `present_value`.
+- **`settlement_engine`** (`engines/settlement_engine.py`) — a module of **pure functions** that compute all derived state. Key exports:
+  - `compute_state(...)` — the forward pass that produces a `LoanState` (settlements, principal balance, fines applied, fines paid total, last payment date).
+  - `build_installments(...)` — builds `Installment` objects from settlements + schedule.
+  - `compute_fines_at(...)` — determines which due dates should have fines applied.
+  - `allocate_payment_per_installment(...)` — runs the per-installment allocation algorithm.
+  - `covered_due_date_count(...)` — how many due dates are covered given a remaining balance.
+  - `is_payment_late(...)` — grace-period-aware lateness check.
+- **TVM functions** (`tvm.py`) — standalone `loan_present_value`, `loan_irr`, `loan_calculate_anticipation`.
+
+**Removed components:** `PaymentLedger` and `FineTracker` no longer exist. Their responsibilities were absorbed into the forward pass in `settlement_engine`.
+
+### CashFlow-Emergence Philosophy
+
+- `record_payment` appends **one** `CashFlowItem` (category `"payment"`) to `self.cashflow`. No fines, no decomposition, no allocation at write time.
+- All financial state is derived by `_compute_state()`, which calls `settlement_engine.compute_state`. This performs a single chronological forward pass over all payment events and fine observation dates.
+- Balance properties, settlements, installments, and fines are `@property` methods that invoke `_compute_state()` and return the relevant slice.
+
+### Fine Observation Dates
+
+Fines are event-driven. The `Loan` maintains `_fine_observation_dates: List[datetime]` — explicit timestamps at which fine calculations should be triggered during the forward pass. These are appended by:
+
+- `_on_warp(target_date)` — called by Warp after overriding TimeContext.
+- `calculate_late_fines(as_of_date)` — explicit fine observation.
+
+The forward pass merges payment events with fine observation dates into a sorted timeline. At each event, `compute_fines_at` checks which due dates are overdue and uncovered (using a temporal-proximity window, not balance-based coverage).
 
 ## Constructor Parameters
 
@@ -22,17 +47,15 @@ The `Loan` class is a facade that models a personal loan with daily-compounding 
 | `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Rate used for mora (late) interest; defaults to the base rate |
 | `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora interest is computed (see Mora Strategy below) |
 
-Payment data is stored in a shared `CashFlow` via `PaymentLedger`. Settlement grouping uses category tags (`settlement:N`) instead of positional offsets. Per-settlement metadata (`SettlementSnapshot`) captures snapshot values (beginning_balance, ending_balance) that cannot be derived from the CashFlow alone.
-
 ## Three-Date Payment Model
 
-Every payment internally carries three dates:
+Every payment carries three dates via the `CashFlowEntry`:
 
 | Date | Meaning | Default |
 |---|---|---|
-| `payment_date` | When the money moved | Required |
-| `interest_date` | Cutoff for interest accrual calculation | `payment_date` |
-| `processing_date` | When the system recorded the event (audit trail) | `self.now()` |
+| `payment_date` | When the money moved (stored as `CashFlowEntry.datetime`) | Required |
+| `interest_date` | Cutoff for interest accrual calculation (stored as `CashFlowEntry.interest_date`) | `payment_date` |
+| `processing_date` | Unused, kept for API compatibility | N/A |
 
 The **interest_date** controls how many days of interest are charged. Fewer days = less interest = discount for the borrower. This decouples "when money arrived" from "how much interest to charge."
 
@@ -47,13 +70,11 @@ Neither method takes a date parameter — they use `self.now()` (which respects 
   - **On-time payment**: interest matches the scheduled amount exactly.
   - **Late payment**: interest accrues up to `self.now()`, so the borrower pays extra interest (mora) for the days beyond the due date. Late fines are also applied automatically.
 
-  A large payment naturally covers the current installment **and** eats into future installments — the per-installment allocation and `_covered_due_date_count()` handle this without special-casing.
+  A large payment naturally covers the current installment **and** eats into future installments — the per-installment allocation and `covered_due_date_count()` handle this without special-casing.
 
 - **`anticipate_payment(amount, installments=None, description=None)`** — early payment **with interest discount**. Records payment at `self.now()` and calculates interest only up to `self.now()` (fewer days = less interest charged). When `installments` is provided (1-based numbers), the corresponding expected cash-flow items are temporally deleted via `CashFlowItem.delete()`.
 
 ### Early Payment vs Anticipation
-
-These are distinct concepts:
 
 | | `pay_installment` (early payment) | `anticipate_payment` (anticipation) |
 |---|---|---|
@@ -63,11 +84,11 @@ These are distinct concepts:
 | **Use case** | Borrower wants to pay ahead of time, no discount expected | Borrower negotiates early payoff with reduced interest |
 | **Test folder** | `up_to_date_payments/` | `antecipation/` |
 
-- **`calculate_anticipation(installments)`** — pure calculation (no side effects). Returns an `AnticipationResult(amount, installments)` with the PV-based amount the borrower must pay today to eliminate specific installments. The formula: `amount = current_balance - PV(kept payments at kept dates)`. When all remaining installments are anticipated, `amount = current_balance` (full early payoff). Validates that all requested installment numbers are unpaid and in range.
+- **`calculate_anticipation(installments)`** — pure calculation (no side effects). Returns an `AnticipationResult(amount, installments)` with the PV-based amount the borrower must pay today to eliminate specific installments.
 
 ### Explicit-Date Method
 
-- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None)`** — full control over all dates. When `interest_date` is omitted it defaults to `payment_date` (borrower gets discount for early payment). Useful in tests and batch processing where you need explicit dates.
+- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None)`** — full control over all dates. Appends one `CashFlowItem` to `self.cashflow` and returns the latest derived `Settlement`.
 
 ### Payment Allocation
 
@@ -78,136 +99,123 @@ All payment methods allocate funds **per-installment** in strict sequential orde
 3. **Regular interest** for this installment
 4. **Principal** for this installment
 
-Installment 1 is fully addressed before installment 2 receives anything. This means inst 1's mora interest is paid before inst 2's fine — the allocation order applies *within* each installment, not across all installments at once.
+Installment 1 is fully addressed before installment 2 receives anything.
 
-Interest days and principal balance are pre-computed at the top of `record_payment` using `payment_date` as the filter for existing payments, before any internal state is mutated.
+## Forward Pass: `compute_state`
+
+The central algorithm in `settlement_engine.compute_state`. It processes a merged timeline of payment events and fine observation dates in chronological order:
+
+1. For each event (payment or fine observation), compute fines using only previously processed payments.
+2. For payment events:
+   a. Compute interest (regular + mora) since last payment.
+   b. Build installment snapshot reflecting all prior allocations.
+   c. Add skipped contractual interest for periods beyond the current due-date boundary.
+   d. Run per-installment allocation (`allocate_payment_per_installment`).
+   e. Update running principal, fines paid total, and allocation history.
+   f. Create a `Settlement` object.
+3. Return `LoanState` with all settlements and running state.
+
+### `is_fully_covered` Post-Payment Fixup
+
+The `allocate_payment_per_installment` function determines `is_fully_covered` per allocation in two stages:
+
+1. **During the loop:** `Installment.allocate_from_payment` computes `is_covered` by comparing the total allocated against the installment's remaining balance. This can be `False` when interest caps prevent full interest allocation (e.g., paying all installments at once on the first due date).
+2. **After the loop:** If the post-payment balance (`ending_balance - principal_total`) is within tolerance of zero, the function does a second pass. Any allocation whose principal is fully covered gets `is_fully_covered` overridden to `True`. This handles the case where the loan is paid off but interest caps prevented exact coverage of each installment's interest obligation.
 
 ## Dynamic Amortization Schedule
 
 ### `get_amortization_schedule()`
 
-Returns a clean, ordered list of `PaymentScheduleEntry` records. Past entries come first (reflecting actual payments: real interest paid, real principal paid), followed by projected entries (recalculated from remaining principal, same rate, remaining unpaid due dates, and last payment date as the disbursement reference — same count of remaining payments, new PMT).
-
-If no payments have been made, returns the original static schedule.
+Returns a clean, ordered list of `PaymentScheduleEntry` records. Past entries come first (reflecting actual settlements), followed by projected entries (recalculated from remaining principal).
 
 ### `get_original_schedule()`
 
-Always returns the static schedule based on original loan terms, ignoring any payments. Used internally for fine calculations (`get_expected_payment_amount`) and for comparison.
-
-### PaymentScheduleEntry
-
-Each entry contains: `payment_number`, `due_date` (`date`), `days_in_period`, `beginning_balance`, `payment_amount`, `principal_payment`, `interest_payment`, `ending_balance`. The schedule auto-calculates `total_payments`, `total_interest`, and `total_principal`.
+Always returns the static schedule based on original loan terms, ignoring any payments.
 
 ## Schedulers
 
-All schedulers implement `BaseScheduler.generate_schedule(principal, interest_rate, due_dates: List[date], disbursement_date: datetime) -> PaymentSchedule`.
+All schedulers implement `BaseScheduler.generate_schedule(principal, interest_rate, due_dates, disbursement_date) -> PaymentSchedule`.
 
 ### PriceScheduler (French Amortization)
 
-Fixed total payment per period. Interest portion decreases and principal portion increases over time. The PMT is computed as `principal / sum(1 / (1 + daily_rate)^n)` where `n` is the number of days from disbursement to each due date.
+Fixed total payment per period. The PMT is computed as `principal / sum(1 / (1 + daily_rate)^n)`.
 
 #### Matching external systems with `InterestRate` precision
 
-Some lending systems (e.g. Brazilian banks) truncate the effective annual rate to a fixed number of decimal places before deriving the daily rate. This introduces a tiny difference in the daily rate which can shift the PMT by several cents on large principals.
-
-`InterestRate` supports two optional parameters to reproduce this behaviour:
-
-- `precision: int` — number of decimal places to keep on the effective annual rate during conversions. `None` (default) preserves full precision.
-- `rounding: str` — Python `decimal` rounding mode (default `ROUND_HALF_UP`).
-
-Precision is applied in `_to_effective_annual()`, the hub through which `to_daily()`, `to_monthly()`, and `to_annual()` all pass. The stored `_decimal_rate` and the converted output rate are **not** separately quantized — they naturally inherit limited precision from the quantized annual.
-
-Example: a Brazilian system stores the annual rate as `0.126825` (6 decimal places) for a 1% monthly rate whose full annual is `0.126825030...`. To match:
-
-```python
-rate = InterestRate("1% m", precision=6)
-loan = Loan(Money("10000"), rate, due_dates, disbursement_date)
-```
+`InterestRate` supports `precision: int` and `rounding: str` parameters to reproduce truncated rate behaviour from external systems.
 
 ### InvertedPriceScheduler (Constant Amortization System / SAC)
 
-Fixed principal payment per period (`principal / number_of_payments`). Interest is computed on the outstanding balance, so total payment decreases over time. The last payment adjusts to ensure zero final balance.
+Fixed principal payment per period (`principal / number_of_payments`). Interest is computed on the outstanding balance.
 
 ## Late Payments
 
-A late payment incurs two costs, both handled automatically by `pay_installment` and `record_payment`:
-
-1. **Fines** — a flat percentage of the missed installment amount.
-2. **Mora interest** — extra daily-compounded interest for the days beyond the due date.
-
 ### Fines
 
-- `calculate_late_fines(as_of_date)` scans all due dates up to `as_of_date`, applies one fine per missed due date (never duplicated), and stores them in `fines_applied: Dict[date, Money]`.
-- `is_payment_late(due_date, as_of_date)` respects `grace_period_days`.
-- `is_paid_off` requires zero `current_balance` (principal, interest, mora, and fines all zero).
-- Fine amounts are calculated from the **original** schedule (`get_original_schedule`), not the rebuilt schedule.
+- `compute_fines_at` scans all due dates up to the observation time, applies one fine per missed due date (never duplicated).
+- `_has_payment_near` implements a temporal window check: a due date is considered "covered" if sufficient payment was made within a small window (3 days before to 1 day after). This replaces the old balance-based coverage check.
+- `calculate_late_fines(as_of_date)` appends to `_fine_observation_dates` and returns the **delta** of new fines only.
+- Fine amounts are calculated from the **original** schedule.
 
 ### Mora Interest
 
-When `pay_installment` is called after the due date, `interest_date = max(self.now(), next_due_date)` causes interest to accrue beyond the due date up to the actual payment date. The interest is split into two separate `CashFlowItem` entries:
-
-- **Regular interest** (`"interest"`, kind=HAPPENED) — accrued from last payment to the due date using `interest_rate`.
-- **Mora interest** (`"mora_interest"`, kind=HAPPENED) — accrued from the due date to the payment date using `mora_interest_rate`.
-
-On-time and early payments produce only a regular interest item (no mora). Regular interest is always computed with the base `interest_rate`; mora interest uses `mora_interest_rate` (which defaults to `interest_rate` when not provided).
+When `pay_installment` is called after the due date, `interest_date = max(self.now(), next_due_date)` causes interest to accrue beyond the due date. The `InterestCalculator.compute_accrued_interest` method splits interest into regular and mora components.
 
 ### Mora Strategy (`MoraStrategy` enum)
 
-The `mora_strategy` parameter controls how mora interest is computed when a payment is late. Both strategies share the same regular interest calculation; they differ only in the base amount used for the mora portion.
-
-**`MoraStrategy.COMPOUND`** (default):
-- `regular = interest_rate.accrue(principal, regular_days)`
-- `mora = mora_interest_rate.accrue(principal + regular, mora_days)`
-
-The mora rate is applied to the accumulated balance (principal plus accrued regular interest). This means mora compounds on top of regular interest.
-
-**`MoraStrategy.SIMPLE`**:
-- `regular = interest_rate.accrue(principal, regular_days)`
-- `mora = mora_interest_rate.accrue(principal, mora_days)`
-
-The mora rate is applied independently to the outstanding principal. Regular interest does not affect the mora base.
-
-With the same rates, COMPOUND always produces more mora than SIMPLE because it applies the mora rate to a larger base. When `mora_interest_rate` equals `interest_rate` and strategy is `COMPOUND`, the result is identical to a single continuous compounding period — preserving the original behaviour before the mora strategy feature was introduced.
-
-The `interest_balance` and `mora_interest_balance` properties respect `mora_interest_rate` and `mora_strategy`. When the borrower is past the next unpaid due date, `_accrued_interest_components()` splits interest into regular and mora via `InterestCalculator.compute_accrued_interest`. `current_balance = principal_balance + interest_balance + mora_interest_balance + fine_balance`.
+**`MoraStrategy.COMPOUND`** (default): mora rate applied to `principal + regular_interest`.
+**`MoraStrategy.SIMPLE`**: mora rate applied to `principal` only.
 
 ## Balance Properties
 
-The loan's outstanding amount is decomposed into four canonical components:
+All derived from `_compute_state()`:
 
 | Property | Type | Meaning |
 |---|---|---|
-| `principal_balance` | `Money` | Outstanding principal (original minus principal payments) |
+| `principal_balance` | `Money` | Outstanding principal |
 | `interest_balance` | `Money` | Regular accrued interest since last payment |
 | `mora_interest_balance` | `Money` | Mora accrued interest (days beyond due date) |
 | `fine_balance` | `Money` | Unpaid fines (total applied minus fines paid) |
 | `current_balance` | `Money` | Sum of all four components |
 
-`_accrued_interest_components()` is the shared private helper that returns `(regular, mora)` — both `interest_balance` and `mora_interest_balance` delegate to it.
+## Installments and Settlements
 
-### Late Overpayment
+### Design Philosophy
 
-A large late payment flows through the standard allocation pipeline (fines -> interest -> principal) with no special-casing. The excess principal naturally covers multiple installments because `_covered_due_date_count()` compares the remaining balance against original schedule milestones.
+A loan is **not** a group of installments. Installments are a **consequence** of the loan terms plus a repayment strategy (scheduler). Settlements are a **consequence** of making a payment. Both are derived views computed from the cashflow, not stored state.
 
-Example: $10k loan, 3 monthly installments at 6%, borrower misses installment 1 and pays $7,000 two weeks late. Allocation: ~$67 fine, ~$72 mora interest (45 days), ~$6,861 principal. The principal reduction covers installments 1 and 2, leaving only installment 3 projected.
+### Installment (`loan.installments`)
 
-## Cash Flow Generation
+A frozen dataclass built by `build_installments` from settlements + schedule. Warp-aware.
 
-- `generate_expected_cash_flow()` — disbursement (positive, category `"disbursement"`, kind=EXPECTED) plus original scheduled payments split into interest (`"interest"`) and principal (`"principal"`) items (negative, kind=EXPECTED). Uses `get_original_schedule()`.
-- `get_actual_cash_flow()` — expected items plus recorded payments (kind=HAPPENED) and fine-application events.
+Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations`.
 
-### CashFlowEntry Hierarchy
+- `balance` — amount still owed to fully settle this installment.
+- `is_fully_paid` — `True` when `balance` is within tolerance of zero.
+- `allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` — allocates in priority order (fine -> mora -> interest -> principal), each capped by both the installment's remaining obligation and running caps.
 
-`CashFlowEntry` is an abstract base class with two concrete subclasses:
+### Settlement (`loan.settlements`)
 
-- **`ExpectedCashFlowEntry`** — projected items (e.g. loan schedule). `kind` property returns `CashFlowType.EXPECTED`.
-- **`HappenedCashFlowEntry`** — recorded facts (e.g. actual payments). `kind` property returns `CashFlowType.HAPPENED`.
+A frozen dataclass capturing how a single payment was allocated. Derived by the forward pass.
 
-The `CashFlowItem` constructor accepts `kind=CashFlowType.EXPECTED` or `kind=CashFlowType.HAPPENED` (default) and instantiates the correct subclass. Filtering works via `entry.kind == CashFlowType.EXPECTED`, `isinstance(entry, ExpectedCashFlowEntry)`, or the query shortcuts `cf.query.expected` / `cf.query.happened`.
+Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`.
+
+### SettlementAllocation
+
+Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`.
+
+Shared between Settlement (forward view) and Installment (reverse view).
+
+### LoanState
+
+Internal dataclass returned by `compute_state`: `settlements`, `principal_balance`, `fines_applied`, `fines_paid_total`, `last_payment_date`.
+
+## Cash Flow Views
+
+- `generate_expected_cash_flow()` — expected schedule items only.
+- `get_actual_cash_flow()` — expected items + decomposed settlement items (fine, interest, mora, principal as separate `CashFlowItem`s) + fine application events.
 
 ### CashFlowItem Categories
-
-Categories are clean domain names. The expected-vs-happened distinction is structural (subclass type), not encoded in the category string:
 
 | Category | Kind | Meaning |
 |---|---|---|
@@ -215,81 +223,16 @@ Categories are clean domain names. The expected-vs-happened distinction is struc
 | `"tax"` | EXPECTED | Tax deducted at disbursement |
 | `"interest"` | EXPECTED | Scheduled interest payment |
 | `"principal"` | EXPECTED | Scheduled principal payment |
-| `"interest"` | HAPPENED | Regular interest paid (up to due date) |
-| `"mora_interest"` | HAPPENED | Mora interest paid (beyond due date) |
-| `"principal"` | HAPPENED | Principal paid |
-| `"fine"` | HAPPENED | Fine paid or fine applied (distinguished by sign) |
-
-## Installments and Settlements
-
-### Design Philosophy
-
-A loan is **not** a group of installments. Installments are a **consequence** of the loan terms plus a repayment strategy (scheduler). Settlements are a **consequence** of making a payment. Both are derived views computed from the cash flow, not stored state.
-
-### Installment (`loan.installments`)
-
-A frozen dataclass representing one period of the repayment plan. Built from the original schedule on demand. Warp-aware: all fields reflect the state at `self.now()`.
-
-Fields: `number`, `due_date` (`date`), `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations: List[SettlementAllocation]`.
-
-Computed properties:
-- `balance: Money` — the amount still owed to fully settle this installment: `(expected_principal + expected_interest + expected_mora + expected_fine) - (principal_paid + interest_paid + mora_paid + fine_paid)`. Clamped to zero.
-- `is_fully_paid: bool` — `True` when `balance` is zero. Single source of truth for payment status.
-
-Field semantics:
-- `expected_payment`, `expected_principal`, `expected_interest` come from the original schedule.
-- `expected_fine` comes from `Loan.fines_applied` for the installment's due date.
-- `expected_mora` is computed by the Loan: for covered installments it equals the sum of prior `mora_allocated` values; for the first uncovered overdue installment it is prior `mora_allocated` **plus** newly accrued mora (from last payment to `self.now()`) via `InterestCalculator.compute_accrued_interest`; for all other installments it is zero. The cumulative form ensures `Installment.allocate` correctly computes `mora_owed = expected_mora - mora_paid` even when the same installment receives mora across multiple settlements.
-- `*_paid` fields are aggregated totals from all settlement allocations attributed to this installment.
-- `allocations` is the reverse view of Settlement: all `SettlementAllocation`s that touched this installment.
-- Created via `Installment.from_schedule_entry(entry, allocations, expected_mora, expected_fine)`.
-- `allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` — allocates from a single remaining payment amount in priority order (fine → mora → interest → principal). Each component is capped by both the installment's remaining obligation and the running cap. Returns `(SettlementAllocation, updated_remaining, updated_fine_remaining, updated_mora_remaining, updated_interest_remaining)`. Used by `SettlementEngine.allocate_payment_per_installment` to walk through installments in order.
-- `PaymentScheduleEntry` remains the internal scheduler data structure. `Installment` is the public-facing API.
-
-### Settlement (`loan.settlements`, returned by payment methods)
-
-A frozen dataclass capturing how a single payment was allocated. Reconstructed from the cash flow (via `PaymentLedger`) rather than stored as separate state.
-
-Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations: List[SettlementAllocation]`.
-
-- `allocations` shows per-installment detail: which installments the payment covered and how much principal/interest/mora/fine went to each.
-- All three payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) return a `Settlement`.
-- The `settlements` property reconstructs all settlements by querying the cash flow. Warp-aware: only includes settlements with `payment_date <= self.now()`.
-- **Reconciliation invariant:** For every settlement, each component total must equal the sum of its per-installment allocations: `settlement.X_paid == sum(a.X_allocated for a in settlement.allocations)` for X in {principal, interest, mora, fine}.
-
-#### Per-Installment Allocation
-
-Payments are allocated **per-installment in strict sequential order**. Within each installment the priority is fine → mora → interest → principal. Installment 1's obligations are fully addressed before installment 2 receives anything.
-
-The allocation is performed by `SettlementEngine.allocate_payment_per_installment(amount, installments, ending_balance, fine_cap, interest_cap, mora_cap)`. The caps bound the total that may be allocated to each non-principal category — during live allocation they come from loan-level accrual (preserving early-payment discounts); during reconstruction they match recorded CashFlowItem totals.
-
-1. Build an installment snapshot (`_build_pre_settlement_installments`) reflecting all prior settlement allocations — avoids circular dependency with `self.settlements`.
-2. For each installment in order, `Installment.allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` processes fine → mora → interest → principal sequentially, each capped by both the installment's remaining obligation and the running cap.
-3. Principal allocation is further capped by reserving funds for later installments' interest and mora: `available_for_principal = remaining - (interest_remaining + mora_remaining)`.
-4. After the installment loop, any remaining cap amounts (interest/mora spill from schedule rounding) are attributed to their respective totals, not to principal.
-5. Sub-cent allocations (< 0.01) are included in the component totals for precision but excluded from the `allocations` list to avoid dust entries.
-6. When the loan is fully paid off (ending_balance ≈ 0), installments whose principal is fully covered are marked `is_fully_covered`.
-
-The `settlements` property maintains a running `allocations_by_number` dict so each settlement sees the cumulative allocation state from prior settlements.
-
-### AnticipationResult
-
-Returned by `calculate_anticipation()`. Frozen dataclass with:
-- `amount: Money` — the total amount to pay today to eliminate the specified installments.
-- `installments: List[Installment]` — the installments being anticipated (removed).
-
-### SettlementAllocation
-
-Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`.
-
-Shared between Settlement (forward view: "this payment covered these installments") and Installment (reverse view: "these allocations covered me").
+| `"payment"` | HAPPENED | Actual payment (undifferentiated — decomposition is derived) |
+| `"fine"` | — | Fine applied or paid (in `get_actual_cash_flow` output) |
+| `"interest"` | — | Interest paid (in `get_actual_cash_flow` output) |
+| `"mora_interest"` | — | Mora interest paid (in `get_actual_cash_flow` output) |
+| `"principal"` | — | Principal paid (in `get_actual_cash_flow` output) |
 
 ## TVM Sugar
 
 - `loan.present_value(discount_rate=None, valuation_date=None)` — defaults to the loan's own rate and `loan.now()`.
 - `loan.irr(guess=None)` — IRR of the expected cash flow.
-
-Both methods are time-aware: inside a `Warp` context they reflect the warped date.
 
 ## Key Learnings
 
@@ -297,116 +240,44 @@ Both methods are time-aware: inside a `Warp` context they reflect the warped dat
 
 **Symptom:** After paying all scheduled installments, a residual balance of ~$103.36 persisted on a $10,000 loan.
 
-**Root cause:** `record_payment` computed interest days via `self.days_since_last_payment(payment_date)`, which filtered payments by `self.now()` (real wall-clock time). When installments were recorded sequentially for future dates, previously-recorded future payments were invisible, leading to inflated day counts, too much interest, too little principal, and a non-zero residual.
+**Root cause:** `record_payment` computed interest days via `self.days_since_last_payment(payment_date)`, which filtered payments by `self.now()` (real wall-clock time). When installments were recorded sequentially for future dates, previously-recorded future payments were invisible.
 
-**Fix:** Pre-compute `days` and `principal_balance` at the top of `record_payment` using `payment_date` as the filter, before step 1 modifies the payment ledger.
+**Fix:** Pre-compute `days` and `principal_balance` at the top of `record_payment` using `payment_date` as the filter, before any internal state is mutated.
 
-**Lesson:** Any method that reads loan state and then mutates it must snapshot the relevant values first. Time-dependent queries inside mutation methods must use the payment's own date, not wall-clock time.
-
-### Warp creates deep clones (important for sugar methods)
-
-Sugar methods (`pay_installment`, `anticipate_payment`) use `self.now()` for the payment date. Inside a `Warp` context, `self.now()` returns the warped date — but payments on the warped loan do **not** persist back to the original. This is by design: Warp is for observation, not mutation. Use `record_payment(amount, date)` or `record_payment(...)` with explicit dates to set up loan state outside of Warp.
+**Lesson:** Any method that reads loan state and then mutates it must snapshot the relevant values first.
 
 ### Due date coverage uses cumulative principal, not payment count (fixed 2026-02-20)
 
-**Symptom:** `_next_unpaid_due_date()` and `get_amortization_schedule()` would miscount covered due dates when partial payments, overpayments, or multiple anticipations were made.
-
-**Root cause:** The original implementation used the number of schedule entries to determine how many due dates were covered — assuming one `record_payment` call = one installment. This broke with partial payments (inflated count) and large overpayments (undercounted).
-
-**Fix:** `_covered_due_date_count()` compares the remaining principal (from the last actual entry) against the original schedule's `ending_balance` milestones. A due date is covered when remaining principal is at or below that entry's ending balance.
+**Fix:** `covered_due_date_count()` compares the remaining principal against the original schedule's `ending_balance` milestones. A due date is covered when remaining principal is at or below that entry's ending balance.
 
 **Lesson:** Avoid coupling "number of events" to "progress through a schedule." Use the financial state (principal balance) as the source of truth.
 
-### Merged schedule is a clean list, not tagged entries (fixed 2026-02-20)
-
-**Symptom:** Tests and consumers of `get_amortization_schedule()` had to filter entries by an `is_actual` flag to separate past payments from projected ones, leading to boilerplate like `[e for e in schedule if not e.is_actual]`.
-
-**Root cause:** `PaymentScheduleEntry` carried an `is_actual: bool` field that leaked an internal implementation detail into the data model. No business logic depended on the flag — it only served test filtering.
-
-**Fix:** Removed `is_actual` from `PaymentScheduleEntry` entirely. The merged schedule is a clean, ordered list: past entries (from `PaymentLedger.actual_schedule_entries()`) come first by construction, followed by projected entries. Tests use positional indexing (`schedule[0]` for the recorded payment, `schedule[1:]` for projected) instead of filtering.
-
-**Lesson:** Don't tag data with internal metadata that consumers must filter. If ordering already encodes the distinction, a flag is redundant. Keep data structures minimal — the fewer fields, the simpler the API.
-
 ### Late payments undercharged interest (fixed 2026-02-20)
 
-**Symptom:** `pay_installment()` called after the due date charged interest only up to the due date, not up to the actual payment date. The borrower was undercharged for the extra late days.
-
-**Root cause:** `pay_installment` set `interest_date = self._next_unpaid_due_date()`. When the borrower paid late (now > due_date), interest was capped at the due date instead of extending to the actual payment date.
-
-**Fix:** Changed to `interest_date = max(self.now(), self._next_unpaid_due_date())`. Early/on-time payments still accrue interest up to the due date (unchanged). Late payments now accrue interest up to `self.now()` (extra days charged).
-
-**Lesson:** A late payment incurs two costs: fines (flat percentage of missed payment) and mora interest (extra daily-compounded interest beyond the due date). Both must be accounted for. The `max()` pattern ensures one method handles all three timing scenarios correctly.
-
-### Same-time payments misattributed (fixed 2026-02-27, eliminated by design 2026-03-20)
-
-**Symptom:** When two payments were recorded at the exact same datetime, the second settlement had all-zero amounts.
-
-**Original fix:** Replaced datetime-based grouping with positional offset tracking (`_payment_item_offsets`).
-
-**Current state:** The `PaymentLedger` refactoring eliminated this bug class entirely. Payment items are now tagged with `frozenset({"interest", "settlement:1"})` category tags when written to the shared `CashFlow`. Querying by tag (`settlement:N`) is unambiguous regardless of datetime values or ordering. No offset tracking needed.
-
-**Lesson:** When grouping requires identity (not equality), use explicit tags rather than value-based boundaries.
-
-### Day-count mismatch with non-midnight disbursement (fixed 2026-03-20)
-
-**Symptom:** When `disbursement_date` had a non-midnight time component (e.g. 19:53), the first installment was never marked `is_fully_covered` even when the payment was large enough to cover it. The settlement interest was consistently lower than the scheduled interest by about one day's worth.
-
-**Root cause:** The scheduler computes `days_in_period` using date subtraction (`(due_date - prev_date).days`), but `PaymentLedger.compute_interest_snapshot` used datetime subtraction (`(interest_date - last_pay_date).days`). Python's `timedelta.days` truncates: `(April 12 00:00 - March 6 19:53).days == 36`, while `(April 12 - March 6).days == 37`. The 1-day shortfall meant settlement interest was less than the schedule expected, so `Installment.allocate` could not fully cover the first installment's interest obligation.
-
-**Fix:** Use `.date()` on both operands in all three day-count calculations: `compute_interest_snapshot`, `_build_installments_snapshot` (mora days), and `days_since_last_payment`. This aligns with the scheduler's calendar-day convention. Financial day counting operates on dates, not timestamps.
-
-**Lesson:** When one subsystem counts days using dates and another uses datetimes, the results will diverge whenever a timestamp has a non-midnight time. Normalize to the same type (`.date()`) at every day-count boundary.
-
-### Mora under-distributed across allocations (fixed 2026-03-19)
-
-**Symptom:** `settlement.mora_paid` was consistently higher than `sum(a.mora_allocated for a in settlement.allocations)`. The difference was always positive and exactly equalled the mora allocated to the same installment in prior settlements.
-
-**Root cause:** `_build_installments_snapshot` computed `expected_mora` for the first uncovered installment (`i == covered`) using only the newly accrued mora for the current period. It did not include mora already attributed from prior settlements. When `Installment.allocate` ran `mora_owed = expected_mora - mora_paid`, the `mora_paid` (cumulative from prior allocations) was subtracted from a non-cumulative `expected_mora`, producing an artificially low `mora_owed` and leaving mora unallocated.
-
-**Trigger condition:** Two or more consecutive late payments where the same installment remains uncovered (partial late payments).
-
-**Fix:** `expected_mora = prior_mora + accrued_mora` — sum the mora already allocated from prior settlements before adding the newly accrued amount. This makes the `i == covered` branch cumulative, matching the pattern already used for fully-covered installments (`i < covered`).
-
-**Lesson:** When a derived quantity (expected_mora) participates in a subtraction against a cumulative counter (mora_paid), the derived quantity must also be cumulative. Mixing period-level and cumulative values in the same expression produces silent under-distribution.
+**Fix:** `interest_date = max(self.now(), next_due_date)` in `pay_installment`. Late payments now accrue interest up to `self.now()`.
 
 ### Payment allocation order was loan-level, not per-installment (fixed 2026-03-20)
 
-**Symptom:** When all 6 installments were overdue and the borrower made a partial payment (R$ 382.97), fines were spread across all 6 installments first (R$ 45.90), then mora interest (R$ 250.49), then regular interest (R$ 86.62) — leaving nothing for principal. The payment "disappeared" into penalties without retiring any principal.
+**Fix:** Rewrote allocation to be strictly per-installment sequential. `allocate_payment_per_installment` walks installments in order. Within each, `Installment.allocate_from_payment` applies fine -> mora -> interest -> principal.
 
-**Root cause:** The allocation logic treated each component (fine, mora, interest, principal) as a **separate pool** distributed across all installments. This meant installment 6's fine was paid before installment 1's mora interest, violating the intended priority.
-
-**Fix:** Rewrote allocation to be strictly **per-installment sequential**. `SettlementEngine.allocate_payment_per_installment` walks installments in order. Within each, `Installment.allocate_from_payment` applies fine → mora → interest → principal. Only after inst 1 is fully addressed does inst 2 receive anything. Running caps (`fine_remaining`, `mora_remaining`, `interest_remaining`) prevent over-allocation beyond loan-level accruals. The same method is used for both live allocation and reconstruction (ensuring consistency).
-
-**Lesson:** When allocation priority is defined as "fine before mora before interest before principal," clarify whether that order applies *across the loan* or *within each installment*. The per-installment interpretation is correct for Brazilian lending: installment 1's mora interest is more urgent than installment 2's fine.
+**Lesson:** The per-installment interpretation is correct for Brazilian lending: installment 1's mora interest is more urgent than installment 2's fine.
 
 ### Sub-cent precision loss in allocation loop (fixed 2026-03-20)
 
-**Symptom:** After making all scheduled payments on a 12-installment loan, the balance was R$ 5.17 instead of zero. SA integration tests showed a ~0.001 discrepancy between Python replay and stored settlement balances, cascading to ~0.01 per settlement.
+**Fix:** Use `raw_amount` comparisons in the allocation loop instead of `Money`'s 2dp-rounded methods. Sub-cent allocations are included in component totals but excluded from the `allocations` list.
 
-**Root cause:** `Money.is_zero()` and `Money.is_positive()` use `real_amount` (rounded to 2 decimal places). When the PriceScheduler rounds interest to 2dp but accrued interest has full precision, the difference (e.g., 0.00132) creates a sub-cent remainder. The allocation loop's `remaining.is_zero()` check treated this as zero and broke early. The spill logic's `remaining.is_positive()` also treated it as non-positive. The sub-cent amount was silently lost — not attributed to interest, principal, or anything. Over 12 installments the losses compounded to R$ 5.17.
-
-**Fix:** Use `raw_amount` comparisons in the allocation loop: `not remaining.raw_amount` instead of `remaining.is_zero()`, `remaining.raw_amount > 0` instead of `remaining.is_positive()`, and `allocation.total_allocated.raw_amount <= 0` instead of `not allocation.total_allocated.is_positive()`. This preserves full precision for accounting while keeping `Money`'s 2dp semantics for business display.
-
-Sub-cent allocations (where `total_allocated.real_amount` rounds to zero) are included in the component totals but excluded from the `allocations` list. This ensures correct totals without creating dust entries in the per-installment breakdown.
-
-**Lesson:** `Money`'s `real_amount`-based comparisons (`is_zero`, `is_positive`, `>`, `<`) are correct for business display but dangerous in accounting loops where sub-cent values compound. Use `raw_amount` in tight allocation loops. The allocation pipeline has two audiences: the CashFlowItem totals (need full precision) and the per-installment breakdown (display-level precision is fine).
+**Lesson:** `Money`'s `real_amount`-based comparisons are correct for business display but dangerous in accounting loops where sub-cent values compound.
 
 ### Contractual interest lost for later installments (fixed 2026-03-22)
 
-**Symptom:** When a partial payment left `_next_unpaid_due_date` stuck at D1 (because remaining principal > schedule[0].ending_balance), any subsequent payment after D1 received `interest_accrued = 0` from `compute_accrued_interest`. This zero became the `interest_cap` in `allocate_payment_per_installment`, preventing contractual interest for installments D2, D3, etc. from being allocated. The interest was permanently lost.
+**Fix:** `_skipped_contractual_interest` sums unpaid contractual interest for installments past `next_due` and up to `cutoff`. The forward pass uses `interest_cap = regular + skipped` to ensure later periods' contractual interest is included.
 
-**Root cause:** `compute_accrued_interest` only considers a single due-date boundary (`next_unpaid_due_date`). When `last_payment_date > due_date`, it returns `regular = 0` (mora only). This is correct for the one period it covers, but installments beyond that boundary have their own contractual interest obligations that were never captured in any `interest_cap`.
+### is_fully_covered used pre-payment balance (fixed 2026-03-22)
 
-**Fix (two sites):**
+**Symptom:** When a single payment fully paid off the loan, some allocations had `is_fully_covered = False` even though the loan's remaining balance was zero. This happened because the interest cap prevented full interest allocation to later installments (their interest hadn't accrued yet), and the coverage check failed since `total_allocated < installment.balance`.
 
-1. **`Loan.record_payment`**: After building the installment snapshot, compute a `skipped_contractual` sum — the total unpaid contractual interest for installments whose due dates fall strictly after `next_due` and on or before `interest_date`. Set `interest_cap = interest_accrued + skipped_contractual`. This preserves early-payment discounts (no installments are "skipped" when paying early/on-time) while ensuring later periods' contractual interest is included for late payments.
+**Root cause:** `allocate_payment_per_installment` checked `ending_balance <= tolerance` at the **start** of the function (line 183), using the pre-payment principal. For a payment that fully pays off the loan, the pre-payment balance is the full remaining principal, so this check was always `False`. The override that corrects `is_fully_covered` when principal is fully covered never activated.
 
-2. **`SettlementEngine.compute_settlement`**: The reconstruction phase must use the same effective `interest_cap` as the live allocation to maintain the reconciliation invariant. Recompute `interest_accrued` and `skipped_contractual` from the snapshot data and pass the result as `interest_cap_override` to `build_settlement_allocations`.
+**Fix:** Moved the override to a post-loop fixup. After the allocation loop and spillover handling, compute `post_balance = ending_balance - principal_total`. If `post_balance <= tolerance`, iterate through allocations and fix `is_fully_covered` for any installment whose principal was fully allocated (within tolerance).
 
-The helper `SettlementEngine._skipped_contractual_interest(installments, next_due, cutoff)` is shared by both sites.
-
-**Why the condition is `inst.due_date > next_due`** (strict inequality): The installment AT `next_due` is already handled by `compute_accrued_interest` — its regular interest is either computed (when `regular_days > 0`) or intentionally zero (early payment discount). Only installments *beyond* that boundary are "skipped."
-
-**Lesson:** When a financial engine uses a single-period boundary to compute an aggregate (like interest caps), verify that multi-period scenarios don't leave some periods uncounted. A global cap that combines the current period's accrual with the sum of skipped periods' contractual obligations avoids the gap.
-
-**Follow-up (out of scope):** `_accrued_interest_components()` (used by `interest_balance` / `mora_interest_balance`) has the same single-due-date limitation, meaning balance display can show 0 interest when contractual interest is owed. This is display-only and does not cause data loss.
+**Lesson:** When a boolean flag depends on the outcome of the allocation, it must be evaluated after the allocation completes, not before. Pre-payment state is only useful for pre-conditions; coverage determination requires post-payment state.

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -210,10 +210,11 @@ Shared between Settlement (forward view) and Installment (reverse view).
 
 Internal dataclass returned by `compute_state`: `settlements`, `principal_balance`, `fines_applied`, `fines_paid_total`, `last_payment_date`.
 
-## Cash Flow Views
+## Cash Flow
 
-- `generate_expected_cash_flow()` — expected schedule items only.
-- `get_actual_cash_flow()` — expected items + decomposed settlement items (fine, interest, mora, principal as separate `CashFlowItem`s) + fine application events.
+`loan.cashflow` is the single source of truth -- a `CashFlow` containing both expected items (schedule) and actual payment items. Allocation detail (fine, interest, mora, principal breakdown) is available through `loan.settlements`, not the cashflow.
+
+- `generate_expected_cash_flow()` — convenience filter returning expected schedule items only.
 
 ### CashFlowItem Categories
 
@@ -223,11 +224,7 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 | `"tax"` | EXPECTED | Tax deducted at disbursement |
 | `"interest"` | EXPECTED | Scheduled interest payment |
 | `"principal"` | EXPECTED | Scheduled principal payment |
-| `"payment"` | HAPPENED | Actual payment (undifferentiated — decomposition is derived) |
-| `"fine"` | — | Fine applied or paid (in `get_actual_cash_flow` output) |
-| `"interest"` | — | Interest paid (in `get_actual_cash_flow` output) |
-| `"mora_interest"` | — | Mora interest paid (in `get_actual_cash_flow` output) |
-| `"principal"` | — | Principal paid (in `get_actual_cash_flow` output) |
+| `"payment"` | HAPPENED | Actual payment (allocation derived via `loan.settlements`) |
 
 ## TVM Sugar
 

--- a/money_warp/cash_flow/entry.py
+++ b/money_warp/cash_flow/entry.py
@@ -42,12 +42,17 @@ class CashFlowEntry(ABC):
 
     ``category`` is a frozenset of string tags. A single string is
     normalized to ``frozenset({string})`` by :class:`CashFlowItem`.
+
+    ``interest_date`` is an optional secondary date used by loan payments
+    to indicate the cutoff for interest accrual. When ``None``, the
+    entry's ``datetime`` is used as the interest accrual cutoff.
     """
 
     amount: Money
     datetime: datetime
     description: Optional[str] = None
     category: FrozenSet[str] = frozenset()
+    interest_date: Optional[datetime] = None
 
     @property
     @abstractmethod

--- a/money_warp/cash_flow/item.py
+++ b/money_warp/cash_flow/item.py
@@ -45,6 +45,7 @@ class CashFlowItem:
         entry: Optional[CashFlowEntry] = None,
         time_context: Optional[TimeContext] = None,
         effective_date: Optional["datetime"] = None,
+        interest_date: Optional["datetime"] = None,
     ) -> None:
         if entry is not None:
             initial = entry
@@ -58,6 +59,7 @@ class CashFlowItem:
                 datetime=datetime,
                 description=description,
                 category=_normalize_category(category),
+                interest_date=interest_date,
             )
         else:
             raise TypeError(
@@ -121,6 +123,11 @@ class CashFlowItem:
     def kind(self) -> CashFlowType:
         entry = self._require_resolved()
         return entry.kind
+
+    @property
+    def interest_date(self) -> Optional["datetime"]:
+        entry = self._require_resolved()
+        return entry.interest_date
 
     # ------------------------------------------------------------------
     # Delegated helpers

--- a/money_warp/loan/__init__.py
+++ b/money_warp/loan/__init__.py
@@ -1,6 +1,5 @@
 """Loan module for personal loan modeling with flexible payment schedules."""
 
-from .engines.fine_tracker import FineTracker
 from .engines.interest_calculator import InterestCalculator, MoraStrategy
 from .installment import Installment
 from .loan import Loan
@@ -8,7 +7,6 @@ from .settlement import AnticipationResult, Settlement, SettlementAllocation
 
 __all__ = [
     "AnticipationResult",
-    "FineTracker",
     "Installment",
     "InterestCalculator",
     "Loan",

--- a/money_warp/loan/engines/__init__.py
+++ b/money_warp/loan/engines/__init__.py
@@ -1,15 +1,22 @@
 """Computational engines for loan payment processing."""
 
-from .fine_tracker import FineTracker
 from .interest_calculator import InterestCalculator, MoraStrategy
-from .payment_ledger import PaymentLedger, SettlementSnapshot
-from .settlement_engine import SettlementEngine
+from .settlement_engine import (
+    LoanState,
+    build_installments,
+    compute_fines_at,
+    compute_state,
+    covered_due_date_count,
+    is_payment_late,
+)
 
 __all__ = [
-    "FineTracker",
     "InterestCalculator",
+    "LoanState",
     "MoraStrategy",
-    "PaymentLedger",
-    "SettlementEngine",
-    "SettlementSnapshot",
+    "build_installments",
+    "compute_fines_at",
+    "compute_state",
+    "covered_due_date_count",
+    "is_payment_late",
 ]

--- a/money_warp/loan/engines/settlement_engine.py
+++ b/money_warp/loan/engines/settlement_engine.py
@@ -1,376 +1,447 @@
-"""Settlement and installment computation from payment data."""
+"""Settlement computation from cashflow data.
 
-from datetime import date, datetime
-from typing import Dict, List, Optional
+All allocation emerges from the CashFlow + schedule. Nothing is
+decomposed or stored at payment time. The forward pass through
+payments replicates the financial allocation algorithm (per-installment
+priority: fine -> mora -> interest -> principal) on demand.
+"""
 
+from datetime import date, datetime, timedelta
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from ...interest_rate import InterestRate
 from ...money import Money
 from ...scheduler import PaymentSchedule
 from ...tz import to_datetime
 from ..installment import Installment
 from ..settlement import Settlement, SettlementAllocation
 from .interest_calculator import InterestCalculator
-from .payment_ledger import PaymentLedger
 
 _COVERAGE_TOLERANCE = Money("0.01")
 
 
-class SettlementEngine:
-    """Pure computation of settlements and installments from ledger data.
+@dataclass(frozen=True)
+class LoanState:
+    """Snapshot of derived loan state from the forward pass."""
 
-    Holds no mutable state — all data comes from the PaymentLedger
-    (which queries the shared CashFlow) and the original schedule.
+    settlements: List[Settlement]
+    principal_balance: Money
+    fines_applied: Dict[date, Money]
+    fines_paid_total: Money
+    last_payment_date: datetime
+
+
+# ------------------------------------------------------------------
+# Coverage
+# ------------------------------------------------------------------
+
+def covered_due_date_count(
+    remaining_balance: Money,
+    schedule: PaymentSchedule,
+) -> int:
+    """How many due dates are covered given a remaining principal balance."""
+    covered = 0
+    for entry in schedule:
+        if remaining_balance <= entry.ending_balance + _COVERAGE_TOLERANCE:
+            covered += 1
+        else:
+            break
+    return covered
+
+
+# ------------------------------------------------------------------
+# Fine computation
+# ------------------------------------------------------------------
+
+def is_payment_late(due_date: date, grace_period_days: int, as_of: datetime) -> bool:
+    """Whether a payment is late considering the grace period."""
+    effective_due = due_date + timedelta(days=grace_period_days)
+    return as_of.date() > effective_due
+
+
+_WINDOW_DAYS_BEFORE = 3
+_WINDOW_DAYS_AFTER = 1
+
+
+def _has_payment_near(
+    due_date: date,
+    as_of: datetime,
+    schedule: PaymentSchedule,
+    payment_entries: list,
+) -> bool:
+    """Check if sufficient payment has been made near a due date.
+
+    Replicates the old FineTracker's temporal proximity check:
+    exact-date match first, then a small window around the due date.
     """
+    expected = Money.zero()
+    for entry in schedule:
+        if entry.due_date == due_date:
+            expected = entry.payment_amount
+            break
+    if expected.is_zero():
+        return False
 
-    def __init__(self, interest_calc: InterestCalculator) -> None:
-        self._interest = interest_calc
+    exact = [
+        p for p in payment_entries
+        if p.datetime.date() == due_date and p.datetime <= as_of
+    ]
+    if sum((p.amount for p in exact), Money.zero()) >= (expected - _COVERAGE_TOLERANCE):
+        return True
 
-    # ------------------------------------------------------------------
-    # Coverage
-    # ------------------------------------------------------------------
+    window_start = to_datetime(due_date - timedelta(days=_WINDOW_DAYS_BEFORE))
+    window_end = min(as_of, to_datetime(due_date + timedelta(days=_WINDOW_DAYS_AFTER)))
+    window = [
+        p for p in payment_entries
+        if window_start <= p.datetime <= window_end and p.datetime <= as_of
+    ]
+    return sum((p.amount for p in window), Money.zero()) >= (expected - _COVERAGE_TOLERANCE)
 
-    @staticmethod
-    def covered_due_date_count(
-        remaining_balance: Money,
-        schedule: PaymentSchedule,
-    ) -> int:
-        """How many due dates are covered given a remaining principal balance.
 
-        Unifies the previously duplicated ``_covered_due_date_count`` and
-        ``_covered_count_for_balance`` methods.
-        """
-        covered = 0
+def compute_fines_at(
+    as_of: datetime,
+    due_dates: List[date],
+    schedule: PaymentSchedule,
+    fine_rate: InterestRate,
+    grace_period_days: int,
+    existing_fines: Dict[date, Money],
+    payment_entries: list,
+) -> Dict[date, Money]:
+    """Compute fines for overdue due dates as of *as_of*.
+
+    A due date gets a fine when it is past the grace period AND
+    no sufficient payment was made near it (within a small window).
+    """
+    fines = dict(existing_fines)
+
+    for dd in due_dates:
+        if dd in fines:
+            continue
+        if not is_payment_late(dd, grace_period_days, as_of):
+            continue
+        if _has_payment_near(dd, as_of, schedule, payment_entries):
+            continue
         for entry in schedule:
-            if remaining_balance <= entry.ending_balance + _COVERAGE_TOLERANCE:
-                covered += 1
-            else:
-                break
-        return covered
-
-    # ------------------------------------------------------------------
-    # Contractual interest for skipped periods
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _skipped_contractual_interest(
-        installments: List[Installment],
-        next_due: Optional[date],
-        cutoff: date,
-    ) -> Money:
-        """Sum unpaid contractual interest for installments past *next_due*.
-
-        Returns the total ``expected_interest - interest_paid`` for every
-        installment whose due date falls strictly after *next_due* and on
-        or before *cutoff*.  These are periods that
-        :meth:`InterestCalculator.compute_accrued_interest` cannot reach
-        because it only considers one due-date boundary.
-        """
-        if next_due is None:
-            return Money.zero()
-        total = Money.zero()
-        for inst in installments:
-            if inst.due_date > next_due and inst.due_date <= cutoff:
-                owed = inst.expected_interest - inst.interest_paid
-                if owed.is_positive():
-                    total = total + owed
-        return total
-
-    # ------------------------------------------------------------------
-    # Per-installment payment allocation
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def allocate_payment_per_installment(
-        amount: Money,
-        installments: List[Installment],
-        ending_balance: Money,
-        fine_cap: Money,
-        interest_cap: Money,
-        mora_cap: Money,
-    ) -> tuple:
-        """Allocate a payment across installments in priority order.
-
-        Each installment is processed sequentially.  Within each
-        installment the priority is fine -> mora -> interest -> principal.
-        Installment 1's obligations are fully addressed before
-        installment 2 receives anything.
-
-        *fine_cap*, *interest_cap*, and *mora_cap* bound the total
-        amount that may be allocated to each category.  During live
-        allocation these come from the loan-level accrual (preserving
-        the early-payment discount).  During reconstruction they match
-        the recorded CashFlowItem totals.
-
-        Any payment remainder after all installment obligations are met
-        is attributed to principal (overpayment).
-
-        Returns:
-            ``(fine_total, mora_total, interest_total, principal_total,
-            allocations)`` where *allocations* is a list of
-            :class:`SettlementAllocation`.
-        """
-        loan_fully_paid = ending_balance <= _COVERAGE_TOLERANCE
-        remaining = amount
-        fine_remaining = fine_cap
-        mora_remaining = mora_cap
-        interest_remaining = interest_cap
-        fine_total = Money.zero()
-        mora_total = Money.zero()
-        interest_total = Money.zero()
-        principal_total = Money.zero()
-        allocations: List[SettlementAllocation] = []
-
-        for inst in installments:
-            if not remaining.raw_amount:
+            if entry.due_date == dd:
+                fine_amount = Money(entry.payment_amount.raw_amount * fine_rate.as_decimal())
+                fines[dd] = fine_amount
                 break
 
-            allocation, remaining, fine_remaining, mora_remaining, interest_remaining = inst.allocate_from_payment(
-                remaining,
-                fine_remaining,
-                mora_remaining,
-                interest_remaining,
-            )
+    return fines
 
-            if allocation.total_allocated.raw_amount <= 0:
-                continue
 
-            fine_total = fine_total + allocation.fine_allocated
-            mora_total = mora_total + allocation.mora_allocated
-            interest_total = interest_total + allocation.interest_allocated
-            principal_total = principal_total + allocation.principal_allocated
+# ------------------------------------------------------------------
+# Skipped contractual interest
+# ------------------------------------------------------------------
 
-            if not allocation.total_allocated.is_positive():
-                continue
+def _skipped_contractual_interest(
+    installments: List[Installment],
+    next_due: Optional[date],
+    cutoff: date,
+) -> Money:
+    """Sum unpaid contractual interest for installments past *next_due*.
 
-            if loan_fully_paid and not allocation.is_fully_covered:
-                principal_owed = inst.expected_principal - inst.principal_paid
-                if allocation.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
-                    allocation = SettlementAllocation(
-                        installment_number=allocation.installment_number,
-                        principal_allocated=allocation.principal_allocated,
-                        interest_allocated=allocation.interest_allocated,
-                        mora_allocated=allocation.mora_allocated,
-                        fine_allocated=allocation.fine_allocated,
-                        is_fully_covered=True,
-                    )
+    Returns the total ``expected_interest - interest_paid`` for every
+    installment whose due date falls strictly after *next_due* and on
+    or before *cutoff*. These are periods that the interest calculator
+    cannot reach because it only considers one due-date boundary.
+    """
+    if next_due is None:
+        return Money.zero()
+    total = Money.zero()
+    for inst in installments:
+        if inst.due_date > next_due and inst.due_date <= cutoff:
+            owed = inst.expected_interest - inst.interest_paid
+            if owed.is_positive():
+                total = total + owed
+    return total
 
-            allocations.append(allocation)
+
+# ------------------------------------------------------------------
+# Per-installment payment allocation
+# ------------------------------------------------------------------
+
+def allocate_payment_per_installment(
+    amount: Money,
+    installments: List[Installment],
+    ending_balance: Money,
+    fine_cap: Money,
+    interest_cap: Money,
+    mora_cap: Money,
+) -> Tuple[Money, Money, Money, Money, List[SettlementAllocation]]:
+    """Allocate a payment across installments in priority order.
+
+    Each installment is processed sequentially. Within each
+    installment the priority is fine -> mora -> interest -> principal.
+    Installment 1's obligations are fully addressed before
+    installment 2 receives anything.
+
+    Returns:
+        (fine_total, mora_total, interest_total, principal_total, allocations)
+    """
+    remaining = amount
+    fine_remaining = fine_cap
+    mora_remaining = mora_cap
+    interest_remaining = interest_cap
+    fine_total = Money.zero()
+    mora_total = Money.zero()
+    interest_total = Money.zero()
+    principal_total = Money.zero()
+    allocations: List[SettlementAllocation] = []
+
+    for inst in installments:
+        if not remaining.raw_amount:
+            break
+
+        allocation, remaining, fine_remaining, mora_remaining, interest_remaining = inst.allocate_from_payment(
+            remaining, fine_remaining, mora_remaining, interest_remaining,
+        )
+
+        if allocation.total_allocated.raw_amount <= 0:
+            continue
+
+        fine_total = fine_total + allocation.fine_allocated
+        mora_total = mora_total + allocation.mora_allocated
+        interest_total = interest_total + allocation.interest_allocated
+        principal_total = principal_total + allocation.principal_allocated
+
+        if not allocation.total_allocated.is_positive():
+            continue
+        allocations.append(allocation)
+
+    if remaining.raw_amount > 0:
+        mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
+        remaining = remaining - mora_spill
+        mora_total = mora_total + mora_spill
+
+        interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
+        remaining = remaining - interest_spill
+        interest_total = interest_total + interest_spill
 
         if remaining.raw_amount > 0:
-            mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
-            remaining = remaining - mora_spill
-            mora_total = mora_total + mora_spill
+            principal_total = principal_total + remaining
 
-            interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
-            remaining = remaining - interest_spill
-            interest_total = interest_total + interest_spill
+    post_balance = ending_balance - principal_total
+    if post_balance <= _COVERAGE_TOLERANCE:
+        inst_by_number = {inst.number: inst for inst in installments}
+        fixed: List[SettlementAllocation] = []
+        for alloc in allocations:
+            if not alloc.is_fully_covered:
+                inst = inst_by_number.get(alloc.installment_number)
+                if inst is not None:
+                    principal_owed = inst.expected_principal - inst.principal_paid
+                    if alloc.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
+                        alloc = SettlementAllocation(
+                            installment_number=alloc.installment_number,
+                            principal_allocated=alloc.principal_allocated,
+                            interest_allocated=alloc.interest_allocated,
+                            mora_allocated=alloc.mora_allocated,
+                            fine_allocated=alloc.fine_allocated,
+                            is_fully_covered=True,
+                        )
+            fixed.append(alloc)
+        allocations = fixed
 
-            if remaining.raw_amount > 0:
-                principal_total = principal_total + remaining
+    return fine_total, mora_total, interest_total, principal_total, allocations
 
-        return fine_total, mora_total, interest_total, principal_total, allocations
 
-    # ------------------------------------------------------------------
-    # Settlement construction
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# Installment snapshot construction
+# ------------------------------------------------------------------
 
-    def compute_settlement(
-        self,
-        entry_index: int,
-        allocations_by_number: Dict[int, List[SettlementAllocation]],
-        ledger: PaymentLedger,
-        schedule: PaymentSchedule,
-        fines_applied: Dict[date, Money],
-        disbursement_date: datetime,
-    ) -> Settlement:
-        """Compute a Settlement for the payment event at entry_index.
+def _build_installments_snapshot(
+    allocs_by_number: Dict[int, List[SettlementAllocation]],
+    principal_balance: Money,
+    as_of_date: datetime,
+    schedule: PaymentSchedule,
+    fines_applied: Dict[date, Money],
+    interest_calc: InterestCalculator,
+    last_payment_date: Optional[datetime] = None,
+) -> List[Installment]:
+    """Build Installment objects from pre-computed allocation data."""
+    covered = covered_due_date_count(principal_balance, schedule)
 
-        Args:
-            entry_index: 0-based index into ledger snapshots.
-            allocations_by_number: Per-installment allocations from prior settlements.
-            ledger: The payment ledger to query.
-            schedule: The original payment schedule.
-            fines_applied: Fine amounts per due date.
-            disbursement_date: Loan disbursement date (fallback for first payment).
-        """
-        snap = ledger.snapshot(entry_index)
-        items = ledger.items_for_settlement(entry_index + 1)
+    result: List[Installment] = []
+    for i, entry in enumerate(schedule):
+        installment_num = i + 1
+        allocs = allocs_by_number.get(installment_num, [])
 
-        fine_paid = items["fine"]
-        interest_paid = items["interest"]
-        mora_paid = items["mora_interest"]
-        principal_paid = items["principal"]
-        payment_amount = fine_paid + interest_paid + mora_paid + principal_paid
+        expected_fine = fines_applied.get(entry.due_date, Money.zero())
+        prior_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
 
-        datetimes = ledger.actual_payment_datetimes()
-        last_pay_date = disbursement_date if entry_index == 0 else datetimes[entry_index - 1]
+        if i < covered:
+            expected_mora = prior_mora
+        elif i == covered and entry.due_date < as_of_date.date():
+            if last_payment_date is not None:
+                total_days = (as_of_date.date() - last_payment_date.date()).days
+                _, accrued_mora = interest_calc.compute_accrued_interest(
+                    total_days, principal_balance, entry.due_date, last_payment_date,
+                )
+            else:
+                days_overdue = (as_of_date.date() - entry.due_date).days
+                _, accrued_mora = interest_calc.compute_accrued_interest(
+                    days_overdue, principal_balance, entry.due_date, to_datetime(entry.due_date),
+                )
+            expected_mora = prior_mora + accrued_mora
+        else:
+            expected_mora = Money.zero()
 
-        installments = self.build_installments_snapshot(
-            allocations_by_number,
-            snap.beginning_balance,
-            snap.payment_date,
-            schedule,
-            fines_applied,
-            last_payment_date=last_pay_date,
+        result.append(Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine))
+
+    return result
+
+
+# ------------------------------------------------------------------
+# Forward pass: compute all settlements from cashflow
+# ------------------------------------------------------------------
+
+def compute_state(
+    principal: Money,
+    interest_calc: InterestCalculator,
+    schedule: PaymentSchedule,
+    due_dates: List[date],
+    fine_rate: InterestRate,
+    grace_period_days: int,
+    disbursement_date: datetime,
+    payment_entries: list,
+    as_of: datetime,
+    fine_observation_dates: Optional[List[datetime]] = None,
+) -> LoanState:
+    """Forward pass: compute all settlements and derived state from payments.
+
+    For each payment, builds installment snapshots, computes interest
+    (including skipped contractual interest), and runs the per-installment
+    allocation algorithm.
+
+    Fines are computed at each payment date AND at any explicit
+    ``fine_observation_dates`` (from Warp or calculate_late_fines calls).
+    Without observation dates, fines are only computed when payments
+    are processed -- matching the old behavior where fines required
+    an explicit trigger.
+    """
+    running_principal = principal
+    last_payment_date = disbursement_date
+    fines_applied: Dict[date, Money] = {}
+    fines_paid_total = Money.zero()
+    settlements: List[Settlement] = []
+    allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+    processed_payments: list = []
+
+    # Build a merged timeline of payment events and fine observation points
+    events: List[Tuple[datetime, bool, Optional[object]]] = []
+    for payment in payment_entries:
+        events.append((payment.datetime, True, payment))
+    if fine_observation_dates:
+        for dt in fine_observation_dates:
+            events.append((dt, False, None))
+    events.sort(key=lambda e: (e[0], not e[1]))
+
+    for event_dt, is_payment, payment in events:
+        if event_dt > as_of:
+            break
+
+        # Compute fines using only previously processed payments
+        fines_applied = compute_fines_at(
+            event_dt, due_dates, schedule,
+            fine_rate, grace_period_days, fines_applied,
+            processed_payments,
         )
 
-        covered = self.covered_due_date_count(snap.beginning_balance, schedule)
-        next_due = schedule[covered].due_date if covered < len(schedule) else None
-        interest_accrued, _ = self._interest.compute_accrued_interest(
-            snap.days_in_period, snap.beginning_balance, next_due, last_pay_date
-        )
-        skipped_contractual = self._skipped_contractual_interest(installments, next_due, snap.payment_date.date())
-        interest_cap = Money(interest_accrued.raw_amount + skipped_contractual.raw_amount)
+        if not is_payment:
+            continue
 
-        allocations = self.build_settlement_allocations(
-            installments,
-            fine_paid,
-            mora_paid,
-            interest_paid,
-            principal_paid,
-            snap.ending_balance,
-            interest_cap_override=interest_cap,
+        # Compute interest
+        interest_date = payment.interest_date if payment.interest_date is not None else payment.datetime
+        days = max(0, (interest_date.date() - last_payment_date.date()).days)
+
+        covered = covered_due_date_count(running_principal, schedule)
+        next_due = due_dates[covered] if covered < len(due_dates) else None
+
+        regular, mora = interest_calc.compute_accrued_interest(
+            days, running_principal, next_due, last_payment_date,
         )
 
-        return Settlement(
-            payment_amount=payment_amount,
-            payment_date=snap.payment_date,
+        # Build installment snapshot for allocation
+        installments = _build_installments_snapshot(
+            allocs_by_number, running_principal, payment.datetime,
+            schedule, fines_applied, interest_calc,
+            last_payment_date=last_payment_date,
+        )
+
+        # Skipped contractual interest
+        skipped = _skipped_contractual_interest(installments, next_due, interest_date.date())
+        interest_cap = Money(regular.raw_amount + skipped.raw_amount)
+
+        # Fine balance
+        total_fines_amount = (
+            Money(sum(f.raw_amount for f in fines_applied.values()))
+            if fines_applied
+            else Money.zero()
+        )
+        fine_balance = total_fines_amount - fines_paid_total
+        if fine_balance.is_negative():
+            fine_balance = Money.zero()
+
+        # Per-installment allocation
+        fine_paid, mora_paid, interest_paid, principal_paid, allocations = allocate_payment_per_installment(
+            payment.amount, installments, running_principal,
+            fine_cap=fine_balance, interest_cap=interest_cap, mora_cap=mora,
+        )
+
+        # Update running state
+        fines_paid_total = fines_paid_total + fine_paid
+        running_principal = running_principal - principal_paid
+        if running_principal.is_negative():
+            running_principal = Money.zero()
+
+        for a in allocations:
+            allocs_by_number.setdefault(a.installment_number, []).append(a)
+
+        settlements.append(Settlement(
+            payment_amount=payment.amount,
+            payment_date=payment.datetime,
             fine_paid=fine_paid,
             interest_paid=interest_paid,
             mora_paid=mora_paid,
             principal_paid=principal_paid,
-            remaining_balance=snap.ending_balance,
+            remaining_balance=running_principal,
             allocations=allocations,
-        )
+        ))
 
-    def build_settlement_allocations(
-        self,
-        installments: List[Installment],
-        fine_paid: Money,
-        mora_paid: Money,
-        interest_paid: Money,
-        principal_paid: Money,
-        ending_balance: Money,
-        interest_cap_override: Optional[Money] = None,
-    ) -> List[SettlementAllocation]:
-        """Reconstruct per-installment allocations from recorded totals.
+        last_payment_date = payment.datetime
+        processed_payments.append(payment)
 
-        Uses the same :meth:`allocate_payment_per_installment` logic so
-        that reconstruction and live allocation are always consistent.
-        The recorded totals serve as caps so that fines/interest/mora
-        applied by *later* payments don't leak into earlier settlements.
+    return LoanState(
+        settlements=settlements,
+        principal_balance=running_principal,
+        fines_applied=fines_applied,
+        fines_paid_total=fines_paid_total,
+        last_payment_date=last_payment_date,
+    )
 
-        When *interest_cap_override* is provided it replaces the default
-        ``interest_paid`` cap, ensuring the reconstruction uses the same
-        effective cap as the live allocation in :meth:`Loan.record_payment`.
-        """
-        payment_amount = fine_paid + mora_paid + interest_paid + principal_paid
-        interest_cap = interest_cap_override if interest_cap_override is not None else interest_paid
 
-        _, _, _, _, allocations = self.allocate_payment_per_installment(
-            payment_amount,
-            installments,
-            ending_balance,
-            fine_cap=fine_paid,
-            interest_cap=interest_cap,
-            mora_cap=mora_paid,
-        )
-        return allocations
+# ------------------------------------------------------------------
+# Aggregate views
+# ------------------------------------------------------------------
 
-    def build_installments_snapshot(
-        self,
-        allocations_by_number: Dict[int, List[SettlementAllocation]],
-        principal_balance: Money,
-        as_of_date: datetime,
-        schedule: PaymentSchedule,
-        fines_applied: Dict[date, Money],
-        last_payment_date: Optional[datetime] = None,
-    ) -> List[Installment]:
-        """Build Installment objects from pre-computed allocation data."""
-        covered = self.covered_due_date_count(principal_balance, schedule)
+def build_installments(
+    schedule: PaymentSchedule,
+    settlements: List[Settlement],
+    fines_applied: Dict[date, Money],
+    principal_balance: Money,
+    as_of: datetime,
+    interest_calc: InterestCalculator,
+    last_payment_date: datetime,
+) -> List[Installment]:
+    """Build the installment view from settlements + schedule."""
+    allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+    for settlement in settlements:
+        for a in settlement.allocations:
+            allocs_by_number.setdefault(a.installment_number, []).append(a)
 
-        result: List[Installment] = []
-        for i, entry in enumerate(schedule):
-            installment_num = i + 1
-            allocs = allocations_by_number.get(installment_num, [])
-
-            expected_fine = fines_applied.get(entry.due_date, Money.zero())
-            prior_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
-
-            if i < covered:
-                expected_mora = prior_mora
-            elif i == covered and entry.due_date < as_of_date.date():
-                if last_payment_date is not None:
-                    total_days = (as_of_date.date() - last_payment_date.date()).days
-                    _, accrued_mora = self._interest.compute_accrued_interest(
-                        total_days,
-                        principal_balance,
-                        entry.due_date,
-                        last_payment_date,
-                    )
-                else:
-                    days_overdue = (as_of_date.date() - entry.due_date).days
-                    _, accrued_mora = self._interest.compute_accrued_interest(
-                        days_overdue,
-                        principal_balance,
-                        entry.due_date,
-                        to_datetime(entry.due_date),
-                    )
-                expected_mora = prior_mora + accrued_mora
-            else:
-                expected_mora = Money.zero()
-
-            result.append(Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine))
-
-        return result
-
-    # ------------------------------------------------------------------
-    # Aggregate views
-    # ------------------------------------------------------------------
-
-    def all_settlements(
-        self,
-        ledger: PaymentLedger,
-        schedule: PaymentSchedule,
-        fines_applied: Dict[date, Money],
-        disbursement_date: datetime,
-        current_time: datetime,
-    ) -> List[Settlement]:
-        """All settlements up to *current_time*, reconstructed from the ledger."""
-        datetimes = ledger.actual_payment_datetimes()
-        allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
-        result: List[Settlement] = []
-        for i, dt in enumerate(datetimes):
-            if dt > current_time:
-                break
-            settlement = self.compute_settlement(
-                i, allocs_by_number, ledger, schedule, fines_applied, disbursement_date
-            )
-            for a in settlement.allocations:
-                allocs_by_number.setdefault(a.installment_number, []).append(a)
-            result.append(settlement)
-        return result
-
-    def all_installments(
-        self,
-        settlements: List[Settlement],
-        principal_balance: Money,
-        as_of_date: datetime,
-        schedule: PaymentSchedule,
-        fines_applied: Dict[date, Money],
-    ) -> List[Installment]:
-        """Build the full installment list from accumulated settlement allocations."""
-        allocations_by_number: Dict[int, List[SettlementAllocation]] = {}
-        for settlement in settlements:
-            for allocation in settlement.allocations:
-                num = allocation.installment_number
-                if num not in allocations_by_number:
-                    allocations_by_number[num] = []
-                allocations_by_number[num].append(allocation)
-
-        return self.build_installments_snapshot(
-            allocations_by_number,
-            principal_balance,
-            as_of_date,
-            schedule,
-            fines_applied,
-        )
+    return _build_installments_snapshot(
+        allocs_by_number, principal_balance, as_of,
+        schedule, fines_applied, interest_calc,
+        last_payment_date=last_payment_date,
+    )

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -18,9 +18,8 @@ class Installment:
     Represents the borrower's obligation for one period: what is expected,
     what has actually been paid, and the detailed per-payment allocations.
 
-    Installments are consequences of the loan -- they describe HOW the
-    borrower repays, not what defines the loan itself. The Loan builds
-    these on demand as a live snapshot reflecting the current time context.
+    Installments are derived views -- the Loan builds them on demand
+    from the CashFlow and the schedule.
     """
 
     number: int
@@ -63,21 +62,8 @@ class Installment:
         each capped by both the installment's remaining obligation and
         the corresponding running cap.
 
-        The running caps prevent over-allocation: during live allocation
-        they reflect the loan-level accrual (e.g. the interest discount
-        for early payments); during reconstruction they match the
-        recorded CashFlowItem totals.
-
-        Args:
-            remaining: Unallocated portion of the payment.
-            fine_remaining: Remaining fine cap across all installments.
-            mora_remaining: Remaining mora cap across all installments.
-            interest_remaining: Remaining interest cap across all installments.
-
-        Returns:
-            ``(SettlementAllocation, updated_remaining,
-            updated_fine_remaining, updated_mora_remaining,
-            updated_interest_remaining)``.
+        The running caps prevent over-allocation: they match the
+        loan-level accrual computed during the forward pass.
         """
         fine_owed = self.expected_fine - self.fine_paid
         fine_alloc = Money(min(fine_owed.raw_amount, remaining.raw_amount, fine_remaining.raw_amount))
@@ -121,14 +107,7 @@ class Installment:
         expected_mora: Money,
         expected_fine: Money,
     ) -> "Installment":
-        """Build an Installment from a scheduler's PaymentScheduleEntry.
-
-        Args:
-            entry: The schedule entry from the scheduler.
-            allocations: SettlementAllocations attributed to this installment.
-            expected_mora: Mora interest owed for this installment.
-            expected_fine: Fine amount owed for this installment.
-        """
+        """Build an Installment from a scheduler's PaymentScheduleEntry."""
         principal_paid = Money(sum(a.principal_allocated.raw_amount for a in allocations))
         interest_paid = Money(sum(a.interest_allocated.raw_amount for a in allocations))
         mora_paid = Money(sum(a.mora_allocated.raw_amount for a in allocations))

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,4 +1,4 @@
-"""Simplified Loan class that delegates calculations to configurable scheduler."""
+"""Loan class -- everything emerges from the CashFlow."""
 
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Type
@@ -11,59 +11,43 @@ from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, Pr
 from ..tax.base import BaseTax, TaxResult
 from ..time_context import TimeContext
 from ..tz import to_datetime, tz_aware
-from .engines.fine_tracker import FineTracker, _get_expected_payment
 from .engines.interest_calculator import InterestCalculator, MoraStrategy
-from .engines.payment_ledger import PaymentLedger
-from .engines.settlement_engine import SettlementEngine
+from .engines.settlement_engine import (
+    LoanState,
+    build_installments,
+    compute_fines_at,
+    compute_state,
+    covered_due_date_count,
+    is_payment_late,
+)
 from .installment import Installment
 from .settlement import AnticipationResult, Settlement, SettlementAllocation
 from .tvm import loan_calculate_anticipation, loan_irr, loan_present_value
 
 
 class Loan:
-    """
-    Represents a personal loan as a state machine with late payment fine support.
+    """Represents a personal loan where everything emerges from the CashFlow.
 
-    Delegates complex calculations to a configurable scheduler and focuses on
-    state management and tracking actual payments. Supports configurable late
-    payment fines with grace periods.
+    The CashFlow is the single source of truth. Expected items (the
+    amortization schedule) and actual payments both live in one CashFlow.
+    Settlements, installment views, balances, and fines are all derived
+    on demand -- nothing is decomposed or stored at payment time.
 
-    Features:
-    - Flexible payment schedules using configurable schedulers
-    - Automatic payment allocation: Fines → Interest → Principal
-    - Configurable fines (default 2% of missed payment)
-    - Configurable grace periods before fines apply
-    - Time-aware fine calculation and application
-    - Comprehensive cash flow tracking including fine events
+    Payment allocation priority: Fine -> Mora Interest -> Interest -> Principal.
+    Installment 1 is fully addressed before installment 2.
 
     Examples:
         >>> from money_warp import Loan, Money, InterestRate
         >>> from datetime import date, datetime
-        >>> from decimal import Decimal
         >>>
-        >>> # Basic loan with default fine settings
         >>> loan = Loan(
         ...     Money("10000"),
         ...     InterestRate("5% annual"),
         ...     [date(2024, 2, 1), date(2024, 3, 1)]
         ... )
         >>>
-        >>> # Loan with custom fine settings
-        >>> loan = Loan(
-        ...     Money("10000"),
-        ...     InterestRate("5% annual"),
-        ...     [date(2024, 2, 1)],
-        ...     fine_rate=Decimal("0.05"),  # 5% fine
-        ...     grace_period_days=7  # 7-day grace period
-        ... )
-        >>>
-        >>> # Check for late payments and apply fines
-        >>> fines = loan.calculate_late_fines(datetime(2024, 2, 10))
-        >>> print(f"Fines applied: {fines}")
-        >>>
-        >>> # Make payment (automatically allocated to fines first)
-        >>> loan.record_payment(Money("500"), datetime(2024, 2, 11))
-        >>> print(f"Outstanding fines: {loan.fine_balance}")
+        >>> loan.record_payment(Money("500"), datetime(2024, 2, 1))
+        >>> print(f"Balance: {loan.current_balance}")
     """
 
     @tz_aware
@@ -81,40 +65,6 @@ class Loan:
         taxes: Optional[List[BaseTax]] = None,
         is_grossed_up: bool = False,
     ) -> None:
-        """
-        Create a loan with flexible payment schedule.
-
-        Args:
-            principal: The loan amount
-            interest_rate: The annual interest rate
-            due_dates: List of payment due dates (flexible scheduling)
-            disbursement_date: When the loan was disbursed (defaults to now). Must be before the first due date.
-            scheduler: Scheduler class to use for calculations (defaults to PriceScheduler)
-            fine_rate: Fine rate applied to missed payments (defaults to 2% annual)
-            grace_period_days: Days after due date before fines apply (defaults to 0)
-            mora_interest_rate: Interest rate for mora (late) interest (defaults to interest_rate)
-            mora_strategy: How mora interest is computed (defaults to COMPOUND)
-            taxes: Optional list of taxes applied to this loan (e.g., IOF)
-            is_grossed_up: Whether the principal was grossed up to absorb taxes.
-                When True, generate_expected_cash_flow() omits the separate tax entry
-                because the tax is already reflected in the higher principal.
-
-        Examples:
-            >>> # Basic loan with default 2% fine, no grace period
-            >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [date(2024, 2, 1)])
-            >>>
-            >>> # Loan with custom 5% fine and 3-day grace period
-            >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [date(2024, 2, 1)],
-            ...            fine_rate=InterestRate("5% annual"), grace_period_days=3)
-            >>>
-            >>> # Loan with separate mora interest rate
-            >>> loan = Loan(Money("10000"), InterestRate("5% annual"),
-            ...            [date(2024, 2, 1)],
-            ...            mora_interest_rate=InterestRate("12% annual"))
-        """
-        # Validate inputs first
         if not due_dates:
             raise ValueError("At least one due date is required")
         if principal.is_negative() or principal.is_zero():
@@ -136,36 +86,223 @@ class Loan:
         self.scheduler = scheduler or PriceScheduler
         self.fine_rate = fine_rate if fine_rate is not None else InterestRate("2% annual")
         self.grace_period_days = grace_period_days
-        self._fines = FineTracker(self.fine_rate, grace_period_days, self._time_ctx)
         self.taxes: List[BaseTax] = taxes or []
         self.is_grossed_up = is_grossed_up
-
-        # Shared payment CashFlow — single source of truth for payment items
-        self._payment_cf = CashFlow.empty()
-        self._ledger = PaymentLedger(self._payment_cf, self._time_ctx)
-        self._settlements_engine = SettlementEngine(self._interest)
         self._tax_cache: Optional[Dict[str, TaxResult]] = None
+        self._fine_observation_dates: List[datetime] = []
+
+        self.cashflow = self._build_initial_cashflow()
+
+    # ------------------------------------------------------------------
+    # CashFlow construction
+    # ------------------------------------------------------------------
+
+    def _build_initial_cashflow(self) -> CashFlow:
+        """Build the initial CashFlow with expected items from the schedule."""
+        items: List[CashFlowItem] = []
+        ctx = self._time_ctx
+        expected = CashFlowType.EXPECTED
+
+        total_tax = self.total_tax
+        if total_tax.is_positive() and self.is_grossed_up:
+            items.append(CashFlowItem(
+                self.net_disbursement, self.disbursement_date,
+                "Loan disbursement", "disbursement",
+                kind=expected, time_context=ctx,
+            ))
+        elif total_tax.is_positive():
+            items.append(CashFlowItem(
+                self.principal, self.disbursement_date,
+                "Loan disbursement", "disbursement",
+                kind=expected, time_context=ctx,
+            ))
+            items.append(CashFlowItem(
+                Money(-total_tax.raw_amount), self.disbursement_date,
+                "Tax deducted at disbursement", "tax",
+                kind=expected, time_context=ctx,
+            ))
+        else:
+            items.append(CashFlowItem(
+                self.principal, self.disbursement_date,
+                "Loan disbursement", "disbursement",
+                kind=expected, time_context=ctx,
+            ))
+
+        schedule = self.get_original_schedule()
+        for entry in schedule:
+            due_dt = to_datetime(entry.due_date)
+            items.append(CashFlowItem(
+                Money(-entry.interest_payment.raw_amount), due_dt,
+                f"Interest payment {entry.payment_number}", "interest",
+                kind=expected, time_context=ctx,
+            ))
+            items.append(CashFlowItem(
+                Money(-entry.principal_payment.raw_amount), due_dt,
+                f"Principal payment {entry.payment_number}", "principal",
+                kind=expected, time_context=ctx,
+            ))
+
+        return CashFlow(items)
+
+    # ------------------------------------------------------------------
+    # Payment recording
+    # ------------------------------------------------------------------
+
+    @tz_aware
+    def record_payment(
+        self,
+        amount: Money,
+        payment_date: datetime,
+        interest_date: Optional[datetime] = None,
+        processing_date: Optional[datetime] = None,
+        description: Optional[str] = None,
+    ) -> Settlement:
+        """Record a payment. Just one CashFlowItem -- everything else is derived.
+
+        Args:
+            amount: Total payment amount (positive value).
+            payment_date: When the money moved.
+            interest_date: Cutoff date for interest accrual calculation.
+                Defaults to payment_date.
+            processing_date: Unused, kept for API compatibility.
+            description: Optional description of the payment.
+
+        Returns:
+            Settlement describing how the payment was allocated.
+        """
+        if amount.is_negative() or amount.is_zero():
+            raise ValueError("Payment amount must be positive")
+
+        if interest_date is None:
+            interest_date = payment_date
+
+        self.cashflow.add_item(CashFlowItem(
+            amount, payment_date,
+            description or f"Payment on {payment_date.date()}", "payment",
+            time_context=self._time_ctx,
+            interest_date=interest_date,
+        ))
+
+        return self.settlements[-1]
+
+    def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
+        """Pay the next installment.
+
+        Interest accrual depends on timing:
+        - Early/on-time: interest accrues up to the due date.
+        - Late: interest accrues up to self.now().
+        """
+        payment_date = self.now()
+        next_due = self._next_unpaid_due_date()
+        interest_date = max(payment_date, to_datetime(next_due))
+        return self.record_payment(
+            amount, payment_date=payment_date,
+            interest_date=interest_date, description=description,
+        )
+
+    def anticipate_payment(
+        self,
+        amount: Money,
+        installments: Optional[List[int]] = None,
+        description: Optional[str] = None,
+    ) -> Settlement:
+        """Make an early payment with interest discount.
+
+        Interest is calculated only up to self.now(), so the borrower
+        pays less interest for fewer elapsed days.
+
+        When *installments* is provided (1-based), the corresponding
+        expected cash-flow items are temporally deleted.
+        """
+        payment_date = self.now()
+
+        if installments is not None:
+            self._delete_expected_items_for(installments, payment_date)
+
+        return self.record_payment(
+            amount, payment_date=payment_date,
+            interest_date=payment_date, description=description,
+        )
+
+    def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:
+        """Calculate the amount to pay today to eliminate specific installments."""
+        return loan_calculate_anticipation(self, installments)
+
+    def _delete_expected_items_for(self, installments: List[int], effective_date: datetime) -> None:
+        """Temporally delete expected cash-flow items for the given installments."""
+        removed_set = set(installments)
+        for item in self.cashflow.raw_items():
+            entry = item.resolve()
+            if entry is None or entry.kind != CashFlowType.EXPECTED:
+                continue
+            if entry.category.isdisjoint({"interest", "principal"}):
+                continue
+            desc = entry.description or ""
+            for num in removed_set:
+                if desc.endswith(f" {num}"):
+                    item.delete(effective_date)
+                    break
+
+    # ------------------------------------------------------------------
+    # Derived state (computed from CashFlow)
+    # ------------------------------------------------------------------
+
+    def _compute_state(self) -> LoanState:
+        """Run the forward pass over all payments to derive loan state."""
+        return compute_state(
+            self.principal, self._interest, self.get_original_schedule(),
+            self.due_dates, self.fine_rate, self.grace_period_days,
+            self.disbursement_date, self._payment_entries(), self.now(),
+            fine_observation_dates=self._fine_observation_dates,
+        )
+
+    def _payment_entries(self) -> list:
+        """Payment CashFlowEntry objects from the cashflow, sorted by datetime."""
+        entries = [
+            e for e in self.cashflow.items()
+            if "payment" in e.category
+        ]
+        return sorted(entries, key=lambda e: e.datetime)
+
+    # ------------------------------------------------------------------
+    # Settlements and installments
+    # ------------------------------------------------------------------
+
+    @property
+    def settlements(self) -> List[Settlement]:
+        """All settlements (derived from CashFlow)."""
+        return self._compute_state().settlements
+
+    @property
+    def installments(self) -> List[Installment]:
+        """The repayment plan as Installment objects (derived from CashFlow)."""
+        state = self._compute_state()
+        return build_installments(
+            self.get_original_schedule(), state.settlements,
+            state.fines_applied, state.principal_balance,
+            self.now(), self._interest, state.last_payment_date,
+        )
+
+    # ------------------------------------------------------------------
+    # Balance properties
+    # ------------------------------------------------------------------
 
     @property
     def principal_balance(self) -> Money:
-        """Get the current principal balance (original principal minus principal payments)."""
-        return self._ledger.principal_balance(self.principal)
+        """Outstanding principal (derived from CashFlow)."""
+        return self._compute_state().principal_balance
 
     def _accrued_interest_components(self) -> tuple:
-        """Return ``(regular, mora)`` accrued interest since last payment.
+        """Return (regular, mora) accrued interest since last payment."""
+        state = self._compute_state()
+        days = (self.now().date() - state.last_payment_date.date()).days
 
-        Shared computation used by :pyattr:`interest_balance` and
-        :pyattr:`mora_interest_balance`.
-        """
-        days = self.days_since_last_payment()
-        principal_bal = self.principal_balance
-
-        if principal_bal.is_positive() and days > 0:
-            try:
-                due_date = self._next_unpaid_due_date()
-            except ValueError:
-                due_date = None
-            return self._interest.compute_accrued_interest(days, principal_bal, due_date, self.last_payment_date)
+        if state.principal_balance.is_positive() and days > 0:
+            covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
+            next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
+            return self._interest.compute_accrued_interest(
+                days, state.principal_balance, next_due, state.last_payment_date,
+            )
 
         return Money.zero(), Money.zero()
 
@@ -176,54 +313,115 @@ class Loan:
 
     @property
     def mora_interest_balance(self) -> Money:
-        """Mora accrued interest since last payment.
-
-        Respects ``mora_interest_rate`` and ``mora_strategy`` when the
-        borrower is past the next unpaid due date.
-        """
+        """Mora accrued interest since last payment."""
         return self._accrued_interest_components()[1]
 
     @property
-    def current_balance(self) -> Money:
-        """Get the current outstanding balance.
+    def fine_balance(self) -> Money:
+        """Unpaid fine amount (derived from CashFlow)."""
+        state = self._compute_state()
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values()))
+            if state.fines_applied
+            else Money.zero()
+        )
+        outstanding = total_fines - state.fines_paid_total
+        return outstanding if outstanding.is_positive() else Money.zero()
 
-        Equal to ``principal_balance + interest_balance +
-        mora_interest_balance + fine_balance``.
-        """
+    @property
+    def current_balance(self) -> Money:
+        """Total outstanding balance (principal + interest + mora + fines)."""
         return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
 
     @property
     def is_paid_off(self) -> bool:
-        """Check if the loan is fully paid off, including all fines."""
+        """Whether the loan is fully paid off."""
         return self.current_balance.is_zero() or self.current_balance.is_negative()
 
-    @property
-    def last_payment_date(self) -> datetime:
-        """Get the date of the last payment made, or disbursement date if no payments."""
-        return self._ledger.last_payment_date(self.disbursement_date)
+    # ------------------------------------------------------------------
+    # Fine-related properties and methods
+    # ------------------------------------------------------------------
 
     @property
     def fines_applied(self) -> Dict[date, Money]:
-        """Fine amounts applied per due date (delegates to FineTracker)."""
-        return self._fines.fines_applied
+        """Fine amounts applied per due date (derived from CashFlow)."""
+        return self._compute_state().fines_applied
 
     @fines_applied.setter
     def fines_applied(self, value: Dict[date, Money]) -> None:
-        self._fines.fines_applied = value
+        pass
 
     @property
     def total_fines(self) -> Money:
-        """Get the total amount of fines applied to this loan."""
-        return self._fines.total_fines
+        """Total amount of fines applied."""
+        fines = self.fines_applied
+        if not fines:
+            return Money.zero()
+        return Money(sum(f.raw_amount for f in fines.values()))
+
+    @tz_aware
+    def is_payment_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
+        """Check if a payment is late considering the grace period."""
+        check = as_of_date if as_of_date is not None else self.now()
+        return is_payment_late(due_date, self.grace_period_days, check)
+
+    def _on_warp(self, target_date: datetime) -> None:
+        """Hook called by Warp after overriding TimeContext."""
+        self._fine_observation_dates.append(target_date)
+
+    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
+        """Compute and record fine observations as of a date.
+
+        Appends the observation date so that subsequent property queries
+        include fines for due dates overdue at that point.
+
+        Returns the amount of NEW fines applied (zero if already applied).
+        """
+        as_of = as_of_date if as_of_date is not None else self.now()
+        old_total = self.total_fines
+        self._fine_observation_dates.append(as_of)
+        new_total = self.total_fines
+        return new_total - old_total
+
+    # ------------------------------------------------------------------
+    # Payment info
+    # ------------------------------------------------------------------
 
     @property
-    def fine_balance(self) -> Money:
-        """Unpaid fine amount (total fines applied minus fines paid)."""
-        return self._fines.fine_balance(self._ledger.actual_payment_items)
+    def last_payment_date(self) -> datetime:
+        """Date of the last payment, or disbursement date if none."""
+        return self._compute_state().last_payment_date
+
+    def now(self) -> datetime:
+        """Current datetime (Warp-aware via shared TimeContext)."""
+        return self._time_ctx.now()
+
+    def days_since_last_payment(self) -> int:
+        """Days since the last payment (Warp-aware)."""
+        return (self.now().date() - self.last_payment_date.date()).days
+
+    def _covered_due_date_count(self) -> int:
+        """How many due dates have been covered by payments."""
+        return covered_due_date_count(self.principal_balance, self.get_original_schedule())
+
+    def _next_unpaid_due_date(self) -> date:
+        """Find the next due date that hasn't been fully paid.
+
+        Raises:
+            ValueError: If all due dates have been paid.
+        """
+        covered = self._covered_due_date_count()
+        if covered >= len(self.due_dates):
+            raise ValueError("All due dates have been paid")
+        return self.due_dates[covered]
+
+    # ------------------------------------------------------------------
+    # Taxes
+    # ------------------------------------------------------------------
 
     @property
     def tax_amounts(self) -> Dict[str, TaxResult]:
-        """Per-tax results keyed by tax class name. Computed lazily and cached."""
+        """Per-tax results keyed by tax class name. Computed lazily."""
         if self._tax_cache is not None:
             return self._tax_cache
 
@@ -250,500 +448,156 @@ class Loan:
         """Amount the borrower actually receives (principal minus total tax)."""
         return self.principal - self.total_tax
 
-    def now(self) -> datetime:
-        """Current datetime (Warp-aware via shared TimeContext)."""
-        return self._time_ctx.now()
-
-    def _on_warp(self, target_date: datetime) -> None:
-        """Hook called by Warp after overriding TimeContext."""
-        self.calculate_late_fines()
-
-    def days_since_last_payment(self) -> int:
-        """Get the number of days since the last payment (Warp-aware via TimeContext)."""
-        return (self.now().date() - self.last_payment_date.date()).days
-
     def get_expected_payment_amount(self, due_date: date) -> Money:
-        """Get the expected payment amount for a specific due date from the original schedule."""
-        return _get_expected_payment(due_date, self.due_dates, self.get_original_schedule())
-
-    @tz_aware
-    def is_payment_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
-        """Check if a payment is late considering the grace period."""
-        return self._fines.is_payment_late(due_date, as_of_date)
-
-    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
-        """Calculate and apply late payment fines for any new late payments."""
-        return self._fines.calculate_late_fines(
-            self.due_dates, self.get_original_schedule(), self._ledger.all_payment_items, as_of=as_of_date
-        )
-
-    @tz_aware
-    def present_value(
-        self, discount_rate: Optional[InterestRate] = None, valuation_date: Optional[datetime] = None
-    ) -> Money:
-        """Calculate the Present Value of the loan's expected cash flows."""
-        return loan_present_value(self, discount_rate, valuation_date)
-
-    def irr(self, guess: Optional[Rate] = None) -> Rate:
-        """Calculate the Internal Rate of Return (IRR) of the loan's expected cash flows."""
-        return loan_irr(self, guess)
-
-    def generate_expected_cash_flow(self) -> CashFlow:
-        """
-        Generate the expected payment schedule without fines.
-
-        This represents the original loan terms and expected payments.
-        Fines are contingent events and are not included in the expected cash flow.
-        Use get_actual_cash_flow() to see what actually happened, including fines.
-
-        When taxes are present on a non-grossed-up loan, the full principal is
-        the disbursement entry and the tax appears as a separate outflow, so the
-        day-0 net equals net_disbursement.  For grossed-up loans the tax is
-        already absorbed into the higher principal, so only net_disbursement
-        (= requested amount) is emitted with no separate tax entry.
-
-        Returns:
-            CashFlow with loan disbursement and expected payment schedule
-        """
-        items = []
-        ctx = self._time_ctx
-        expected = CashFlowType.EXPECTED
-
-        total_tax = self.total_tax
-        if total_tax.is_positive() and self.is_grossed_up:
-            items.append(
-                CashFlowItem(
-                    self.net_disbursement,
-                    self.disbursement_date,
-                    "Loan disbursement",
-                    "disbursement",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
-        elif total_tax.is_positive():
-            items.append(
-                CashFlowItem(
-                    self.principal,
-                    self.disbursement_date,
-                    "Loan disbursement",
-                    "disbursement",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
-            items.append(
-                CashFlowItem(
-                    Money(-total_tax.raw_amount),
-                    self.disbursement_date,
-                    "Tax deducted at disbursement",
-                    "tax",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
-        else:
-            items.append(
-                CashFlowItem(
-                    self.principal,
-                    self.disbursement_date,
-                    "Loan disbursement",
-                    "disbursement",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
-
+        """Get the expected payment amount for a specific due date."""
         schedule = self.get_original_schedule()
-
         for entry in schedule:
-            due_dt = to_datetime(entry.due_date)
-            items.append(
-                CashFlowItem(
-                    Money(-entry.interest_payment.raw_amount),
-                    due_dt,
-                    f"Interest payment {entry.payment_number}",
-                    "interest",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
-            items.append(
-                CashFlowItem(
-                    Money(-entry.principal_payment.raw_amount),
-                    due_dt,
-                    f"Principal payment {entry.payment_number}",
-                    "principal",
-                    kind=expected,
-                    time_context=ctx,
-                )
-            )
+            if entry.due_date == due_date:
+                return entry.payment_amount
+        raise ValueError(f"Due date {due_date} is not in loan's due dates")
 
-        return CashFlow(items)
-
-    @tz_aware
-    def record_payment(
-        self,
-        amount: Money,
-        payment_date: datetime,
-        interest_date: Optional[datetime] = None,
-        processing_date: Optional[datetime] = None,
-        description: Optional[str] = None,
-    ) -> Settlement:
-        """
-        Record an actual payment made on the loan with automatic allocation.
-
-        Payment allocation priority (per installment):
-        Fine -> Mora Interest -> Interest -> Principal.
-        Installment 1 is fully addressed before installment 2.
-
-        Args:
-            amount: Total payment amount (positive value)
-            payment_date: When the money moved
-            interest_date: Cutoff date for interest accrual calculation.
-                Defaults to payment_date (borrower gets discount for early payment).
-            processing_date: When the system recorded the event (audit trail).
-                Defaults to self.now().
-            description: Optional description of the payment
-
-        Returns:
-            Settlement describing how the payment was allocated.
-        """
-        if amount.is_negative() or amount.is_zero():
-            raise ValueError("Payment amount must be positive")
-
-        if interest_date is None:
-            interest_date = payment_date
-        if processing_date is None:
-            processing_date = self.now()
-
-        self.calculate_late_fines(payment_date)
-
-        days, principal_balance, last_pay_date = self._ledger.compute_interest_snapshot(
-            payment_date, interest_date, self.principal, self.disbursement_date
-        )
-
-        try:
-            next_due = self._next_unpaid_due_date()
-        except ValueError:
-            next_due = None
-
-        interest_accrued, mora_accrued = self._interest.compute_accrued_interest(
-            days, principal_balance, next_due, last_pay_date
-        )
-
-        installments = self._build_pre_settlement_installments(principal_balance, payment_date, last_pay_date)
-
-        skipped = SettlementEngine._skipped_contractual_interest(installments, next_due, interest_date.date())
-        interest_cap = Money(interest_accrued.raw_amount + skipped.raw_amount)
-
-        ending_balance = principal_balance
-        fine_paid, mora_paid, interest_paid, principal_paid, _ = SettlementEngine.allocate_payment_per_installment(
-            amount,
-            installments,
-            ending_balance,
-            fine_cap=self.fine_balance,
-            interest_cap=interest_cap,
-            mora_cap=mora_accrued,
-        )
-
-        settlement_num, ending_balance = self._ledger.record_allocation(
-            fine_paid,
-            mora_paid,
-            interest_paid,
-            principal_paid,
-            payment_date,
-            days,
-            principal_balance,
-            description,
-        )
-
-        allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
-        schedule = self.get_original_schedule()
-        for i in range(settlement_num - 1):
-            prev = self._settlements_engine.compute_settlement(
-                i, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
-            )
-            for a in prev.allocations:
-                allocs_by_number.setdefault(a.installment_number, []).append(a)
-
-        return self._settlements_engine.compute_settlement(
-            settlement_num - 1, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
-        )
-
-    def _build_pre_settlement_installments(
-        self,
-        principal_balance: Money,
-        payment_date: datetime,
-        last_payment_date: Optional[datetime],
-    ) -> List[Installment]:
-        """Build an installment snapshot reflecting all prior settlements.
-
-        Called *before* a new payment is recorded so that
-        :meth:`SettlementEngine.allocate_payment_per_installment` can
-        determine per-installment obligations.
-        """
-        allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
-        schedule = self.get_original_schedule()
-        for i in range(self._ledger.settlement_count):
-            prev = self._settlements_engine.compute_settlement(
-                i, allocs_by_number, self._ledger, schedule, self.fines_applied, self.disbursement_date
-            )
-            for a in prev.allocations:
-                allocs_by_number.setdefault(a.installment_number, []).append(a)
-
-        return self._settlements_engine.build_installments_snapshot(
-            allocs_by_number,
-            principal_balance,
-            payment_date,
-            self.get_original_schedule(),
-            self.fines_applied,
-            last_payment_date=last_payment_date,
-        )
-
-    def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
-        """
-        Pay the next installment.
-
-        Interest accrual depends on timing relative to the due date:
-        - Early/on-time: interest accrues up to the due date (no discount).
-        - Late: interest accrues up to self.now(), so the borrower pays extra
-          interest for the additional days beyond the due date.
-
-        This is the most common payment method and works correctly whether the
-        borrower pays early, on time, or late.
-
-        Args:
-            amount: Total payment amount (positive value)
-            description: Optional description of the payment
-
-        Returns:
-            Settlement describing how the payment was allocated.
-        """
-        payment_date = self.now()
-        next_due = self._next_unpaid_due_date()
-        interest_date = max(payment_date, to_datetime(next_due))
-        return self.record_payment(
-            amount,
-            payment_date=payment_date,
-            interest_date=interest_date,
-            description=description,
-        )
-
-    def anticipate_payment(
-        self,
-        amount: Money,
-        installments: Optional[List[int]] = None,
-        description: Optional[str] = None,
-    ) -> Settlement:
-        """Make an early payment with interest discount.
-
-        Interest is calculated only up to ``self.now()``, so the borrower
-        pays less interest for fewer elapsed days.
-
-        When *installments* is provided (1-based installment numbers),
-        the corresponding expected cash-flow items are temporally
-        deleted so that ``due_dates`` and future schedules no longer
-        include them.
-
-        Args:
-            amount: Total payment amount (positive value).
-            installments: Optional 1-based installment numbers to remove.
-            description: Optional description of the payment.
-
-        Returns:
-            Settlement describing how the payment was allocated.
-        """
-        payment_date = self.now()
-
-        if installments is not None:
-            self._delete_expected_items_for(installments, payment_date)
-
-        return self.record_payment(
-            amount,
-            payment_date=payment_date,
-            interest_date=payment_date,
-            description=description,
-        )
-
-    def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:
-        """Calculate the amount to pay today to eliminate specific installments."""
-        return loan_calculate_anticipation(self, installments)
-
-    def _delete_expected_items_for(self, installments: List[int], effective_date: datetime) -> None:
-        """Temporally delete expected cash-flow items for the given installments.
-
-        Scans the expected cash flow for ``expected_interest`` and
-        ``expected_principal`` items whose payment number matches one of
-        the requested installments and calls ``delete(effective_date)``
-        on their underlying :class:`CashFlowItem` containers.
-        """
-        expected_cf = self.generate_expected_cash_flow()
-        removed_set = set(installments)
-
-        for item in expected_cf.raw_items():
-            entry = item.resolve()
-            if entry is None:
-                continue
-            if entry.category.isdisjoint({"interest", "principal"}):
-                continue
-            desc = entry.description or ""
-            for num in removed_set:
-                if desc.endswith(f" {num}"):
-                    item.delete(effective_date)
-                    break
-
-    @property
-    def settlements(self) -> List[Settlement]:
-        """All settlements made on this loan (Warp-aware)."""
-        return self._settlements_engine.all_settlements(
-            self._ledger,
-            self.get_original_schedule(),
-            self.fines_applied,
-            self.disbursement_date,
-            self.now(),
-        )
-
-    @property
-    def installments(self) -> List[Installment]:
-        """The repayment plan as Installment objects (Warp-aware)."""
-        return self._settlements_engine.all_installments(
-            self.settlements,
-            self.principal_balance,
-            self.now(),
-            self.get_original_schedule(),
-            self.fines_applied,
-        )
-
-    def _covered_due_date_count(self) -> int:
-        """How many due dates have been covered by payments so far."""
-        snapshots = self._ledger.snapshots
-        if not snapshots:
-            return 0
-        remaining = snapshots[-1].ending_balance
-        return SettlementEngine.covered_due_date_count(remaining, self.get_original_schedule())
-
-    def _next_unpaid_due_date(self) -> date:
-        """
-        Find the next due date that hasn't been fully paid yet.
-
-        Uses cumulative principal comparison against the original schedule
-        to determine coverage, so partial payments, overpayments, and
-        multiple anticipations are handled correctly.
-
-        Returns:
-            The next unpaid due date
-
-        Raises:
-            ValueError: If all due dates have been paid
-        """
-        covered = self._covered_due_date_count()
-        if covered >= len(self.due_dates):
-            raise ValueError("All due dates have been paid")
-        return self.due_dates[covered]
-
-    def get_actual_cash_flow(self) -> CashFlow:
-        """
-        Get the actual cash flow combining expected schedule with actual payments made.
-
-        This shows both what was expected and what actually happened for comparison.
-        Includes fine applications and fine payments.
-        """
-        expected_cf = self.generate_expected_cash_flow()
-        items = list(expected_cf.raw_items())
-
-        for due_date, fine_amount in self.fines_applied.items():
-            items.append(
-                CashFlowItem(
-                    fine_amount,
-                    to_datetime(due_date + timedelta(days=self.grace_period_days + 1)),
-                    f"Late payment fine applied for {due_date}",
-                    "fine",
-                    time_context=self._time_ctx,
-                )
-            )
-
-        for payment in self._ledger.actual_payment_items:
-            items.append(
-                CashFlowItem(
-                    -payment.amount,
-                    payment.datetime,
-                    payment.description or f"Actual payment on {payment.datetime.date()}",
-                    payment.category,
-                    time_context=self._time_ctx,
-                )
-            )
-
-        return CashFlow(items)
+    # ------------------------------------------------------------------
+    # Schedule
+    # ------------------------------------------------------------------
 
     def get_original_schedule(self) -> PaymentSchedule:
-        """
-        Get the original amortization schedule as calculated at loan origination.
-
-        This always returns the static schedule based on the original loan terms,
-        ignoring any payments that have been made.
-
-        Returns:
-            PaymentSchedule based on original loan parameters
-        """
+        """The original amortization schedule (static, ignores payments)."""
         return self.scheduler.generate_schedule(
-            self.principal, self.interest_rate, self.due_dates, self.disbursement_date
+            self.principal, self.interest_rate, self.due_dates, self.disbursement_date,
         )
 
     def get_amortization_schedule(self) -> PaymentSchedule:
-        """
-        Get the current amortization schedule merging actual past with projected future.
-
-        Returns a clean, ordered list: recorded payment entries first, then
-        projected entries recalculated from the remaining principal and
-        remaining due dates with a new PMT.
-
-        If no payments have been made, returns the original schedule.
-
-        Returns:
-            PaymentSchedule with past entries followed by projected future entries
-        """
-        if not self._ledger.actual_schedule_entries():
+        """Current schedule: recorded past entries + projected future."""
+        state = self._compute_state()
+        if not state.settlements:
             return self.get_original_schedule()
 
-        actual_entries = list(self._ledger.actual_schedule_entries())
-        covered = self._covered_due_date_count()
+        actual_entries: List[PaymentScheduleEntry] = []
+        prev_balance = self.principal
+        prev_date = self.disbursement_date
 
+        for i, s in enumerate(state.settlements):
+            days = (s.payment_date.date() - prev_date.date()).days
+            actual_entries.append(PaymentScheduleEntry(
+                payment_number=i + 1,
+                due_date=s.payment_date.date(),
+                days_in_period=days,
+                beginning_balance=prev_balance,
+                payment_amount=s.interest_paid + s.mora_paid + s.principal_paid,
+                principal_payment=s.principal_paid,
+                interest_payment=s.interest_paid + s.mora_paid,
+                ending_balance=s.remaining_balance,
+            ))
+            prev_balance = s.remaining_balance
+            prev_date = s.payment_date
+
+        covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
         remaining_due_dates = self.due_dates[covered:]
         if not remaining_due_dates:
             return PaymentSchedule(entries=actual_entries)
 
-        remaining_principal = actual_entries[-1].ending_balance
-        if remaining_principal.is_zero() or remaining_principal.is_negative():
+        if state.principal_balance.is_zero() or state.principal_balance.is_negative():
             return PaymentSchedule(entries=actual_entries)
 
-        last_payment_date = self._ledger.actual_payment_datetimes()[-1]
         projected_schedule = self.scheduler.generate_schedule(
-            remaining_principal,
-            self.interest_rate,
-            remaining_due_dates,
-            last_payment_date,
+            state.principal_balance, self.interest_rate,
+            remaining_due_dates, state.last_payment_date,
         )
 
-        projected_entries = []
+        projected_entries: List[PaymentScheduleEntry] = []
         for entry in projected_schedule:
-            projected_entries.append(
-                PaymentScheduleEntry(
-                    payment_number=len(actual_entries) + entry.payment_number,
-                    due_date=entry.due_date,
-                    days_in_period=entry.days_in_period,
-                    beginning_balance=entry.beginning_balance,
-                    payment_amount=entry.payment_amount,
-                    principal_payment=entry.principal_payment,
-                    interest_payment=entry.interest_payment,
-                    ending_balance=entry.ending_balance,
-                )
-            )
+            projected_entries.append(PaymentScheduleEntry(
+                payment_number=len(actual_entries) + entry.payment_number,
+                due_date=entry.due_date,
+                days_in_period=entry.days_in_period,
+                beginning_balance=entry.beginning_balance,
+                payment_amount=entry.payment_amount,
+                principal_payment=entry.principal_payment,
+                interest_payment=entry.interest_payment,
+                ending_balance=entry.ending_balance,
+            ))
 
         return PaymentSchedule(entries=actual_entries + projected_entries)
 
+    # ------------------------------------------------------------------
+    # Cash flow views
+    # ------------------------------------------------------------------
+
+    def generate_expected_cash_flow(self) -> CashFlow:
+        """Expected cash flow (schedule items only, no payments)."""
+        return self.cashflow.filter_by_kind(CashFlowType.EXPECTED)
+
+    def get_actual_cash_flow(self) -> CashFlow:
+        """Combined cash flow: expected schedule + actual payments + fines.
+
+        Decomposes payments into fine/interest/mora/principal items
+        for detailed cash-flow analysis.
+        """
+        expected_items = [
+            item for item in self.cashflow.raw_items()
+            if (entry := item.resolve()) is not None and entry.kind == CashFlowType.EXPECTED
+        ]
+        items = list(expected_items)
+        state = self._compute_state()
+
+        for due_date, fine_amount in state.fines_applied.items():
+            items.append(CashFlowItem(
+                fine_amount,
+                to_datetime(due_date + timedelta(days=self.grace_period_days + 1)),
+                f"Late payment fine applied for {due_date}",
+                "fine",
+                time_context=self._time_ctx,
+            ))
+
+        for settlement in state.settlements:
+            label = f"Payment on {settlement.payment_date.date()}"
+            if settlement.fine_paid.is_positive():
+                items.append(CashFlowItem(
+                    -settlement.fine_paid, settlement.payment_date,
+                    f"Fine payment - {label}", "fine",
+                    time_context=self._time_ctx,
+                ))
+            if settlement.interest_paid.is_positive():
+                items.append(CashFlowItem(
+                    -settlement.interest_paid, settlement.payment_date,
+                    f"Interest portion - {label}", "interest",
+                    time_context=self._time_ctx,
+                ))
+            if settlement.mora_paid.is_positive():
+                items.append(CashFlowItem(
+                    -settlement.mora_paid, settlement.payment_date,
+                    f"Mora interest - {label}", "mora_interest",
+                    time_context=self._time_ctx,
+                ))
+            if settlement.principal_paid.is_positive():
+                items.append(CashFlowItem(
+                    -settlement.principal_paid, settlement.payment_date,
+                    f"Principal portion - {label}", "principal",
+                    time_context=self._time_ctx,
+                ))
+
+        return CashFlow(items)
+
+    # ------------------------------------------------------------------
+    # TVM
+    # ------------------------------------------------------------------
+
+    @tz_aware
+    def present_value(
+        self, discount_rate: Optional[InterestRate] = None, valuation_date: Optional[datetime] = None,
+    ) -> Money:
+        """Present Value of the loan's expected cash flows."""
+        return loan_present_value(self, discount_rate, valuation_date)
+
+    def irr(self, guess: Optional[Rate] = None) -> Rate:
+        """Internal Rate of Return of the loan's expected cash flows."""
+        return loan_irr(self, guess)
+
+    # ------------------------------------------------------------------
+    # Dunder
+    # ------------------------------------------------------------------
+
     def __str__(self) -> str:
-        """String representation of the loan."""
         fine_info = f", fines={self.fine_balance}" if self.fine_balance.is_positive() else ""
         return (
             f"Loan(principal={self.principal}, rate={self.interest_rate}, "
@@ -751,7 +605,6 @@ class Loan:
         )
 
     def __repr__(self) -> str:
-        """Detailed representation for debugging."""
         return (
             f"Loan(principal={self.principal!r}, interest_rate={self.interest_rate!r}, "
             f"due_dates={self.due_dates!r}, disbursement_date={self.disbursement_date!r}, "

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,6 +1,6 @@
 """Loan class -- everything emerges from the CashFlow."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import Dict, List, Optional, Type
 
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
@@ -526,57 +526,6 @@ class Loan:
     def generate_expected_cash_flow(self) -> CashFlow:
         """Expected cash flow (schedule items only, no payments)."""
         return self.cashflow.filter_by_kind(CashFlowType.EXPECTED)
-
-    def get_actual_cash_flow(self) -> CashFlow:
-        """Combined cash flow: expected schedule + actual payments + fines.
-
-        Decomposes payments into fine/interest/mora/principal items
-        for detailed cash-flow analysis.
-        """
-        expected_items = [
-            item for item in self.cashflow.raw_items()
-            if (entry := item.resolve()) is not None and entry.kind == CashFlowType.EXPECTED
-        ]
-        items = list(expected_items)
-        state = self._compute_state()
-
-        for due_date, fine_amount in state.fines_applied.items():
-            items.append(CashFlowItem(
-                fine_amount,
-                to_datetime(due_date + timedelta(days=self.grace_period_days + 1)),
-                f"Late payment fine applied for {due_date}",
-                "fine",
-                time_context=self._time_ctx,
-            ))
-
-        for settlement in state.settlements:
-            label = f"Payment on {settlement.payment_date.date()}"
-            if settlement.fine_paid.is_positive():
-                items.append(CashFlowItem(
-                    -settlement.fine_paid, settlement.payment_date,
-                    f"Fine payment - {label}", "fine",
-                    time_context=self._time_ctx,
-                ))
-            if settlement.interest_paid.is_positive():
-                items.append(CashFlowItem(
-                    -settlement.interest_paid, settlement.payment_date,
-                    f"Interest portion - {label}", "interest",
-                    time_context=self._time_ctx,
-                ))
-            if settlement.mora_paid.is_positive():
-                items.append(CashFlowItem(
-                    -settlement.mora_paid, settlement.payment_date,
-                    f"Mora interest - {label}", "mora_interest",
-                    time_context=self._time_ctx,
-                ))
-            if settlement.principal_paid.is_positive():
-                items.append(CashFlowItem(
-                    -settlement.principal_paid, settlement.payment_date,
-                    f"Principal portion - {label}", "principal",
-                    time_context=self._time_ctx,
-                ))
-
-        return CashFlow(items)
 
     # ------------------------------------------------------------------
     # TVM

--- a/tests/loan/test_cash_flow.py
+++ b/tests/loan/test_cash_flow.py
@@ -1,4 +1,4 @@
-"""Tests for Loan expected and actual cash flow generation."""
+"""Tests for Loan expected cash flow generation."""
 
 from datetime import date, datetime, timezone
 from decimal import Decimal
@@ -66,65 +66,3 @@ def test_loan_generate_expected_cash_flow_net_zero():
     # Net should be close to zero (disbursement + payments)
     net = cash_flow.net_present_value()
     assert abs(net.real_amount) < Decimal("0.01")
-
-
-def test_loan_get_actual_cash_flow_empty_initially():
-    principal = Money("10000.00")
-    rate = InterestRate("5% a")
-    due_dates = [date(2024, 2, 1)]
-
-    loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
-    actual_cf = loan.get_actual_cash_flow()
-
-    # Should have disbursement + expected payments, but no actual (happened) payments yet
-    disbursement_items = actual_cf.query.filter_by(category="disbursement").all()
-    happened_interest = actual_cf.query.happened.filter_by(category="interest").all()
-
-    assert len(disbursement_items) == 1
-    assert len(happened_interest) == 0
-
-
-def test_loan_get_actual_cash_flow_includes_payments():
-    principal = Money("10000.00")
-    rate = InterestRate("5% a")
-    due_dates = [date(2024, 2, 1)]
-
-    loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc))
-    loan.record_payment(Money("5000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc), description="First payment")
-
-    actual_cf = loan.get_actual_cash_flow()
-
-    # Should have expected payments + actual (happened) payments
-    happened_interest = actual_cf.query.happened.filter_by(category="interest").all()
-    happened_principal = actual_cf.query.happened.filter_by(category="principal").all()
-
-    assert len(happened_interest) >= 1
-    assert len(happened_principal) >= 1
-
-
-def test_loan_get_actual_cash_flow_includes_fines():
-    principal = Money("10000.00")
-    rate = InterestRate("5% a")
-    due_dates = [date(2024, 2, 1)]
-
-    loan = Loan(
-        principal,
-        rate,
-        due_dates,
-        disbursement_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        fine_rate=InterestRate("2% annual"),
-        grace_period_days=3,
-    )
-
-    # Apply fines and make payment
-    loan.calculate_late_fines(datetime(2024, 2, 10, tzinfo=timezone.utc))
-    loan.record_payment(Money("500"), datetime(2024, 2, 11, tzinfo=timezone.utc))
-
-    actual_cf = loan.get_actual_cash_flow()
-
-    fine_items = actual_cf.query.filter_by(category="fine").all()
-    fine_applied_items = [i for i in fine_items if i.is_inflow()]
-    fine_payment_items = [i for i in fine_items if i.is_outflow()]
-
-    assert len(fine_applied_items) == 1
-    assert len(fine_payment_items) >= 1

--- a/tests/loan/test_fines.py
+++ b/tests/loan/test_fines.py
@@ -235,9 +235,8 @@ def test_loan_record_payment_allocates_to_fines_first():
     loan.record_payment(payment_amount, datetime(2024, 2, 6, tzinfo=timezone.utc))
 
     # Check that payment went to fines
-    fine_payments = [p for p in loan._ledger.actual_payment_items if "fine" in p.category]
-    assert len(fine_payments) == 1
-    assert fine_payments[0].amount == payment_amount
+    settlement = loan.settlements[-1]
+    assert settlement.fine_paid == payment_amount
 
 
 def test_loan_record_payment_allocates_fines_then_principal():
@@ -262,13 +261,9 @@ def test_loan_record_payment_allocates_fines_then_principal():
     loan.record_payment(payment_amount, datetime(2024, 2, 6, tzinfo=timezone.utc))
 
     # Check allocations
-    fine_payments = [p for p in loan._ledger.actual_payment_items if "fine" in p.category]
-    principal_payments = [p for p in loan._ledger.actual_payment_items if "principal" in p.category]
-
-    assert len(fine_payments) == 1
-    assert fine_payments[0].amount == total_fines
-    assert len(principal_payments) == 1
-    assert principal_payments[0].amount == Money("200")
+    settlement = loan.settlements[-1]
+    assert settlement.fine_paid == total_fines
+    assert settlement.principal_paid == Money("200")
 
 
 def test_loan_current_balance_includes_fine_balance():
@@ -385,16 +380,11 @@ def test_pay_installment_late_triggers_fines_and_extra_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("11000.00"))
-        fine_items = [p for p in warped._ledger.all_payment_items if "fine" in p.category]
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert len(fine_items) == 1
-    assert fine_items[0].amount > Money.zero()
-    assert len(interest_items) == 1
-    assert interest_items[0].amount > Money.zero()
-    assert len(mora_items) == 1
-    assert mora_items[0].amount > Money.zero()
+    assert settlement.fine_paid > Money.zero()
+    assert settlement.interest_paid > Money.zero()
+    assert settlement.mora_paid > Money.zero()
 
 
 # --- Late overpayment covering multiple installments ---
@@ -429,9 +419,8 @@ def test_late_overpayment_fine_equals_two_percent_of_scheduled_payment():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        fine_items = [p for p in warped._ledger.all_payment_items if "fine" in p.category]
 
-    assert fine_items[0].amount == expected_fine
+    assert warped.settlements[-1].fine_paid == expected_fine
 
 
 def test_late_overpayment_total_interest_for_45_days():
@@ -453,10 +442,8 @@ def test_late_overpayment_total_interest_for_45_days():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        interest_items = [
-            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
-        ]
-        total_interest = sum((p.amount for p in interest_items), Money.zero())
+        settlement = warped.settlements[-1]
+        total_interest = settlement.interest_paid + settlement.mora_paid
 
     assert total_interest == Money(expected_total)
 
@@ -483,9 +470,8 @@ def test_late_overpayment_principal_is_remainder_after_fine_and_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        principal_items = [p for p in warped._ledger.all_payment_items if "principal" in p.category]
 
-    assert principal_items[0].amount == Money(expected_principal)
+    assert warped.settlements[-1].principal_paid == Money(expected_principal)
 
 
 def test_late_overpayment_ending_balance_in_actual_entry():
@@ -511,9 +497,8 @@ def test_late_overpayment_ending_balance_in_actual_entry():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("7000.00"))
-        entry = warped._ledger.actual_schedule_entries()[-1]
 
-    assert entry.ending_balance == Money(expected_ending)
+    assert warped.settlements[-1].remaining_balance == Money(expected_ending)
 
 
 def test_late_overpayment_covers_two_installments():

--- a/tests/loan/test_mora_interest.py
+++ b/tests/loan/test_mora_interest.py
@@ -19,11 +19,10 @@ def test_late_payment_produces_separate_mora_interest_item():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert len(interest_items) == 1
-    assert len(mora_items) == 1
+    assert settlement.interest_paid != Money.zero()
+    assert settlement.mora_paid != Money.zero()
 
 
 def test_mora_interest_equals_difference_between_total_and_regular():
@@ -42,11 +41,10 @@ def test_mora_interest_equals_difference_between_total_and_regular():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert interest_items[0].amount == Money(regular_interest)
-    assert mora_items[0].amount == Money(expected_mora)
+    assert settlement.interest_paid == Money(regular_interest)
+    assert settlement.mora_paid == Money(expected_mora)
 
 
 def test_regular_interest_matches_scheduled_interest():
@@ -62,9 +60,9 @@ def test_regular_interest_matches_scheduled_interest():
 
     with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert interest_items[0].amount == scheduled_interest
+    assert settlement.interest_paid == scheduled_interest
 
 
 @pytest.mark.parametrize(
@@ -87,10 +85,8 @@ def test_total_interest_on_late_payment_matches_manual_calculation(late_days):
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        all_interest = [
-            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
-        ]
-        total_interest = sum((p.amount for p in all_interest), Money.zero())
+        settlement = warped.settlements[-1]
+        total_interest = settlement.interest_paid + settlement.mora_paid
 
     assert total_interest == Money(expected_total)
 
@@ -106,11 +102,10 @@ def test_on_time_payment_produces_no_mora_interest_item():
 
     with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert len(interest_items) == 1
-    assert len(mora_items) == 0
+    assert settlement.interest_paid != Money.zero()
+    assert settlement.mora_paid == Money.zero()
 
 
 def test_early_payment_produces_no_mora_interest_item():
@@ -124,9 +119,9 @@ def test_early_payment_produces_no_mora_interest_item():
 
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert len(mora_items) == 0
+    assert settlement.mora_paid == Money.zero()
 
 
 def test_on_time_interest_unchanged():
@@ -144,9 +139,9 @@ def test_on_time_interest_unchanged():
 
     with Warp(loan, due_date) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert interest_items[0].amount == Money(expected_interest)
+    assert settlement.interest_paid == Money(expected_interest)
 
 
 # --- Custom mora interest rate tests ---
@@ -198,11 +193,10 @@ def test_on_time_payment_unaffected_by_custom_mora_rate():
 
     with Warp(loan, due_date) as warped:
         warped.pay_installment(Money("10500.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert interest_items[0].amount == Money(expected_interest)
-    assert len(mora_items) == 0
+    assert settlement.interest_paid == Money(expected_interest)
+    assert settlement.mora_paid == Money.zero()
 
 
 def test_mora_with_custom_rate_compound_strategy():
@@ -235,9 +229,9 @@ def test_mora_with_custom_rate_compound_strategy():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert mora_items[0].amount == Money(expected_mora)
+    assert settlement.mora_paid == Money(expected_mora)
 
 
 def test_mora_with_custom_rate_simple_strategy():
@@ -264,9 +258,9 @@ def test_mora_with_custom_rate_simple_strategy():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_items = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert mora_items[0].amount == Money(expected_mora)
+    assert settlement.mora_paid == Money(expected_mora)
 
 
 def test_simple_vs_compound_mora_compound_produces_more():
@@ -297,11 +291,11 @@ def test_simple_vs_compound_mora_compound_produces_more():
 
     with Warp(loan_compound, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_compound = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category][0].amount
+        mora_compound = warped.settlements[-1].mora_paid
 
     with Warp(loan_simple, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        mora_simple = [p for p in warped._ledger.all_payment_items if "mora_interest" in p.category][0].amount
+        mora_simple = warped.settlements[-1].mora_paid
 
     assert mora_compound > mora_simple
 
@@ -328,9 +322,9 @@ def test_regular_interest_unchanged_regardless_of_mora_rate():
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        settlement = warped.settlements[-1]
 
-    assert interest_items[0].amount == Money(expected_regular)
+    assert settlement.interest_paid == Money(expected_regular)
 
 
 @pytest.mark.parametrize(
@@ -379,10 +373,8 @@ def test_total_interest_with_custom_mora_rate_matches_manual(mora_rate_str, stra
 
     with Warp(loan, payment_date) as warped:
         warped.pay_installment(Money("11000.00"))
-        all_interest = [
-            p for p in warped._ledger.all_payment_items if not p.category.isdisjoint({"interest", "mora_interest"})
-        ]
-        total_interest = sum((p.amount for p in all_interest), Money.zero())
+        settlement = warped.settlements[-1]
+        total_interest = settlement.interest_paid + settlement.mora_paid
 
     assert total_interest == Money(expected_total)
 

--- a/tests/loan/test_payment_methods.py
+++ b/tests/loan/test_payment_methods.py
@@ -22,7 +22,7 @@ def test_pay_installment_uses_now_as_payment_date():
 
     with Warp(loan, datetime(2025, 1, 20, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("5000.00"))
-        assert warped._ledger.all_payment_items[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
+        assert warped.settlements[-1].payment_date == datetime(2025, 1, 20, tzinfo=timezone.utc)
 
 
 def test_pay_installment_charges_interest_to_due_date():
@@ -36,12 +36,11 @@ def test_pay_installment_charges_interest_to_due_date():
     # pay_installment on Jan 15 should charge interest for 31 days (to Feb 1 due date)
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(Money("5000.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
-        assert len(interest_items) == 1
+        settlement = warped.settlements[-1]
 
         daily_rate = InterestRate("6% a").to_daily().as_decimal()
         expected_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
-        assert interest_items[0].amount == Money(expected_interest)
+        assert settlement.interest_paid == Money(expected_interest)
 
 
 def test_pay_installment_no_discount_vs_anticipate_discount():
@@ -55,15 +54,15 @@ def test_pay_installment_no_discount_vs_anticipate_discount():
     loan1 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan1, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped1:
         warped1.pay_installment(Money("5000.00"))
-        installment_interest = [p for p in warped1._ledger.all_payment_items if "interest" in p.category]
+        installment_interest = warped1.settlements[-1].interest_paid
 
     # anticipate_payment: interest for 14 days (disbursement to payment date)
     loan2 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan2, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped2:
         warped2.anticipate_payment(Money("5000.00"))
-        anticipate_interest = [p for p in warped2._ledger.all_payment_items if "interest" in p.category]
+        anticipate_interest = warped2.settlements[-1].interest_paid
 
-    assert installment_interest[0].amount > anticipate_interest[0].amount
+    assert installment_interest > anticipate_interest
 
 
 def test_pay_installment_more_principal_with_anticipate():
@@ -77,14 +76,14 @@ def test_pay_installment_more_principal_with_anticipate():
     loan1 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan1, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped1:
         warped1.pay_installment(payment)
-        installment_principal = [p for p in warped1._ledger.all_payment_items if "principal" in p.category]
+        installment_principal = warped1.settlements[-1].principal_paid
 
     loan2 = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan2, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped2:
         warped2.anticipate_payment(payment)
-        anticipate_principal = [p for p in warped2._ledger.all_payment_items if "principal" in p.category]
+        anticipate_principal = warped2.settlements[-1].principal_paid
 
-    assert anticipate_principal[0].amount > installment_principal[0].amount
+    assert anticipate_principal > installment_principal
 
 
 # --- anticipate_payment tests ---
@@ -100,7 +99,7 @@ def test_anticipate_payment_uses_now_as_payment_date():
 
     with Warp(loan, datetime(2025, 1, 20, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        assert warped._ledger.all_payment_items[-1].datetime == datetime(2025, 1, 20, tzinfo=timezone.utc)
+        assert warped.settlements[-1].payment_date == datetime(2025, 1, 20, tzinfo=timezone.utc)
 
 
 def test_anticipate_payment_charges_interest_only_for_elapsed_days():
@@ -113,11 +112,11 @@ def test_anticipate_payment_charges_interest_only_for_elapsed_days():
 
     with Warp(loan, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(Money("5000.00"))
-        interest_items = [p for p in warped._ledger.all_payment_items if "interest" in p.category]
+        settlement = warped.settlements[-1]
 
         daily_rate = InterestRate("6% a").to_daily().as_decimal()
         expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
-        assert interest_items[0].amount == Money(expected_interest)
+        assert settlement.interest_paid == Money(expected_interest)
 
 
 def test_anticipate_payment_negative_amount_raises_error():
@@ -193,10 +192,10 @@ def test_record_payment_with_explicit_interest_date():
         interest_date=datetime(2025, 2, 1, tzinfo=timezone.utc),
     )
 
-    interest_items = [p for p in loan._ledger.all_payment_items if "interest" in p.category]
+    settlement = loan.settlements[-1]
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
-    assert interest_items[0].amount == Money(expected_interest)
+    assert settlement.interest_paid == Money(expected_interest)
 
 
 def test_record_payment_interest_date_defaults_to_payment_date():
@@ -209,10 +208,10 @@ def test_record_payment_interest_date_defaults_to_payment_date():
 
     loan.record_payment(Money("5000.00"), payment_date=datetime(2025, 1, 15, tzinfo=timezone.utc))
 
-    interest_items = [p for p in loan._ledger.all_payment_items if "interest" in p.category]
+    settlement = loan.settlements[-1]
     daily_rate = InterestRate("6% a").to_daily().as_decimal()
     expected_interest = Decimal("10000") * ((1 + daily_rate) ** 14 - 1)
-    assert interest_items[0].amount == Money(expected_interest)
+    assert settlement.interest_paid == Money(expected_interest)
 
 
 # --- Schedule rebuild tests ---
@@ -688,11 +687,11 @@ def test_anticipate_vs_installment_ending_balance_comparison():
     loan_installment = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan_installment, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.pay_installment(scheduled_pmt)
-        installment_remaining = warped._ledger.actual_schedule_entries()[-1].ending_balance
+        installment_remaining = warped.settlements[-1].remaining_balance
 
     loan_anticipate = Loan(principal, rate, due_dates, disbursement_date=disbursement)
     with Warp(loan_anticipate, datetime(2025, 1, 15, tzinfo=timezone.utc)) as warped:
         warped.anticipate_payment(scheduled_pmt)
-        anticipate_remaining = warped._ledger.actual_schedule_entries()[-1].ending_balance
+        anticipate_remaining = warped.settlements[-1].remaining_balance
 
     assert anticipate_remaining < installment_remaining

--- a/tests/loan/test_payments.py
+++ b/tests/loan/test_payments.py
@@ -28,12 +28,11 @@ def test_loan_record_payment_creates_interest_and_principal_items():
     loan = Loan(principal, rate, due_dates, disbursement_date)
     loan.record_payment(Money("5000.00"), datetime(2024, 1, 15, tzinfo=timezone.utc))
 
-    # Should have created interest and principal payment items
-    assert len(loan._ledger.actual_payment_items) == 2
-
-    # Check categories
-    assert any("interest" in p.category for p in loan._ledger.actual_payment_items)
-    assert any("principal" in p.category for p in loan._ledger.actual_payment_items)
+    settlement = loan.settlements[-1]
+    assert settlement.interest_paid.is_positive()
+    assert settlement.principal_paid.is_positive()
+    assert settlement.interest_paid == Money("22.37")
+    assert settlement.principal_paid == Money("4977.63")
 
 
 def test_loan_record_payment_updates_last_payment_date():

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -124,12 +124,12 @@ def test_warp_filters_future_payments(sample_loan):
     target_date = datetime(2024, 1, 20, tzinfo=timezone.utc)
 
     with Warp(sample_loan, target_date) as warped_loan:
-        # Should only have the first payment
-        assert len(warped_loan._ledger.actual_payment_items) == 2  # Interest + principal portions of first payment
+        # Should only have the first payment (one settlement per recorded payment)
+        assert len(warped_loan.settlements) == 1
 
-        # All payments should be before or on target date
-        for payment in warped_loan._ledger.actual_payment_items:
-            assert payment.datetime <= target_date
+        # All settlements should be before or on target date
+        for settlement in warped_loan.settlements:
+            assert settlement.payment_date <= target_date
 
 
 def test_warp_recalculates_balance_from_filtered_payments(sample_loan):
@@ -185,18 +185,15 @@ def test_warp_to_past_ignores_future_payments():
 
     # Warp to middle date
     with Warp(loan, datetime(2024, 2, 5, tzinfo=timezone.utc)) as warped_loan:
-        # Should only have first payment (2 items: interest + principal)
-        assert len(warped_loan._ledger.actual_payment_items) == 2
+        # Should only have first payment
+        assert len(warped_loan.settlements) == 1
 
-        # Check that it's the first payment
-        payment_dates = [p.datetime for p in warped_loan._ledger.actual_payment_items]
-        assert all(d == datetime(2024, 1, 10, tzinfo=timezone.utc) for d in payment_dates)
+        assert warped_loan.settlements[0].payment_date == datetime(2024, 1, 10, tzinfo=timezone.utc)
 
 
 def test_warp_to_future_keeps_all_past_payments():
-    # Disable fines so payments produce interest/mora + principal only.
-    # Payment 1 (Jan 10) is early -> interest + principal = 2 items
-    # Payment 2 (Feb 10) is late vs Jan 15 due date -> interest + mora + principal = 3 items
+    # Disable fines so payments are allocated without fine components.
+    # Two recorded payments -> two settlements.
     loan = Loan(
         Money("10000"),
         InterestRate("5% annual"),
@@ -208,9 +205,9 @@ def test_warp_to_future_keeps_all_past_payments():
     loan.record_payment(Money("500"), datetime(2024, 1, 10, tzinfo=timezone.utc), description="Payment 1")
     loan.record_payment(Money("600"), datetime(2024, 2, 10, tzinfo=timezone.utc), description="Payment 2")
 
-    # Warp to future date — both past payments must be visible (5 items: 2 + 3)
+    # Warp to future date — both past payments must be visible
     with Warp(loan, datetime(2025, 1, 1, tzinfo=timezone.utc)) as warped_loan:
-        assert len(warped_loan._ledger.actual_payment_items) == 5
+        assert len(warped_loan.settlements) == 2
 
 
 # String representations


### PR DESCRIPTION
## Summary

- **Single CashFlow source of truth**: `Loan.cashflow` holds both expected schedule items and actual payment items. `record_payment` appends one `CashFlowItem` -- no decomposition, no allocation at write time.
- **All state derived on demand**: Settlements, installments, balances, and fines are computed by a forward pass (`compute_state`) over the cashflow. `PaymentLedger` and `FineTracker` are removed; `SettlementEngine` class replaced with pure functions in `settlement_engine` module.
- **Removed `get_actual_cash_flow()`**: It fabricated CashFlowItems from derived settlements, violating the emergence philosophy. Consumers use `loan.cashflow` for raw facts and `loan.settlements` for allocation detail.
- **Fixed `is_fully_covered` bug**: The flag now uses post-payment balance instead of pre-payment balance, correctly marking allocations as covered when a payment fully pays off the loan.

## Test plan

- [x] All 1660 tests pass (3 removed with `get_actual_cash_flow`)
- [x] Zero references to `get_actual_cash_flow` remain in codebase
- [x] `knowledge/loan.md` and `knowledge/architecture.md` updated
- [x] `docs/examples/quickstart.md` and `docs/examples/fines.md` updated