### PR TITLE
refactor: extract Allocation into its own module

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -117,8 +117,8 @@ MoneyWarp provides a comprehensive set of classes for financial calculations and
       show_source: false
       heading_level: 4
 
-### SettlementAllocation
-::: money_warp.SettlementAllocation
+### Allocation
+::: money_warp.Allocation
     options:
       show_root_heading: true
       show_source: false

--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -27,8 +27,9 @@ money_warp/
 │   ├── interest_calculator.py # InterestCalculator (stateless rate math)
 │   ├── settlement_engine.py   # Pure functions: forward pass, fines, allocation
 │   ├── tvm.py                 # TVM standalone functions (PV, IRR, anticipation)
+│   ├── allocation.py          # Allocation dataclass (per-installment payment breakdown)
 │   ├── installment.py         # Installment dataclass
-│   └── settlement.py          # Settlement, SettlementAllocation dataclasses
+│   └── settlement.py          # Settlement, AnticipationResult dataclasses
 ├── scheduler/
 │   ├── base.py            # BaseScheduler (abstract)
 │   ├── price_scheduler.py           # PriceScheduler (French amortization)

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -200,9 +200,9 @@ A frozen dataclass capturing how a single payment was allocated. Derived by the 
 
 Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`.
 
-### SettlementAllocation
+### Allocation
 
-Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`.
+Defined in `loan/allocation.py`. Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`.
 
 Shared between Settlement (forward view) and Installment (reverse view).
 

--- a/money_warp/__init__.py
+++ b/money_warp/__init__.py
@@ -20,7 +20,7 @@ from money_warp.date_utils import (
     generate_weekly_dates,
 )
 from money_warp.interest_rate import CompoundingFrequency, InterestRate, YearSize
-from money_warp.loan import AnticipationResult, Installment, Loan, MoraStrategy, Settlement, SettlementAllocation
+from money_warp.loan import Allocation, AnticipationResult, Installment, Loan, MoraStrategy, Settlement
 from money_warp.money import Money
 from money_warp.present_value import (
     discount_factor,
@@ -77,7 +77,7 @@ __all__ = [
     "MoraStrategy",
     "Installment",
     "Settlement",
-    "SettlementAllocation",
+    "Allocation",
     "BaseScheduler",
     "PriceScheduler",
     "InvertedPriceScheduler",

--- a/money_warp/loan/__init__.py
+++ b/money_warp/loan/__init__.py
@@ -1,16 +1,17 @@
 """Loan module for personal loan modeling with flexible payment schedules."""
 
+from .allocation import Allocation
 from .engines.interest_calculator import InterestCalculator, MoraStrategy
 from .installment import Installment
 from .loan import Loan
-from .settlement import AnticipationResult, Settlement, SettlementAllocation
+from .settlement import AnticipationResult, Settlement
 
 __all__ = [
+    "Allocation",
     "AnticipationResult",
     "Installment",
     "InterestCalculator",
     "Loan",
     "MoraStrategy",
     "Settlement",
-    "SettlementAllocation",
 ]

--- a/money_warp/loan/allocation.py
+++ b/money_warp/loan/allocation.py
@@ -1,0 +1,26 @@
+"""Allocation data structure for per-installment payment breakdown."""
+
+from dataclasses import dataclass
+
+from ..money import Money
+
+
+@dataclass(frozen=True)
+class Allocation:
+    """Breakdown of a payment's allocation to a single installment.
+
+    Each allocation shows how much principal, interest, mora, and fine
+    from a payment were attributed to a specific installment.
+    """
+
+    installment_number: int
+    principal_allocated: Money
+    interest_allocated: Money
+    mora_allocated: Money
+    fine_allocated: Money
+    is_fully_covered: bool
+
+    @property
+    def total_allocated(self) -> Money:
+        """Sum of all components allocated to this installment."""
+        return self.principal_allocated + self.interest_allocated + self.mora_allocated + self.fine_allocated

--- a/money_warp/loan/engines/settlement_engine.py
+++ b/money_warp/loan/engines/settlement_engine.py
@@ -15,7 +15,8 @@ from ...money import Money
 from ...scheduler import PaymentSchedule
 from ...tz import to_datetime
 from ..installment import Installment
-from ..settlement import Settlement, SettlementAllocation
+from ..allocation import Allocation
+from ..settlement import Settlement
 from .interest_calculator import InterestCalculator
 
 _COVERAGE_TOLERANCE = Money("0.01")
@@ -169,7 +170,7 @@ def allocate_payment_per_installment(
     fine_cap: Money,
     interest_cap: Money,
     mora_cap: Money,
-) -> Tuple[Money, Money, Money, Money, List[SettlementAllocation]]:
+) -> Tuple[Money, Money, Money, Money, List[Allocation]]:
     """Allocate a payment across installments in priority order.
 
     Each installment is processed sequentially. Within each
@@ -188,7 +189,7 @@ def allocate_payment_per_installment(
     mora_total = Money.zero()
     interest_total = Money.zero()
     principal_total = Money.zero()
-    allocations: List[SettlementAllocation] = []
+    allocations: List[Allocation] = []
 
     for inst in installments:
         if not remaining.raw_amount:
@@ -225,14 +226,14 @@ def allocate_payment_per_installment(
     post_balance = ending_balance - principal_total
     if post_balance <= _COVERAGE_TOLERANCE:
         inst_by_number = {inst.number: inst for inst in installments}
-        fixed: List[SettlementAllocation] = []
+        fixed: List[Allocation] = []
         for alloc in allocations:
             if not alloc.is_fully_covered:
                 inst = inst_by_number.get(alloc.installment_number)
                 if inst is not None:
                     principal_owed = inst.expected_principal - inst.principal_paid
                     if alloc.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
-                        alloc = SettlementAllocation(
+                        alloc = Allocation(
                             installment_number=alloc.installment_number,
                             principal_allocated=alloc.principal_allocated,
                             interest_allocated=alloc.interest_allocated,
@@ -251,7 +252,7 @@ def allocate_payment_per_installment(
 # ------------------------------------------------------------------
 
 def _build_installments_snapshot(
-    allocs_by_number: Dict[int, List[SettlementAllocation]],
+    allocs_by_number: Dict[int, List[Allocation]],
     principal_balance: Money,
     as_of_date: datetime,
     schedule: PaymentSchedule,
@@ -325,7 +326,7 @@ def compute_state(
     fines_applied: Dict[date, Money] = {}
     fines_paid_total = Money.zero()
     settlements: List[Settlement] = []
-    allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+    allocs_by_number: Dict[int, List[Allocation]] = {}
     processed_payments: list = []
 
     # Build a merged timeline of payment events and fine observation points
@@ -435,7 +436,7 @@ def build_installments(
     last_payment_date: datetime,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""
-    allocs_by_number: Dict[int, List[SettlementAllocation]] = {}
+    allocs_by_number: Dict[int, List[Allocation]] = {}
     for settlement in settlements:
         for a in settlement.allocations:
             allocs_by_number.setdefault(a.installment_number, []).append(a)

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 
 from ..money import Money
 from ..scheduler import PaymentScheduleEntry
-from .settlement import SettlementAllocation
+from .allocation import Allocation
 
 _COVERAGE_TOLERANCE = Money("0.01")
 
@@ -34,7 +34,7 @@ class Installment:
     interest_paid: Money
     mora_paid: Money
     fine_paid: Money
-    allocations: List[SettlementAllocation]
+    allocations: List[Allocation]
 
     @property
     def balance(self) -> Money:
@@ -55,7 +55,7 @@ class Installment:
         fine_remaining: Money,
         mora_remaining: Money,
         interest_remaining: Money,
-    ) -> Tuple[SettlementAllocation, Money, Money, Money, Money]:
+    ) -> Tuple[Allocation, Money, Money, Money, Money]:
         """Allocate from a single payment amount in priority order.
 
         Processes fine -> mora -> interest -> principal sequentially,
@@ -89,7 +89,7 @@ class Installment:
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
         is_covered = total >= (self.balance - _COVERAGE_TOLERANCE)
 
-        allocation = SettlementAllocation(
+        allocation = Allocation(
             installment_number=self.number,
             principal_allocated=principal_alloc,
             interest_allocated=interest_alloc,
@@ -103,7 +103,7 @@ class Installment:
     def from_schedule_entry(
         cls,
         entry: PaymentScheduleEntry,
-        allocations: List[SettlementAllocation],
+        allocations: List[Allocation],
         expected_mora: Money,
         expected_fine: Money,
     ) -> "Installment":

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -21,7 +21,7 @@ from .engines.settlement_engine import (
     is_payment_late,
 )
 from .installment import Installment
-from .settlement import AnticipationResult, Settlement, SettlementAllocation
+from .settlement import AnticipationResult, Settlement
 from .tvm import loan_calculate_anticipation, loan_irr, loan_present_value
 
 

--- a/money_warp/loan/settlement.py
+++ b/money_warp/loan/settlement.py
@@ -5,30 +5,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING, List
 
 from ..money import Money
+from .allocation import Allocation
 
 if TYPE_CHECKING:
     from .installment import Installment
-
-
-@dataclass(frozen=True)
-class SettlementAllocation:
-    """Breakdown of a payment's allocation to a single installment.
-
-    Each allocation shows how much principal, interest, mora, and fine
-    from a payment were attributed to a specific installment.
-    """
-
-    installment_number: int
-    principal_allocated: Money
-    interest_allocated: Money
-    mora_allocated: Money
-    fine_allocated: Money
-    is_fully_covered: bool
-
-    @property
-    def total_allocated(self) -> Money:
-        """Sum of all components allocated to this installment."""
-        return self.principal_allocated + self.interest_allocated + self.mora_allocated + self.fine_allocated
 
 
 @dataclass(frozen=True)
@@ -47,7 +27,7 @@ class Settlement:
     mora_paid: Money
     principal_paid: Money
     remaining_balance: Money
-    allocations: List[SettlementAllocation]
+    allocations: List[Allocation]
 
     @property
     def total_paid(self) -> Money:

--- a/tests/loan/test_settlement.py
+++ b/tests/loan/test_settlement.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pytest
 
-from money_warp import InterestRate, Loan, Money, Settlement, SettlementAllocation, Warp
+from money_warp import Allocation, InterestRate, Loan, Money, Settlement, Warp
 
 
 def _payment_datetime(d: date) -> datetime:
@@ -96,9 +96,9 @@ def test_settlement_allocation_installment_number(simple_loan):
     assert settlement.allocations[0].installment_number == 1
 
 
-def test_settlement_allocation_is_settlement_allocation_type(simple_loan):
+def test_settlement_allocation_is_allocation_type(simple_loan):
     settlement = simple_loan.record_payment(Money("3500"), datetime(2025, 2, 1, tzinfo=timezone.utc))
-    assert isinstance(settlement.allocations[0], SettlementAllocation)
+    assert isinstance(settlement.allocations[0], Allocation)
 
 
 # --- Single installment coverage ---


### PR DESCRIPTION
## Summary
- Moved `SettlementAllocation` out of `settlement.py` into a new `allocation.py` module and renamed it to `Allocation`.
- Updated all imports, type hints, constructor calls, exports, tests, and documentation across 11 files.
- No backward-compatibility alias -- clean break.

## Changes
- New file `money_warp/loan/allocation.py` with the `Allocation` frozen dataclass (same fields and `total_allocated` property).
- `settlement.py` now imports `Allocation` from `.allocation` instead of defining it inline.
- All internal consumers (`installment.py`, `settlement_engine.py`, `loan.py`) and public exports (`loan/__init__.py`, `__init__.py`) updated.
- Test renamed from `test_settlement_allocation_is_settlement_allocation_type` to `test_settlement_allocation_is_allocation_type`.
- Knowledge files (`architecture.md`, `loan.md`) and API docs (`modules.md`) updated.

## Test plan
- [x] All existing tests pass (`poetry run pytest` -- 1660 passed, 5 xfailed)
- [x] No stale `SettlementAllocation` references remain in the codebase
- [x] `Allocation` is importable from `money_warp` top-level

## Docs
- Updated `knowledge/architecture.md` (added `allocation.py` to tree)
- Updated `knowledge/loan.md` (renamed section from `SettlementAllocation` to `Allocation`)
- Updated `docs/modules.md` (autodoc reference updated)