### PR TITLE
Fix settlement spill invariant and refactor allocation engine

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -11,7 +11,8 @@ The Loan delegates computation to two focused components in `engines.py`:
   - `compute_state(...)` — the forward pass that produces a `LoanState` (settlements, principal balance, fines applied, fines paid total, last payment date).
   - `build_installments(...)` — builds `Installment` objects from settlements + schedule.
   - `compute_fines_at(...)` — determines which due dates should have fines applied.
-  - `allocate_payment_per_installment(...)` — runs the per-installment allocation algorithm.
+  - `allocate_payment_into_installments(...)` — orchestrates per-installment allocation.
+  - `allocate_payment_into_installment(...)` — allocates payment to a single installment (fine -> mora -> interest -> principal).
   - `covered_due_date_count(...)` — how many due dates are covered given a remaining balance.
   - `is_payment_late(...)` — grace-period-aware lateness check.
 - **TVM functions** (`tvm.py`) — standalone `loan_present_value`, `loan_irr`, `loan_calculate_anticipation`.
@@ -110,17 +111,17 @@ The central algorithm in `engines.compute_state`. It processes a merged timeline
    a. Compute interest (regular + mora) since last payment.
    b. Build installment snapshot reflecting all prior allocations.
    c. Add skipped contractual interest for periods beyond the current due-date boundary.
-   d. Run per-installment allocation (`allocate_payment_per_installment`).
+   d. Run per-installment allocation (`allocate_payment_into_installments`).
    e. Update running principal, fines paid total, and allocation history.
    f. Create a `Settlement` object.
 3. Return `LoanState` with all settlements and running state.
 
 ### `is_fully_covered` Post-Payment Fixup
 
-The `allocate_payment_per_installment` function determines `is_fully_covered` per allocation in two stages:
+The `allocate_payment_into_installments` function determines `is_fully_covered` per allocation in two stages:
 
-1. **During the loop:** `Installment.allocate_from_payment` computes `is_covered` by comparing the total allocated against the installment's remaining balance. This can be `False` when interest caps prevent full interest allocation (e.g., paying all installments at once on the first due date).
-2. **After the loop:** If the post-payment balance (`ending_balance - principal_total`) is within tolerance of zero, the function does a second pass. Any allocation whose principal is fully covered gets `is_fully_covered` overridden to `True`. This handles the case where the loan is paid off but interest caps prevented exact coverage of each installment's interest obligation.
+1. **During the loop:** `allocate_payment_into_installment` computes `is_covered` by comparing the total allocated against the installment's remaining balance. This can be `False` when interest caps prevent full interest allocation (e.g., paying all installments at once on the first due date).
+2. **After the loop:** `_fixup_coverage_flags` checks if the post-payment balance is within tolerance of zero. If so, any allocation whose principal was fully covered gets `is_fully_covered` overridden to `True`. This handles the case where the loan is paid off but interest caps prevented exact coverage of each installment's interest obligation.
 
 ## Dynamic Amortization Schedule
 
@@ -205,7 +206,8 @@ Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_pr
 
 - `balance` — amount still owed to fully settle this installment.
 - `is_fully_paid` — `True` when `balance` is within tolerance of zero.
-- `allocate_from_payment(remaining, fine_remaining, mora_remaining, interest_remaining)` — allocates in priority order (fine -> mora -> interest -> principal), each capped by both the installment's remaining obligation and running caps.
+
+Per-installment allocation logic lives in `engines.allocate_payment_into_installment` (not on the Installment class).
 
 ### Settlement (`loan.settlements`)
 
@@ -268,13 +270,13 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 
 ### Payment allocation order was loan-level, not per-installment (fixed 2026-03-20)
 
-**Fix:** Rewrote allocation to be strictly per-installment sequential. `allocate_payment_per_installment` walks installments in order. Within each, `Installment.allocate_from_payment` applies fine -> mora -> interest -> principal.
+**Fix:** Rewrote allocation to be strictly per-installment sequential. `allocate_payment_into_installments` walks installments in order. Within each, `allocate_payment_into_installment` applies fine -> mora -> interest -> principal.
 
 **Lesson:** The per-installment interpretation is correct for Brazilian lending: installment 1's mora interest is more urgent than installment 2's fine.
 
 ### Sub-cent precision loss in allocation loop (fixed 2026-03-20)
 
-**Fix:** Use `raw_amount` comparisons in the allocation loop instead of `Money`'s 2dp-rounded methods. Sub-cent allocations are included in component totals but excluded from the `allocations` list.
+**Fix:** Use `raw_amount` comparisons in the allocation loop instead of `Money`'s 2dp-rounded methods. Sub-cent allocations are included in component totals; the `_reconcile_allocations` sweep adjusts the last allocation to match.
 
 **Lesson:** `Money`'s `real_amount`-based comparisons are correct for business display but dangerous in accounting loops where sub-cent values compound.
 
@@ -286,7 +288,7 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 
 **Symptom:** When a single payment fully paid off the loan, some allocations had `is_fully_covered = False` even though the loan's remaining balance was zero. This happened because the interest cap prevented full interest allocation to later installments (their interest hadn't accrued yet), and the coverage check failed since `total_allocated < installment.balance`.
 
-**Root cause:** `allocate_payment_per_installment` checked `ending_balance <= tolerance` at the **start** of the function (line 183), using the pre-payment principal. For a payment that fully pays off the loan, the pre-payment balance is the full remaining principal, so this check was always `False`. The override that corrects `is_fully_covered` when principal is fully covered never activated.
+**Root cause:** The allocation function checked `ending_balance <= tolerance` at the **start**, using the pre-payment principal. For a payment that fully pays off the loan, the pre-payment balance is the full remaining principal, so this check was always `False`. The override that corrects `is_fully_covered` when principal is fully covered never activated.
 
 **Fix:** Moved the override to a post-loop fixup. After the allocation loop and spillover handling, compute `post_balance = ending_balance - principal_total`. If `post_balance <= tolerance`, iterate through allocations and fix `is_fully_covered` for any installment whose principal was fully allocated (within tolerance).
 
@@ -296,8 +298,21 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 
 **Symptom:** After paying the exact scheduled amount, `is_fully_covered` and `is_fully_paid` returned `True` but `is_paid_off` returned `False` and `remaining_balance` showed a sub-cent residual (0.005--0.012). Consumer code marked all installments as PAID but never marked the loan as SETTLED.
 
-**Root cause:** Full-precision interest accrual consumed slightly more than the schedule's 2dp interest, leaving a sub-cent gap on the principal. `allocate_payment_per_installment` and `Installment.is_fully_paid` used `_COVERAGE_TOLERANCE` (1 cent) for their checks, but `compute_state` only snapped `running_principal` to zero when negative — not when it was a sub-cent positive residual. `Loan.is_paid_off` checked `current_balance.is_zero()` (exact zero), which failed for the residual.
+**Root cause:** Full-precision interest accrual consumed slightly more than the schedule's 2dp interest, leaving a sub-cent gap on the principal. `allocate_payment_into_installments` and `Installment.is_fully_paid` used `_COVERAGE_TOLERANCE` (1 cent) for their checks, but `compute_state` only snapped `running_principal` to zero when negative — not when it was a sub-cent positive residual. `Loan.is_paid_off` checked `current_balance.is_zero()` (exact zero), which failed for the residual.
 
 **Fix:** In `compute_state`, after subtracting `principal_paid` from `running_principal`, also snap to zero when the balance is positive but within `_COVERAGE_TOLERANCE`. This aligns the principal balance with the same tolerance used by the allocation and installment layers.
 
 **Lesson:** All consistency checks across a system must use the same tolerance. When tolerance-based flags (`is_fully_covered`, `is_fully_paid`) coexist with exact checks (`is_paid_off` via `is_zero()`), the exact check must be relaxed to match, or the underlying data must be snapped so the exact check naturally passes.
+
+### Settlement spill invariant (fixed 2026-03-23)
+
+**Symptom:** `settlement.X_paid != sum(a.X_allocated for a in settlement.allocations)` for interest and principal. The totals included amounts not reflected in any `Allocation` object.
+
+**Root cause:** Two sources of discrepancy: (1) the "reserved" hold-back for future mora/interest prevented some principal from being allocated to an installment, leaving a remainder ("spill") that was added to totals but not to any allocation; (2) sub-cent allocations (positive at `raw_amount` but zero at `real_amount`) were counted in totals but dropped from the allocations list.
+
+**Fix:** Three changes:
+1. `_compute_spill` distributes leftover payment into mora, interest, and principal totals (pure function, no allocation mutation).
+2. `_reconcile_allocations` does a single sweep after all allocation is done, adjusting the last allocation's amounts so that `sum(allocations.X) == X_total` for all four components. If no allocations exist, it creates one for the last installment.
+3. Per-installment owed amounts are clamped to non-negative (`max(owed, 0)`) to prevent negative allocations when a previous payment's spill over-credited an installment.
+
+**Lesson:** Instead of trying to patch up discrepancies as they arise (merging sub-cent into last, merging spill into last), a single reconciliation sweep at the end is both simpler and more robust. It handles all sources of drift in one place.

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -330,8 +330,34 @@ def allocate_payment_per_installment(
         remaining = remaining - interest_spill
         interest_total = interest_total + interest_spill
 
+        principal_spill = Money.zero()
         if remaining.raw_amount > 0:
+            principal_spill = remaining
             principal_total = principal_total + remaining
+
+        has_spill = mora_spill.raw_amount or interest_spill.raw_amount or principal_spill.raw_amount
+        if has_spill:
+            if allocations:
+                last = allocations[-1]
+                allocations[-1] = Allocation(
+                    installment_number=last.installment_number,
+                    principal_allocated=last.principal_allocated + principal_spill,
+                    interest_allocated=last.interest_allocated + interest_spill,
+                    mora_allocated=last.mora_allocated + mora_spill,
+                    fine_allocated=last.fine_allocated,
+                    is_fully_covered=last.is_fully_covered,
+                )
+            elif installments:
+                allocations.append(
+                    Allocation(
+                        installment_number=installments[-1].number,
+                        principal_allocated=principal_spill,
+                        interest_allocated=interest_spill,
+                        mora_allocated=mora_spill,
+                        fine_allocated=Money.zero(),
+                        is_fully_covered=False,
+                    )
+                )
 
     allocations = _fixup_coverage_flags(allocations, installments, ending_balance, principal_total)
     return fine_total, mora_total, interest_total, principal_total, allocations

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -317,9 +317,18 @@ def allocate_payment_per_installment(
         interest_total = interest_total + allocation.interest_allocated
         principal_total = principal_total + allocation.principal_allocated
 
-        if not allocation.total_allocated.is_positive():
-            continue
-        allocations.append(allocation)
+        if allocation.total_allocated.is_positive():
+            allocations.append(allocation)
+        elif allocations:
+            last = allocations[-1]
+            allocations[-1] = Allocation(
+                installment_number=last.installment_number,
+                principal_allocated=last.principal_allocated + allocation.principal_allocated,
+                interest_allocated=last.interest_allocated + allocation.interest_allocated,
+                mora_allocated=last.mora_allocated + allocation.mora_allocated,
+                fine_allocated=last.fine_allocated + allocation.fine_allocated,
+                is_fully_covered=last.is_fully_covered,
+            )
 
     if remaining.raw_amount > 0:
         mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -258,24 +258,24 @@ def allocate_payment_into_installment(
         (allocation, remaining, fine_remaining, mora_remaining, interest_remaining)
     """
     fine_owed = inst.expected_fine - inst.fine_paid
-    fine_alloc = Money(min(fine_owed.raw_amount, remaining.raw_amount, fine_remaining.raw_amount))
+    fine_alloc = Money(min(max(fine_owed.raw_amount, 0), remaining.raw_amount, fine_remaining.raw_amount))
     remaining = remaining - fine_alloc
     fine_remaining = fine_remaining - fine_alloc
 
     mora_owed = inst.expected_mora - inst.mora_paid
-    mora_alloc = Money(min(mora_owed.raw_amount, remaining.raw_amount, mora_remaining.raw_amount))
+    mora_alloc = Money(min(max(mora_owed.raw_amount, 0), remaining.raw_amount, mora_remaining.raw_amount))
     remaining = remaining - mora_alloc
     mora_remaining = mora_remaining - mora_alloc
 
     interest_owed = inst.expected_interest - inst.interest_paid
-    interest_alloc = Money(min(interest_owed.raw_amount, remaining.raw_amount, interest_remaining.raw_amount))
+    interest_alloc = Money(min(max(interest_owed.raw_amount, 0), remaining.raw_amount, interest_remaining.raw_amount))
     remaining = remaining - interest_alloc
     interest_remaining = interest_remaining - interest_alloc
 
     principal_owed = inst.expected_principal - inst.principal_paid
     reserved = interest_remaining + mora_remaining
     available_for_principal = remaining - reserved if remaining.raw_amount > reserved.raw_amount else Money.zero()
-    principal_alloc = Money(min(principal_owed.raw_amount, available_for_principal.raw_amount))
+    principal_alloc = Money(min(max(principal_owed.raw_amount, 0), available_for_principal.raw_amount))
     remaining = remaining - principal_alloc
 
     total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
@@ -290,19 +290,6 @@ def allocate_payment_into_installment(
         is_fully_covered=is_covered,
     )
     return allocation, remaining, fine_remaining, mora_remaining, interest_remaining
-
-
-def _merge_into_last(allocations: List[Allocation], extra: Allocation) -> None:
-    """Merge *extra*'s amounts into the last entry of *allocations* in-place."""
-    last = allocations[-1]
-    allocations[-1] = Allocation(
-        installment_number=last.installment_number,
-        principal_allocated=last.principal_allocated + extra.principal_allocated,
-        interest_allocated=last.interest_allocated + extra.interest_allocated,
-        mora_allocated=last.mora_allocated + extra.mora_allocated,
-        fine_allocated=last.fine_allocated + extra.fine_allocated,
-        is_fully_covered=last.is_fully_covered,
-    )
 
 
 def _fixup_coverage_flags(
@@ -341,21 +328,12 @@ def _fixup_coverage_flags(
     return fixed
 
 
-def _attribute_spill(
+def _compute_spill(
     remaining: Money,
     mora_remaining: Money,
     interest_remaining: Money,
-    allocations: List[Allocation],
-    installments: List[Installment],
 ) -> Tuple[Money, Money, Money]:
-    """Attribute leftover payment to mora, interest, and principal.
-
-    After all installments have been processed, any remaining money
-    is distributed as mora spill, interest spill, then principal spill
-    (in that order, each capped by the corresponding remaining cap).
-
-    The spill is merged into the last allocation so that settlement
-    totals always equal the sum of their per-allocation counterparts.
+    """Distribute leftover payment into mora, interest, and principal.
 
     Returns:
         (mora_spill, interest_spill, principal_spill)
@@ -367,23 +345,58 @@ def _attribute_spill(
     remaining = remaining - interest_spill
 
     principal_spill = remaining if remaining.raw_amount > 0 else Money.zero()
-
-    has_spill = mora_spill.raw_amount or interest_spill.raw_amount or principal_spill.raw_amount
-    if has_spill:
-        spill_alloc = Allocation(
-            installment_number=allocations[-1].installment_number if allocations else installments[-1].number,
-            principal_allocated=principal_spill,
-            interest_allocated=interest_spill,
-            mora_allocated=mora_spill,
-            fine_allocated=Money.zero(),
-            is_fully_covered=False,
-        )
-        if allocations:
-            _merge_into_last(allocations, spill_alloc)
-        elif installments:
-            allocations.append(spill_alloc)
-
     return mora_spill, interest_spill, principal_spill
+
+
+def _reconcile_allocations(
+    allocations: List[Allocation],
+    installments: List[Installment],
+    fine_total: Money,
+    mora_total: Money,
+    interest_total: Money,
+    principal_total: Money,
+) -> None:
+    """Adjust allocations so their sums exactly match the totals.
+
+    Sub-cent allocations and spill can cause the totals to diverge
+    from ``sum(allocations)``.  This single sweep fixes the gap by
+    adjusting the last allocation.  If no allocations exist yet,
+    a new one is created for the last installment.
+    """
+    sum_f = sum((a.fine_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
+    sum_m = sum((a.mora_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
+    sum_i = sum((a.interest_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
+    sum_p = sum((a.principal_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
+
+    f_diff = fine_total.raw_amount - sum_f
+    m_diff = mora_total.raw_amount - sum_m
+    i_diff = interest_total.raw_amount - sum_i
+    p_diff = principal_total.raw_amount - sum_p
+
+    if not (f_diff or m_diff or i_diff or p_diff):
+        return
+
+    if allocations:
+        last = allocations[-1]
+        allocations[-1] = Allocation(
+            installment_number=last.installment_number,
+            principal_allocated=Money(last.principal_allocated.raw_amount + p_diff),
+            interest_allocated=Money(last.interest_allocated.raw_amount + i_diff),
+            mora_allocated=Money(last.mora_allocated.raw_amount + m_diff),
+            fine_allocated=Money(last.fine_allocated.raw_amount + f_diff),
+            is_fully_covered=last.is_fully_covered,
+        )
+    elif installments:
+        allocations.append(
+            Allocation(
+                installment_number=installments[-1].number,
+                principal_allocated=Money(p_diff),
+                interest_allocated=Money(i_diff),
+                mora_allocated=Money(m_diff),
+                fine_allocated=Money(f_diff),
+                is_fully_covered=False,
+            )
+        )
 
 
 def allocate_payment_into_installments(
@@ -402,8 +415,9 @@ def allocate_payment_into_installments(
     anything.
 
     After the per-installment loop, any leftover money (spill) is
-    attributed to the last allocation so that the returned totals
-    always equal the sum of their per-allocation counterparts.
+    distributed into mora, interest, and principal totals.  A final
+    reconciliation sweep adjusts the last allocation so that the
+    totals always equal the sum of their per-allocation counterparts.
 
     Returns:
         (fine_total, mora_total, interest_total, principal_total, allocations)
@@ -436,17 +450,16 @@ def allocate_payment_into_installments(
 
         if allocation.total_allocated.is_positive():
             allocations.append(allocation)
-        elif allocations:
-            _merge_into_last(allocations, allocation)
 
     if remaining.raw_amount > 0:
-        mora_spill, interest_spill, principal_spill = _attribute_spill(
-            remaining, mora_remaining, interest_remaining, allocations, installments,
+        mora_spill, interest_spill, principal_spill = _compute_spill(
+            remaining, mora_remaining, interest_remaining,
         )
         mora_total = mora_total + mora_spill
         interest_total = interest_total + interest_spill
         principal_total = principal_total + principal_spill
 
+    _reconcile_allocations(allocations, installments, fine_total, mora_total, interest_total, principal_total)
     allocations = _fixup_coverage_flags(allocations, installments, ending_balance, principal_total)
     return fine_total, mora_total, interest_total, principal_total, allocations
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -234,6 +234,77 @@ def _skipped_contractual_interest(
 # ------------------------------------------------------------------
 
 
+def allocate_payment_into_installment(
+    inst: Installment,
+    remaining: Money,
+    fine_remaining: Money,
+    mora_remaining: Money,
+    interest_remaining: Money,
+) -> Tuple[Allocation, Money, Money, Money, Money]:
+    """Allocate payment money to a single installment.
+
+    Processes fine -> mora -> interest -> principal sequentially,
+    each capped by both the installment's remaining obligation and
+    the corresponding running cap.
+
+    The running caps prevent over-allocation: they track the
+    loan-level accrual computed during the forward pass.
+
+    Principal allocation reserves ``interest_remaining + mora_remaining``
+    so that later installments can still absorb their share of
+    interest and mora.
+
+    Returns:
+        (allocation, remaining, fine_remaining, mora_remaining, interest_remaining)
+    """
+    fine_owed = inst.expected_fine - inst.fine_paid
+    fine_alloc = Money(min(fine_owed.raw_amount, remaining.raw_amount, fine_remaining.raw_amount))
+    remaining = remaining - fine_alloc
+    fine_remaining = fine_remaining - fine_alloc
+
+    mora_owed = inst.expected_mora - inst.mora_paid
+    mora_alloc = Money(min(mora_owed.raw_amount, remaining.raw_amount, mora_remaining.raw_amount))
+    remaining = remaining - mora_alloc
+    mora_remaining = mora_remaining - mora_alloc
+
+    interest_owed = inst.expected_interest - inst.interest_paid
+    interest_alloc = Money(min(interest_owed.raw_amount, remaining.raw_amount, interest_remaining.raw_amount))
+    remaining = remaining - interest_alloc
+    interest_remaining = interest_remaining - interest_alloc
+
+    principal_owed = inst.expected_principal - inst.principal_paid
+    reserved = interest_remaining + mora_remaining
+    available_for_principal = remaining - reserved if remaining.raw_amount > reserved.raw_amount else Money.zero()
+    principal_alloc = Money(min(principal_owed.raw_amount, available_for_principal.raw_amount))
+    remaining = remaining - principal_alloc
+
+    total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
+    is_covered = total >= (inst.balance - _COVERAGE_TOLERANCE)
+
+    allocation = Allocation(
+        installment_number=inst.number,
+        principal_allocated=principal_alloc,
+        interest_allocated=interest_alloc,
+        mora_allocated=mora_alloc,
+        fine_allocated=fine_alloc,
+        is_fully_covered=is_covered,
+    )
+    return allocation, remaining, fine_remaining, mora_remaining, interest_remaining
+
+
+def _merge_into_last(allocations: List[Allocation], extra: Allocation) -> None:
+    """Merge *extra*'s amounts into the last entry of *allocations* in-place."""
+    last = allocations[-1]
+    allocations[-1] = Allocation(
+        installment_number=last.installment_number,
+        principal_allocated=last.principal_allocated + extra.principal_allocated,
+        interest_allocated=last.interest_allocated + extra.interest_allocated,
+        mora_allocated=last.mora_allocated + extra.mora_allocated,
+        fine_allocated=last.fine_allocated + extra.fine_allocated,
+        is_fully_covered=last.is_fully_covered,
+    )
+
+
 def _fixup_coverage_flags(
     allocations: List[Allocation],
     installments: List[Installment],
@@ -270,7 +341,52 @@ def _fixup_coverage_flags(
     return fixed
 
 
-def allocate_payment_per_installment(
+def _attribute_spill(
+    remaining: Money,
+    mora_remaining: Money,
+    interest_remaining: Money,
+    allocations: List[Allocation],
+    installments: List[Installment],
+) -> Tuple[Money, Money, Money]:
+    """Attribute leftover payment to mora, interest, and principal.
+
+    After all installments have been processed, any remaining money
+    is distributed as mora spill, interest spill, then principal spill
+    (in that order, each capped by the corresponding remaining cap).
+
+    The spill is merged into the last allocation so that settlement
+    totals always equal the sum of their per-allocation counterparts.
+
+    Returns:
+        (mora_spill, interest_spill, principal_spill)
+    """
+    mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
+    remaining = remaining - mora_spill
+
+    interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
+    remaining = remaining - interest_spill
+
+    principal_spill = remaining if remaining.raw_amount > 0 else Money.zero()
+
+    has_spill = mora_spill.raw_amount or interest_spill.raw_amount or principal_spill.raw_amount
+    if has_spill:
+        spill_alloc = Allocation(
+            installment_number=allocations[-1].installment_number if allocations else installments[-1].number,
+            principal_allocated=principal_spill,
+            interest_allocated=interest_spill,
+            mora_allocated=mora_spill,
+            fine_allocated=Money.zero(),
+            is_fully_covered=False,
+        )
+        if allocations:
+            _merge_into_last(allocations, spill_alloc)
+        elif installments:
+            allocations.append(spill_alloc)
+
+    return mora_spill, interest_spill, principal_spill
+
+
+def allocate_payment_into_installments(
     amount: Money,
     installments: List[Installment],
     ending_balance: Money,
@@ -280,10 +396,14 @@ def allocate_payment_per_installment(
 ) -> Tuple[Money, Money, Money, Money, List[Allocation]]:
     """Allocate a payment across installments in priority order.
 
-    Each installment is processed sequentially. Within each
-    installment the priority is fine -> mora -> interest -> principal.
-    Installment 1's obligations are fully addressed before
-    installment 2 receives anything.
+    Each installment is processed sequentially via
+    :func:`allocate_payment_into_installment`.  Installment 1's
+    obligations are fully addressed before installment 2 receives
+    anything.
+
+    After the per-installment loop, any leftover money (spill) is
+    attributed to the last allocation so that the returned totals
+    always equal the sum of their per-allocation counterparts.
 
     Returns:
         (fine_total, mora_total, interest_total, principal_total, allocations)
@@ -302,11 +422,8 @@ def allocate_payment_per_installment(
         if not remaining.raw_amount:
             break
 
-        allocation, remaining, fine_remaining, mora_remaining, interest_remaining = inst.allocate_from_payment(
-            remaining,
-            fine_remaining,
-            mora_remaining,
-            interest_remaining,
+        allocation, remaining, fine_remaining, mora_remaining, interest_remaining = (
+            allocate_payment_into_installment(inst, remaining, fine_remaining, mora_remaining, interest_remaining)
         )
 
         if allocation.total_allocated.raw_amount <= 0:
@@ -320,53 +437,15 @@ def allocate_payment_per_installment(
         if allocation.total_allocated.is_positive():
             allocations.append(allocation)
         elif allocations:
-            last = allocations[-1]
-            allocations[-1] = Allocation(
-                installment_number=last.installment_number,
-                principal_allocated=last.principal_allocated + allocation.principal_allocated,
-                interest_allocated=last.interest_allocated + allocation.interest_allocated,
-                mora_allocated=last.mora_allocated + allocation.mora_allocated,
-                fine_allocated=last.fine_allocated + allocation.fine_allocated,
-                is_fully_covered=last.is_fully_covered,
-            )
+            _merge_into_last(allocations, allocation)
 
     if remaining.raw_amount > 0:
-        mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
-        remaining = remaining - mora_spill
+        mora_spill, interest_spill, principal_spill = _attribute_spill(
+            remaining, mora_remaining, interest_remaining, allocations, installments,
+        )
         mora_total = mora_total + mora_spill
-
-        interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
-        remaining = remaining - interest_spill
         interest_total = interest_total + interest_spill
-
-        principal_spill = Money.zero()
-        if remaining.raw_amount > 0:
-            principal_spill = remaining
-            principal_total = principal_total + remaining
-
-        has_spill = mora_spill.raw_amount or interest_spill.raw_amount or principal_spill.raw_amount
-        if has_spill:
-            if allocations:
-                last = allocations[-1]
-                allocations[-1] = Allocation(
-                    installment_number=last.installment_number,
-                    principal_allocated=last.principal_allocated + principal_spill,
-                    interest_allocated=last.interest_allocated + interest_spill,
-                    mora_allocated=last.mora_allocated + mora_spill,
-                    fine_allocated=last.fine_allocated,
-                    is_fully_covered=last.is_fully_covered,
-                )
-            elif installments:
-                allocations.append(
-                    Allocation(
-                        installment_number=installments[-1].number,
-                        principal_allocated=principal_spill,
-                        interest_allocated=interest_spill,
-                        mora_allocated=mora_spill,
-                        fine_allocated=Money.zero(),
-                        is_fully_covered=False,
-                    )
-                )
+        principal_total = principal_total + principal_spill
 
     allocations = _fixup_coverage_flags(allocations, installments, ending_balance, principal_total)
     return fine_total, mora_total, interest_total, principal_total, allocations
@@ -533,7 +612,7 @@ def compute_state(
         if fine_balance.is_negative():
             fine_balance = Money.zero()
 
-        fine_paid, mora_paid, interest_paid, principal_paid, allocations = allocate_payment_per_installment(
+        fine_paid, mora_paid, interest_paid, principal_paid, allocations = allocate_payment_into_installments(
             payment.amount,
             installments,
             running_principal,

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import date
-from typing import List, Tuple
+from typing import List
 
 from ..money import Money
 from ..scheduler import PaymentScheduleEntry
@@ -48,56 +48,6 @@ class Installment:
     def is_fully_paid(self) -> bool:
         """Whether this installment has been fully settled (within rounding tolerance)."""
         return self.balance <= _COVERAGE_TOLERANCE
-
-    def allocate_from_payment(
-        self,
-        remaining: Money,
-        fine_remaining: Money,
-        mora_remaining: Money,
-        interest_remaining: Money,
-    ) -> Tuple[Allocation, Money, Money, Money, Money]:
-        """Allocate from a single payment amount in priority order.
-
-        Processes fine -> mora -> interest -> principal sequentially,
-        each capped by both the installment's remaining obligation and
-        the corresponding running cap.
-
-        The running caps prevent over-allocation: they match the
-        loan-level accrual computed during the forward pass.
-        """
-        fine_owed = self.expected_fine - self.fine_paid
-        fine_alloc = Money(min(fine_owed.raw_amount, remaining.raw_amount, fine_remaining.raw_amount))
-        remaining = remaining - fine_alloc
-        fine_remaining = fine_remaining - fine_alloc
-
-        mora_owed = self.expected_mora - self.mora_paid
-        mora_alloc = Money(min(mora_owed.raw_amount, remaining.raw_amount, mora_remaining.raw_amount))
-        remaining = remaining - mora_alloc
-        mora_remaining = mora_remaining - mora_alloc
-
-        interest_owed = self.expected_interest - self.interest_paid
-        interest_alloc = Money(min(interest_owed.raw_amount, remaining.raw_amount, interest_remaining.raw_amount))
-        remaining = remaining - interest_alloc
-        interest_remaining = interest_remaining - interest_alloc
-
-        principal_owed = self.expected_principal - self.principal_paid
-        reserved = interest_remaining + mora_remaining
-        available_for_principal = remaining - reserved if remaining.raw_amount > reserved.raw_amount else Money.zero()
-        principal_alloc = Money(min(principal_owed.raw_amount, available_for_principal.raw_amount))
-        remaining = remaining - principal_alloc
-
-        total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
-        is_covered = total >= (self.balance - _COVERAGE_TOLERANCE)
-
-        allocation = Allocation(
-            installment_number=self.number,
-            principal_allocated=principal_alloc,
-            interest_allocated=interest_alloc,
-            mora_allocated=mora_alloc,
-            fine_allocated=fine_alloc,
-            is_fully_covered=is_covered,
-        )
-        return allocation, remaining, fine_remaining, mora_remaining, interest_remaining
 
     @classmethod
     def from_schedule_entry(

--- a/tests/loan/settlements/late_payments/test_cross_installment_late_payment.py
+++ b/tests/loan/settlements/late_payments/test_cross_installment_late_payment.py
@@ -100,11 +100,11 @@ def test_p2_second_installment(late_cross_settlements):
 
 
 def test_p2_third_installment(late_cross_settlements):
-    """Inst 3 gets its fine and full principal — covered (loan fully paid)."""
+    """Inst 3 gets its fine, full principal, and spill — covered (loan fully paid)."""
     _, settlements = late_cross_settlements
     a = settlements[1].allocations[1]
     assert a.installment_number == 3
-    assert a.principal_allocated == Money("300.05")
+    assert a.principal_allocated == Money("362.96")
     assert a.interest_allocated == Money("0.00")
     assert a.fine_allocated == Money("6.07")
     assert a.mora_allocated == Money("0.00")

--- a/tests/loan/settlements/up_to_date_payments/test_partial_payments.py
+++ b/tests/loan/settlements/up_to_date_payments/test_partial_payments.py
@@ -154,12 +154,12 @@ def test_p5_completes_installment_two(six_partial_settlements):
 
 
 def test_p6_third_installment_not_covered(six_partial_settlements):
-    """Inst 3 gets all of P6 but is NOT fully covered (total < owed)."""
+    """Inst 3 gets all of P6 plus interest spill — still NOT fully covered."""
     _, settlements = six_partial_settlements
     a = settlements[5].allocations[0]
     assert a.installment_number == 3
     assert a.principal_allocated == Money("197.59")
-    assert a.interest_allocated == Money("0.00")
+    assert a.interest_allocated == Money("2.41")
     assert a.is_fully_covered is False
 
 
@@ -182,4 +182,4 @@ def test_final_installment_three_not_paid(six_partial_settlements):
     """Installment 3 still has a remaining balance (R$910 < total owed)."""
     loan, _ = six_partial_settlements
     assert loan.installments[2].is_fully_paid is False
-    assert loan.installments[2].balance == Money("4.50")
+    assert loan.installments[2].balance == Money("0.87")

--- a/tests/loan/test_settlement_spill.py
+++ b/tests/loan/test_settlement_spill.py
@@ -1,0 +1,217 @@
+"""Regression tests for the settlement spill invariant.
+
+Settlement totals must equal the sum of their per-allocation counterparts:
+
+    settlement.X_paid == sum(a.X_allocated for a in settlement.allocations)
+
+for X in {principal, interest, mora, fine}. Before the fix, spill amounts
+and sub-cent allocations were counted in the totals but absent from the
+allocations list.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, Warp
+from money_warp.scheduler import PriceScheduler
+
+
+def _utc(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+def _assert_allocation_invariant(settlement):
+    """Assert that settlement totals equal the sum of allocations."""
+    sum_principal = sum(a.principal_allocated.raw_amount for a in settlement.allocations)
+    sum_interest = sum(a.interest_allocated.raw_amount for a in settlement.allocations)
+    sum_mora = sum(a.mora_allocated.raw_amount for a in settlement.allocations)
+    sum_fine = sum(a.fine_allocated.raw_amount for a in settlement.allocations)
+
+    assert settlement.principal_paid.raw_amount == sum_principal
+    assert settlement.interest_paid.raw_amount == sum_interest
+    assert settlement.mora_paid.raw_amount == sum_mora
+    assert settlement.fine_paid.raw_amount == sum_fine
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def catchup_loan():
+    """5-installment loan: first paid early, then 3 months skipped."""
+    loan = Loan(
+        principal=Money(5000),
+        interest_rate=InterestRate("2.5% a.m."),
+        due_dates=[
+            date(2026, 2, 10),
+            date(2026, 3, 10),
+            date(2026, 4, 10),
+            date(2026, 5, 10),
+            date(2026, 6, 10),
+        ],
+        disbursement_date=datetime(2026, 1, 5, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("1% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+    )
+    with Warp(loan, datetime(2026, 1, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(loan.installments[0].expected_payment)
+    return w
+
+
+@pytest.fixture
+def late_two_installment_loan():
+    """2-installment loan paid late in a single catch-up."""
+    return Loan(
+        principal=Money(2000),
+        interest_rate=InterestRate("3% a.m."),
+        due_dates=[date(2026, 2, 10), date(2026, 3, 10)],
+        disbursement_date=datetime(2026, 1, 10, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("1% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+    )
+
+
+@pytest.fixture
+def on_time_loan():
+    """3-installment loan paid exactly on schedule."""
+    return Loan(
+        principal=Money(10000),
+        interest_rate=InterestRate("6% a"),
+        due_dates=[date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# -- Bug-report reproduction (catch-up payment, large spill) --
+
+
+def test_catchup_settlement_invariant(catchup_loan):
+    with Warp(catchup_loan, datetime(2026, 5, 25, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(5000))
+
+    _assert_allocation_invariant(settlement)
+
+
+def test_catchup_settlement_exact_totals(catchup_loan):
+    with Warp(catchup_loan, datetime(2026, 5, 25, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(5000))
+
+    assert settlement.principal_paid == Money("4512.07")
+    assert settlement.interest_paid == Money("294.98")
+    assert settlement.mora_paid == Money("106.58")
+    assert settlement.fine_paid == Money("86.38")
+    assert settlement.remaining_balance == Money("0.00")
+
+
+def test_catchup_all_installments_covered(catchup_loan):
+    with Warp(catchup_loan, datetime(2026, 5, 25, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(5000))
+
+    assert len(settlement.allocations) == 5
+    assert all(a.is_fully_covered for a in settlement.allocations)
+
+
+# -- Late payment on 2-installment loan --
+
+
+def test_late_payment_settlement_invariant(late_two_installment_loan):
+    with Warp(late_two_installment_loan, datetime(2026, 4, 10, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(2500))
+
+    _assert_allocation_invariant(settlement)
+
+
+def test_late_payment_exact_totals(late_two_installment_loan):
+    with Warp(late_two_installment_loan, datetime(2026, 4, 10, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(2500))
+
+    assert settlement.principal_paid == Money("2328.84")
+    assert settlement.interest_paid == Money("89.21")
+    assert settlement.mora_paid == Money("40.17")
+    assert settlement.fine_paid == Money("41.78")
+    assert settlement.remaining_balance == Money("0.00")
+
+
+def test_late_payment_exact_allocations(late_two_installment_loan):
+    with Warp(late_two_installment_loan, datetime(2026, 4, 10, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money(2500))
+
+    assert len(settlement.allocations) == 2
+
+    a1 = settlement.allocations[0]
+    assert a1.installment_number == 1
+    assert a1.principal_allocated == Money("983.43")
+    assert a1.interest_allocated == Money("61.17")
+    assert a1.mora_allocated == Money("40.17")
+    assert a1.fine_allocated == Money("20.89")
+    assert a1.is_fully_covered is True
+
+    a2 = settlement.allocations[1]
+    assert a2.installment_number == 2
+    assert a2.principal_allocated == Money("1345.41")
+    assert a2.interest_allocated == Money("28.04")
+    assert a2.mora_allocated == Money("0.00")
+    assert a2.fine_allocated == Money("20.89")
+    assert a2.is_fully_covered is True
+
+
+# -- On-time exact payment (sub-cent interest spill) --
+
+
+def test_on_time_exact_payment_invariant(on_time_loan):
+    schedule = on_time_loan.get_original_schedule()
+    settlement = on_time_loan.record_payment(
+        schedule[0].payment_amount,
+        _utc(schedule[0].due_date),
+    )
+
+    _assert_allocation_invariant(settlement)
+
+
+def test_on_time_sequential_payments_invariant(on_time_loan):
+    schedule = on_time_loan.get_original_schedule()
+    for entry in schedule:
+        settlement = on_time_loan.record_payment(
+            entry.payment_amount,
+            _utc(entry.due_date),
+        )
+        _assert_allocation_invariant(settlement)
+
+
+# -- Parametrized: invariant holds for various payment sizes --
+
+
+@pytest.mark.parametrize(
+    "payment_amount",
+    [
+        Money("500"),
+        Money("1079.70"),
+        Money("2000"),
+        Money("5000"),
+        Money("6000"),
+    ],
+)
+def test_invariant_holds_for_various_payment_sizes(payment_amount):
+    loan = Loan(
+        principal=Money(5000),
+        interest_rate=InterestRate("2.5% a.m."),
+        due_dates=[
+            date(2026, 2, 10),
+            date(2026, 3, 10),
+            date(2026, 4, 10),
+            date(2026, 5, 10),
+            date(2026, 6, 10),
+        ],
+        disbursement_date=datetime(2026, 1, 5, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("1% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+    )
+
+    with Warp(loan, datetime(2026, 3, 15, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(payment_amount)
+
+    _assert_allocation_invariant(settlement)


### PR DESCRIPTION
## Summary

- **Fix settlement spill invariant**: `settlement.X_paid` now strictly equals `sum(a.X_allocated for a in settlement.allocations)` for all four components (fine, mora, interest, principal). Previously, "spill" amounts and sub-cent allocations were counted in totals but absent from the allocations list.
- **Refactor allocation engine**: Split `allocate_payment_per_installment` into two focused functions — `allocate_payment_into_installments` (orchestrator loop) and `allocate_payment_into_installment` (single-installment allocation). Moved per-installment logic from `Installment.allocate_from_payment` into `engines.py` and removed the method from `Installment`.
- **Fix overpayment accumulation bug**: Clamped per-installment owed amounts to non-negative, preventing negative allocations when a prior payment's spill had over-credited an installment.

### Key design decisions

- `_compute_spill` is a pure function (no allocation mutation) — returns mora/interest/principal spill amounts.
- `_reconcile_allocations` is a single sweep that adjusts the last allocation to match the totals, replacing all piecemeal sub-cent merging and spill attribution.
- 13 new regression tests covering the invariant across catch-up payments, late payments, on-time payments, and parametrized payment sizes.

## Test plan

- [x] All 1694 tests pass (0 failures, 5 xfailed)
- [x] New `test_settlement_spill.py` verifies the invariant at `raw_amount` precision
- [x] Existing tests for cross-installment late payments, partial payments, and overpayment accumulation updated with correct expected values
- [x] `knowledge/loan.md` updated with new function names and spill invariant key learning