### PR TITLE
feat: handle loan overpayment gracefully

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -177,6 +177,19 @@ All derived from `_compute_state()`:
 | `mora_interest_balance` | `Money` | Mora accrued interest (days beyond due date) |
 | `fine_balance` | `Money` | Unpaid fines (total applied minus fines paid) |
 | `current_balance` | `Money` | Sum of all four components |
+| `overpaid` | `Money` | Total amount paid beyond the loan's obligations |
+
+## Overpayment
+
+When a payment exceeds the loan's total obligations (principal + interest + mora + fines), the excess is tracked as **overpaid**. This is accumulated in `LoanState.overpaid` during the forward pass: whenever `running_principal` goes negative after subtracting `principal_paid`, the absolute value of the negative amount is added to the overpaid accumulator before snapping the principal to zero.
+
+### `pay_installment` after full repayment
+
+`pay_installment` no longer raises `ValueError` when all due dates are covered. Instead it issues `warnings.warn(...)` and records the payment with `interest_date = payment_date` (no interest accrual). The payment flows through the normal engine pipeline and the excess is captured via `Loan.overpaid`.
+
+### `record_payment` overpayment
+
+`record_payment` has always accepted payments after full repayment (it just adds a CashFlowItem). The engine now correctly tracks the excess via `LoanState.overpaid`.
 
 ## Installments and Settlements
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -104,6 +104,7 @@ class LoanState:
     fines_applied: Dict[date, Money]
     fines_paid_total: Money
     last_payment_date: datetime
+    overpaid: Money
 
 
 # ------------------------------------------------------------------
@@ -398,6 +399,7 @@ def compute_state(
     last_payment_date = disbursement_date
     fines_applied: Dict[date, Money] = {}
     fines_paid_total = Money.zero()
+    overpaid = Money.zero()
     settlements: List[Settlement] = []
     allocs_by_number: Dict[int, List[Allocation]] = {}
     processed_payments: list = []
@@ -458,9 +460,10 @@ def compute_state(
 
         fines_paid_total = fines_paid_total + fine_paid
         running_principal = running_principal - principal_paid
-        if running_principal.is_negative() or (
-            running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE
-        ):
+        if running_principal.is_negative():
+            overpaid = overpaid + Money(-running_principal.raw_amount)
+            running_principal = Money.zero()
+        elif running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE:
             running_principal = Money.zero()
 
         for a in allocations:
@@ -486,6 +489,7 @@ def compute_state(
         fines_applied=fines_applied,
         fines_paid_total=fines_paid_total,
         last_payment_date=last_payment_date,
+        overpaid=overpaid,
     )
 
 

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -401,6 +401,11 @@ class Loan:
         """Whether the loan is fully paid off."""
         return self.current_balance.is_zero() or self.current_balance.is_negative()
 
+    @property
+    def overpaid(self) -> Money:
+        """Total amount paid beyond the loan's obligations (derived from CashFlow)."""
+        return self._compute_state().overpaid
+
     # ------------------------------------------------------------------
     # Fine-related properties and methods
     # ------------------------------------------------------------------

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,5 +1,6 @@
 """Loan class -- everything emerges from the CashFlow."""
 
+import warnings
 from datetime import date, datetime
 from typing import Dict, List, Optional, Type
 
@@ -225,8 +226,24 @@ class Loan:
         Interest accrual depends on timing:
         - Early/on-time: interest accrues up to the due date.
         - Late: interest accrues up to self.now().
+
+        When all installments are already paid the payment is recorded
+        as an overpayment (no interest accrual) and a warning is issued.
         """
         payment_date = self.now()
+
+        if self._covered_due_date_count() >= len(self.due_dates):
+            warnings.warn(
+                f"All installments already paid. Recording {amount} as overpayment.",
+                stacklevel=2,
+            )
+            return self.record_payment(
+                amount,
+                payment_date=payment_date,
+                interest_date=payment_date,
+                description=description or "Overpayment",
+            )
+
         next_due = self._next_unpaid_due_date()
         interest_date = max(payment_date, to_datetime(next_due))
         return self.record_payment(

--- a/tests/loan/test_overpayment.py
+++ b/tests/loan/test_overpayment.py
@@ -1,0 +1,123 @@
+"""Tests for loan overpayment handling."""
+
+import warnings
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, Settlement, Warp
+
+
+@pytest.fixture
+def fully_paid_loan():
+    """A 3-payment loan where every scheduled installment is paid exactly."""
+    principal = Money("1000.00")
+    rate = InterestRate("5% a")
+    due_dates = [
+        date(2025, 11, 1),
+        date(2025, 12, 1),
+        date(2026, 1, 1),
+    ]
+    loan = Loan(principal, rate, due_dates, disbursement_date=datetime(2025, 10, 2, tzinfo=timezone.utc))
+
+    schedule = loan.get_original_schedule()
+    for entry in schedule:
+        payment_dt = datetime(entry.due_date.year, entry.due_date.month, entry.due_date.day, tzinfo=timezone.utc)
+        loan.record_payment(entry.payment_amount, payment_dt)
+
+    return loan
+
+
+def test_overpaid_is_zero_before_any_overpayment(fully_paid_loan):
+    assert fully_paid_loan.overpaid == Money.zero()
+
+
+def test_overpaid_is_zero_on_unpaid_loan():
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("5% a"),
+        [date(2025, 11, 1)],
+        disbursement_date=datetime(2025, 10, 2, tzinfo=timezone.utc),
+    )
+    assert loan.overpaid == Money.zero()
+
+
+def test_pay_installment_after_full_repayment_warns(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warped.pay_installment(Money("200.00"))
+
+        assert len(caught) == 1
+        assert "overpayment" in str(caught[0].message).lower()
+
+
+def test_pay_installment_after_full_repayment_returns_settlement(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = warped.pay_installment(Money("200.00"))
+
+        assert isinstance(result, Settlement)
+        assert result.payment_amount == Money("200.00")
+
+
+def test_overpaid_tracks_single_overpayment(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            warped.pay_installment(Money("200.00"))
+
+        assert warped.overpaid == Money("200.00")
+
+
+def test_overpaid_accumulates_multiple_overpayments(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            warped.pay_installment(Money("200.00"))
+            warped.pay_installment(Money("150.00"))
+
+        assert warped.overpaid == Money("350.00")
+
+
+def test_overpaid_via_record_payment(fully_paid_loan):
+    fully_paid_loan.record_payment(
+        Money("300.00"),
+        payment_date=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert fully_paid_loan.overpaid == Money("300.00")
+
+
+def test_is_paid_off_remains_true_after_overpayment(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            warped.pay_installment(Money("100.00"))
+
+        assert warped.is_paid_off is True
+
+
+def test_principal_balance_stays_zero_after_overpayment(fully_paid_loan):
+    with Warp(fully_paid_loan, datetime(2026, 1, 15, tzinfo=timezone.utc)) as warped:
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            warped.pay_installment(Money("500.00"))
+
+        assert warped.principal_balance == Money.zero()
+
+
+@pytest.mark.parametrize(
+    "overpayment_amount",
+    [
+        Money("0.01"),
+        Money("100.00"),
+        Money("9999.99"),
+    ],
+)
+def test_overpaid_exact_amounts(fully_paid_loan, overpayment_amount):
+    fully_paid_loan.record_payment(
+        overpayment_amount,
+        payment_date=datetime(2026, 1, 15, tzinfo=timezone.utc),
+    )
+    assert fully_paid_loan.overpaid == overpayment_amount


### PR DESCRIPTION
## Summary
- `pay_installment` no longer raises `ValueError` when all installments are paid -- it warns and records the payment as an overpayment
- New `Loan.overpaid` property exposes the total excess amount (derived from CashFlow, like all other state)
- Overpayment is tracked in the `compute_state` forward pass by accumulating the amount snapped to zero when `running_principal` goes negative

## Changes
- `engines.py`: Added `overpaid: Money` field to `LoanState`, accumulated in `compute_state` when principal goes negative
- `loan.py`: `pay_installment` catches the all-paid case (warn + record with no interest accrual), new `Loan.overpaid` property
- `test_overpayment.py`: 12 tests covering warning, settlement return, exact amounts, accumulation, and balance invariants
- `knowledge/loan.md`: Documented overpayment behavior and added `overpaid` to the balance properties table

## Test plan
- [x] All existing tests pass (`poetry run pytest` -- 1681 passed)
- [x] `pay_installment` after full repayment warns instead of raising
- [x] `loan.overpaid` returns zero when no overpayment
- [x] `loan.overpaid` returns exact excess after single and multiple overpayments
- [x] `is_paid_off` and `principal_balance` invariants hold after overpayment

## Docs
- Updated `knowledge/loan.md` with Overpayment section and balance property table entry
- `docs/modules.md` auto-generates from docstrings, no manual change needed