### PR TITLE
fix: snap sub-cent principal residual to zero after payment

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -278,3 +278,13 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 **Fix:** Moved the override to a post-loop fixup. After the allocation loop and spillover handling, compute `post_balance = ending_balance - principal_total`. If `post_balance <= tolerance`, iterate through allocations and fix `is_fully_covered` for any installment whose principal was fully allocated (within tolerance).
 
 **Lesson:** When a boolean flag depends on the outcome of the allocation, it must be evaluated after the allocation completes, not before. Pre-payment state is only useful for pre-conditions; coverage determination requires post-payment state.
+
+### Sub-cent principal residual left loan in impossible state (fixed 2026-03-22)
+
+**Symptom:** After paying the exact scheduled amount, `is_fully_covered` and `is_fully_paid` returned `True` but `is_paid_off` returned `False` and `remaining_balance` showed a sub-cent residual (0.005--0.012). Consumer code marked all installments as PAID but never marked the loan as SETTLED.
+
+**Root cause:** Full-precision interest accrual consumed slightly more than the schedule's 2dp interest, leaving a sub-cent gap on the principal. `allocate_payment_per_installment` and `Installment.is_fully_paid` used `_COVERAGE_TOLERANCE` (1 cent) for their checks, but `compute_state` only snapped `running_principal` to zero when negative — not when it was a sub-cent positive residual. `Loan.is_paid_off` checked `current_balance.is_zero()` (exact zero), which failed for the residual.
+
+**Fix:** In `compute_state`, after subtracting `principal_paid` from `running_principal`, also snap to zero when the balance is positive but within `_COVERAGE_TOLERANCE`. This aligns the principal balance with the same tolerance used by the allocation and installment layers.
+
+**Lesson:** All consistency checks across a system must use the same tolerance. When tolerance-based flags (`is_fully_covered`, `is_fully_paid`) coexist with exact checks (`is_paid_off` via `is_zero()`), the exact check must be relaxed to match, or the underlying data must be snapped so the exact check naturally passes.

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -458,7 +458,9 @@ def compute_state(
 
         fines_paid_total = fines_paid_total + fine_paid
         running_principal = running_principal - principal_paid
-        if running_principal.is_negative():
+        if running_principal.is_negative() or (
+            running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE
+        ):
             running_principal = Money.zero()
 
         for a in allocations:

--- a/tests/loan/test_subcent_balance_bug.py
+++ b/tests/loan/test_subcent_balance_bug.py
@@ -1,0 +1,146 @@
+"""Regression tests for sub-cent balance residual after full repayment.
+
+When full-precision interest differs from the schedule's 2dp interest,
+a sub-cent gap can remain on the principal.  Before the fix,
+is_fully_covered / is_fully_paid returned True while is_paid_off
+returned False — an impossible state for consumer code.
+
+See: https://github.com/.../issues/... (sub-cent balance inconsistency)
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money
+
+
+def _utc(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def single_installment_irrational_interest():
+    """Single-installment loan whose daily rate is non-terminating."""
+    principal = Money("267.65")
+    rate = InterestRate("67.458% a")
+    due = date(2025, 11, 10)
+    disbursement = datetime(2025, 10, 10, tzinfo=timezone.utc)
+    return Loan(principal, rate, [due], disbursement_date=disbursement)
+
+
+@pytest.fixture
+def two_installment_irrational_interest():
+    """Two-installment loan whose daily rate is non-terminating."""
+    principal = Money("500.00")
+    rate = InterestRate("67.458% a")
+    due_dates = [date(2025, 11, 10), date(2025, 12, 10)]
+    disbursement = datetime(2025, 10, 10, tzinfo=timezone.utc)
+    return Loan(principal, rate, due_dates, disbursement_date=disbursement)
+
+
+def test_single_installment_is_paid_off_after_exact_scheduled_payment(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+
+    assert loan.is_paid_off is True
+
+
+def test_single_installment_remaining_balance_is_zero(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    settlement = loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+
+    assert settlement.remaining_balance == Money.zero()
+
+
+def test_single_installment_allocation_is_fully_covered(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    settlement = loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+
+    assert settlement.allocations[0].is_fully_covered is True
+
+
+def test_single_installment_is_fully_paid(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+
+    assert loan.installments[0].is_fully_paid is True
+
+
+def test_single_installment_all_consistency_flags_agree(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    settlement = loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+
+    assert settlement.allocations[0].is_fully_covered is True
+    assert loan.installments[0].is_fully_paid is True
+    assert loan.is_paid_off is True
+    assert settlement.remaining_balance == Money.zero()
+    assert loan.principal_balance == Money.zero()
+
+
+def test_two_installments_is_paid_off_after_sequential_payments(
+    two_installment_irrational_interest,
+):
+    loan = two_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+
+    loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+    loan.record_payment(schedule[1].payment_amount, _utc(schedule[1].due_date))
+
+    assert loan.is_paid_off is True
+
+
+def test_two_installments_remaining_balance_is_zero_after_final_payment(
+    two_installment_irrational_interest,
+):
+    loan = two_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+
+    loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+    settlement = loan.record_payment(schedule[1].payment_amount, _utc(schedule[1].due_date))
+
+    assert settlement.remaining_balance == Money.zero()
+
+
+def test_two_installments_all_consistency_flags_agree(
+    two_installment_irrational_interest,
+):
+    loan = two_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+
+    loan.record_payment(schedule[0].payment_amount, _utc(schedule[0].due_date))
+    settlement = loan.record_payment(schedule[1].payment_amount, _utc(schedule[1].due_date))
+
+    assert all(a.is_fully_covered for a in settlement.allocations)
+    assert all(inst.is_fully_paid for inst in loan.installments)
+    assert loan.is_paid_off is True
+    assert settlement.remaining_balance == Money.zero()
+    assert loan.principal_balance == Money.zero()
+
+
+def test_partial_payment_leaves_loan_unpaid(
+    single_installment_irrational_interest,
+):
+    loan = single_installment_irrational_interest
+    schedule = loan.get_original_schedule()
+    half = Money(schedule[0].payment_amount.raw_amount / 2)
+    settlement = loan.record_payment(half, _utc(schedule[0].due_date))
+
+    assert loan.is_paid_off is False
+    assert settlement.remaining_balance.is_positive()
+    assert settlement.allocations[0].is_fully_covered is False


### PR DESCRIPTION
## Summary
- Fix inconsistency where `is_fully_covered` / `is_fully_paid` returned `True` while `is_paid_off` returned `False` due to a sub-cent principal residual (0.005–0.012)
- When full-precision interest consumed slightly more than the schedule's 2dp interest, the loan got stuck in an impossible state: all installments PAID but loan not SETTLED

## Changes
- In `compute_state` (`engines.py`), snap `running_principal` to zero when it is positive but within `_COVERAGE_TOLERANCE` (1 cent) — the same tolerance already used by `allocate_payment_per_installment` and `Installment.is_fully_paid`
- This is a 3-line change (1 deletion, 4 insertions) to the existing negative-balance guard

## Test plan
- [x] All 1669 existing tests pass (`poetry run pytest`)
- [x] 9 new regression tests covering:
  - Single-installment loan with irrational daily interest — pay exact scheduled amount, verify all flags agree
  - Two-installment loan — pay each sequentially, verify consistency after final payment
  - Partial payment guard — confirm `is_paid_off = False` and `remaining_balance > 0` still work

## Docs
- Updated `knowledge/loan.md` with a new Key Learnings entry documenting the bug, root cause, fix, and lesson