### PR TITLE
refactor: simplify payment allocation to two-step loan-level + distribution

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -11,8 +11,9 @@ The Loan delegates computation to two focused components in `engines.py`:
   - `compute_state(...)` — the forward pass that produces a `LoanState` (settlements, principal balance, fines applied, fines paid total, last payment date).
   - `build_installments(...)` — builds `Installment` objects from settlements + schedule.
   - `compute_fines_at(...)` — determines which due dates should have fines applied.
-  - `allocate_payment_into_installments(...)` — orchestrates per-installment allocation.
-  - `allocate_payment_into_installment(...)` — allocates payment to a single installment (fine -> mora -> interest -> principal).
+  - `allocate_payment(...)` — loan-level allocation (fine -> mora -> interest -> principal).
+  - `distribute_into_installments(...)` — maps loan-level totals to per-installment allocations for reporting.
+  - `allocate_payment_into_installments(...)` — convenience wrapper that calls both of the above.
   - `covered_due_date_count(...)` — how many due dates are covered given a remaining balance.
   - `is_payment_late(...)` — grace-period-aware lateness check.
 - **TVM functions** (`tvm.py`) — standalone `loan_present_value`, `loan_irr`, `loan_calculate_anticipation`.
@@ -93,14 +94,12 @@ Neither method takes a date parameter — they use `self.now()` (which respects 
 
 ### Payment Allocation
 
-All payment methods allocate funds **per-installment** in strict sequential order. Within each installment, the priority is:
+Payment allocation uses a two-step process:
 
-1. **Fine** for this installment
-2. **Mora interest** for this installment
-3. **Regular interest** for this installment
-4. **Principal** for this installment
+1. **Loan-level allocation** (`allocate_payment`): determines the totals — how much of the payment goes to fines, mora, interest, and principal. Priority: fine -> mora -> interest -> principal. All accrued fines and interest are settled before any principal.
+2. **Per-installment distribution** (`distribute_into_installments`): maps those totals to individual installments for reporting. Walks installments sequentially — installment 1 absorbs what it can, then installment 2, etc.
 
-Installment 1 is fully addressed before installment 2 receives anything.
+This means all fines across all installments are paid before any mora, all mora before any interest, and all interest before any principal. Within each component, installments are filled in order.
 
 ## Forward Pass: `compute_state`
 
@@ -111,17 +110,17 @@ The central algorithm in `engines.compute_state`. It processes a merged timeline
    a. Compute interest (regular + mora) since last payment.
    b. Build installment snapshot reflecting all prior allocations.
    c. Add skipped contractual interest for periods beyond the current due-date boundary.
-   d. Run per-installment allocation (`allocate_payment_into_installments`).
+   d. Run two-step allocation (`allocate_payment_into_installments`): loan-level math, then per-installment distribution.
    e. Update running principal, fines paid total, and allocation history.
    f. Create a `Settlement` object.
 3. Return `LoanState` with all settlements and running state.
 
-### `is_fully_covered` Post-Payment Fixup
+### Post-Distribution Adjustments
 
-The `allocate_payment_into_installments` function determines `is_fully_covered` per allocation in two stages:
+After distributing loan-level totals into per-installment allocations, two adjustments run:
 
-1. **During the loop:** `allocate_payment_into_installment` computes `is_covered` by comparing the total allocated against the installment's remaining balance. This can be `False` when interest caps prevent full interest allocation (e.g., paying all installments at once on the first due date).
-2. **After the loop:** `_fixup_coverage_flags` checks if the post-payment balance is within tolerance of zero. If so, any allocation whose principal was fully covered gets `is_fully_covered` overridden to `True`. This handles the case where the loan is paid off but interest caps prevented exact coverage of each installment's interest obligation.
+1. **Residual** (`_apply_residual`): ensures `sum(allocations.X) == X_total` for each component. Loan-level accrual can exceed what installments absorb (rounding, partial periods, overpayment); the residual is added to the last allocation.
+2. **Coverage fixup** (`_apply_coverage_fixup`): if the post-payment balance is within tolerance of zero, any allocation whose principal was fully allocated is marked `is_fully_covered = True`.
 
 ## Dynamic Amortization Schedule
 
@@ -207,7 +206,7 @@ Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_pr
 - `balance` — amount still owed to fully settle this installment.
 - `is_fully_paid` — `True` when `balance` is within tolerance of zero.
 
-Per-installment allocation logic lives in `engines.allocate_payment_into_installment` (not on the Installment class).
+Per-installment allocation is a reporting view produced by `engines.distribute_into_installments` (not on the Installment class).
 
 ### Settlement (`loan.settlements`)
 
@@ -268,15 +267,21 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 
 **Fix:** `interest_date = max(self.now(), next_due_date)` in `pay_installment`. Late payments now accrue interest up to `self.now()`.
 
-### Payment allocation order was loan-level, not per-installment (fixed 2026-03-20)
+### Payment allocation simplified to two-step process (refactored 2026-03-23)
 
-**Fix:** Rewrote allocation to be strictly per-installment sequential. `allocate_payment_into_installments` walks installments in order. Within each, `allocate_payment_into_installment` applies fine -> mora -> interest -> principal.
+**Previous design:** Single-pass per-installment loop with running caps, a principal reservation (hold back money from inst 1's principal to fund inst 2's interest/mora), spill redistribution, and reconciliation. The reservation created a hybrid priority that was neither purely per-installment nor purely loan-level.
 
-**Lesson:** The per-installment interpretation is correct for Brazilian lending: installment 1's mora interest is more urgent than installment 2's fine.
+**New design:** Two-step process. `allocate_payment` determines loan-level totals (fine -> mora -> interest -> principal) with four `min()` calls. `distribute_into_installments` maps those totals to installments sequentially for reporting.
+
+**Behavioral change:** All fines and interest across all installments are settled before any principal. For heavily overdue loans, this charges more fines/interest per payment and reduces principal more slowly. Previously, only installments reached during the per-installment walk received fines.
+
+**What was removed:** `allocate_payment_into_installment` (per-installment function with caps and reservation), `_compute_spill` (redistributed over-reserved money), `_reconcile_allocations` (patched drift from spill). Replaced by `_apply_residual` (simpler, handles only one direction of drift) and `_apply_coverage_fixup`.
+
+**Lesson:** When a "per-installment" loop needs a reservation to fund later installments, it's implicitly doing loan-level allocation. Making the loan-level step explicit eliminates the reservation and its cascading cleanup machinery.
 
 ### Sub-cent precision loss in allocation loop (fixed 2026-03-20)
 
-**Fix:** Use `raw_amount` comparisons in the allocation loop instead of `Money`'s 2dp-rounded methods. Sub-cent allocations are included in component totals; the `_reconcile_allocations` sweep adjusts the last allocation to match.
+**Fix:** Use `raw_amount` comparisons in the allocation loop instead of `Money`'s 2dp-rounded methods. Sub-cent allocations are included in component totals; `_apply_residual` adjusts the last allocation to match.
 
 **Lesson:** `Money`'s `real_amount`-based comparisons are correct for business display but dangerous in accounting loops where sub-cent values compound.
 
@@ -304,15 +309,10 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 
 **Lesson:** All consistency checks across a system must use the same tolerance. When tolerance-based flags (`is_fully_covered`, `is_fully_paid`) coexist with exact checks (`is_paid_off` via `is_zero()`), the exact check must be relaxed to match, or the underlying data must be snapped so the exact check naturally passes.
 
-### Settlement spill invariant (fixed 2026-03-23)
+### Settlement spill invariant (fixed 2026-03-23, root cause eliminated 2026-03-23)
 
-**Symptom:** `settlement.X_paid != sum(a.X_allocated for a in settlement.allocations)` for interest and principal. The totals included amounts not reflected in any `Allocation` object.
+**Original symptom:** `settlement.X_paid != sum(a.X_allocated for a in settlement.allocations)` for interest and principal.
 
-**Root cause:** Two sources of discrepancy: (1) the "reserved" hold-back for future mora/interest prevented some principal from being allocated to an installment, leaving a remainder ("spill") that was added to totals but not to any allocation; (2) sub-cent allocations (positive at `raw_amount` but zero at `real_amount`) were counted in totals but dropped from the allocations list.
+**Original root cause:** The per-installment reservation held back principal from being allocated, creating "spill" that appeared in totals but not in allocations. Fixed with `_compute_spill` + `_reconcile_allocations`.
 
-**Fix:** Three changes:
-1. `_compute_spill` distributes leftover payment into mora, interest, and principal totals (pure function, no allocation mutation).
-2. `_reconcile_allocations` does a single sweep after all allocation is done, adjusting the last allocation's amounts so that `sum(allocations.X) == X_total` for all four components. If no allocations exist, it creates one for the last installment.
-3. Per-installment owed amounts are clamped to non-negative (`max(owed, 0)`) to prevent negative allocations when a previous payment's spill over-credited an installment.
-
-**Lesson:** Instead of trying to patch up discrepancies as they arise (merging sub-cent into last, merging spill into last), a single reconciliation sweep at the end is both simpler and more robust. It handles all sources of drift in one place.
+**Permanent fix:** The two-step allocation refactor eliminated the reservation and spill entirely. The invariant now holds by construction: `distribute_into_installments` fills from exact loan-level totals, and `_apply_residual` handles only the residual gap (loan-level accrual exceeding per-installment expectations). Per-installment owed amounts are still clamped to non-negative (`max(owed, 0)`) to prevent negative allocations.

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -2,8 +2,9 @@
 
 Interest calculation splits accrued interest into regular and mora
 components.  Settlement computation replays payments against the
-schedule using a forward pass with per-installment priority:
-fine -> mora -> interest -> principal.
+schedule using a forward pass.  Each payment is allocated in two
+steps: loan-level math (fine -> mora -> interest -> principal)
+followed by per-installment distribution for reporting.
 """
 
 from dataclasses import dataclass
@@ -230,125 +231,104 @@ def _skipped_contractual_interest(
 
 
 # ------------------------------------------------------------------
-# Per-installment payment allocation
+# Payment allocation
 # ------------------------------------------------------------------
 
 
-def allocate_payment_into_installment(
-    inst: Installment,
-    remaining: Money,
-    fine_remaining: Money,
-    mora_remaining: Money,
-    interest_remaining: Money,
-) -> Tuple[Allocation, Money, Money, Money, Money]:
-    """Allocate payment money to a single installment.
+def allocate_payment(
+    amount: Money,
+    fines_owed: Money,
+    mora_accrued: Money,
+    interest_accrued: Money,
+) -> Tuple[Money, Money, Money, Money]:
+    """Loan-level allocation: fine -> mora -> interest -> principal.
 
-    Processes fine -> mora -> interest -> principal sequentially,
-    each capped by both the installment's remaining obligation and
-    the corresponding running cap.
-
-    The running caps prevent over-allocation: they track the
-    loan-level accrual computed during the forward pass.
-
-    Principal allocation reserves ``interest_remaining + mora_remaining``
-    so that later installments can still absorb their share of
-    interest and mora.
+    Determines how a payment splits across the four obligation
+    components.  Everything left after fines, mora, and interest
+    goes to principal reduction (which may exceed the current
+    balance, producing overpayment handled by the caller).
 
     Returns:
-        (allocation, remaining, fine_remaining, mora_remaining, interest_remaining)
+        (fine_paid, mora_paid, interest_paid, principal_paid)
     """
-    fine_owed = inst.expected_fine - inst.fine_paid
-    fine_alloc = Money(min(max(fine_owed.raw_amount, 0), remaining.raw_amount, fine_remaining.raw_amount))
-    remaining = remaining - fine_alloc
-    fine_remaining = fine_remaining - fine_alloc
+    remaining = amount
 
-    mora_owed = inst.expected_mora - inst.mora_paid
-    mora_alloc = Money(min(max(mora_owed.raw_amount, 0), remaining.raw_amount, mora_remaining.raw_amount))
-    remaining = remaining - mora_alloc
-    mora_remaining = mora_remaining - mora_alloc
+    fine_paid = Money(min(fines_owed.raw_amount, remaining.raw_amount))
+    remaining = remaining - fine_paid
 
-    interest_owed = inst.expected_interest - inst.interest_paid
-    interest_alloc = Money(min(max(interest_owed.raw_amount, 0), remaining.raw_amount, interest_remaining.raw_amount))
-    remaining = remaining - interest_alloc
-    interest_remaining = interest_remaining - interest_alloc
+    mora_paid = Money(min(mora_accrued.raw_amount, remaining.raw_amount))
+    remaining = remaining - mora_paid
 
-    principal_owed = inst.expected_principal - inst.principal_paid
-    reserved = interest_remaining + mora_remaining
-    available_for_principal = remaining - reserved if remaining.raw_amount > reserved.raw_amount else Money.zero()
-    principal_alloc = Money(min(max(principal_owed.raw_amount, 0), available_for_principal.raw_amount))
-    remaining = remaining - principal_alloc
+    interest_paid = Money(min(interest_accrued.raw_amount, remaining.raw_amount))
+    remaining = remaining - interest_paid
 
-    total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
-    is_covered = total >= (inst.balance - _COVERAGE_TOLERANCE)
-
-    allocation = Allocation(
-        installment_number=inst.number,
-        principal_allocated=principal_alloc,
-        interest_allocated=interest_alloc,
-        mora_allocated=mora_alloc,
-        fine_allocated=fine_alloc,
-        is_fully_covered=is_covered,
-    )
-    return allocation, remaining, fine_remaining, mora_remaining, interest_remaining
+    principal_paid = remaining
+    return fine_paid, mora_paid, interest_paid, principal_paid
 
 
-def _fixup_coverage_flags(
-    allocations: List[Allocation],
+def distribute_into_installments(
     installments: List[Installment],
-    ending_balance: Money,
+    fine_total: Money,
+    mora_total: Money,
+    interest_total: Money,
     principal_total: Money,
+    ending_balance: Money,
 ) -> List[Allocation]:
-    """Mark allocations as fully covered when the loan is paid off.
+    """Distribute loan-level totals into per-installment allocations.
 
-    After the allocation loop, if the post-payment balance is within
-    tolerance of zero, override ``is_fully_covered`` for any allocation
-    whose principal was fully allocated.
-    """
-    post_balance = ending_balance - principal_total
-    if post_balance > _COVERAGE_TOLERANCE:
-        return allocations
+    Walks installments sequentially, filling each installment's
+    obligations from the pre-computed loan-level totals.  This is a
+    reporting view -- the financial math is done by
+    :func:`allocate_payment`.
 
-    inst_by_number = {inst.number: inst for inst in installments}
-    fixed: List[Allocation] = []
-    for alloc in allocations:
-        if not alloc.is_fully_covered:
-            inst = inst_by_number.get(alloc.installment_number)
-            if inst is not None:
-                principal_owed = inst.expected_principal - inst.principal_paid
-                if alloc.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
-                    alloc = Allocation(
-                        installment_number=alloc.installment_number,
-                        principal_allocated=alloc.principal_allocated,
-                        interest_allocated=alloc.interest_allocated,
-                        mora_allocated=alloc.mora_allocated,
-                        fine_allocated=alloc.fine_allocated,
-                        is_fully_covered=True,
-                    )
-        fixed.append(alloc)
-    return fixed
-
-
-def _compute_spill(
-    remaining: Money,
-    mora_remaining: Money,
-    interest_remaining: Money,
-) -> Tuple[Money, Money, Money]:
-    """Distribute leftover payment into mora, interest, and principal.
+    A residual adjustment ensures ``sum(allocations.X) == X_total``
+    for every component, and a coverage fixup marks allocations as
+    fully covered when the loan is paid off.
 
     Returns:
-        (mora_spill, interest_spill, principal_spill)
+        List of Allocation objects (one per touched installment).
     """
-    mora_spill = Money(min(remaining.raw_amount, mora_remaining.raw_amount))
-    remaining = remaining - mora_spill
+    fine_remaining = fine_total
+    mora_remaining = mora_total
+    interest_remaining = interest_total
+    principal_remaining = principal_total
+    allocations: List[Allocation] = []
 
-    interest_spill = Money(min(remaining.raw_amount, interest_remaining.raw_amount))
-    remaining = remaining - interest_spill
+    for inst in installments:
+        fine_owed = inst.expected_fine - inst.fine_paid
+        fine_alloc = Money(min(max(fine_owed.raw_amount, 0), fine_remaining.raw_amount))
+        fine_remaining = fine_remaining - fine_alloc
 
-    principal_spill = remaining if remaining.raw_amount > 0 else Money.zero()
-    return mora_spill, interest_spill, principal_spill
+        mora_owed = inst.expected_mora - inst.mora_paid
+        mora_alloc = Money(min(max(mora_owed.raw_amount, 0), mora_remaining.raw_amount))
+        mora_remaining = mora_remaining - mora_alloc
+
+        interest_owed = inst.expected_interest - inst.interest_paid
+        interest_alloc = Money(min(max(interest_owed.raw_amount, 0), interest_remaining.raw_amount))
+        interest_remaining = interest_remaining - interest_alloc
+
+        principal_owed = inst.expected_principal - inst.principal_paid
+        principal_alloc = Money(min(max(principal_owed.raw_amount, 0), principal_remaining.raw_amount))
+        principal_remaining = principal_remaining - principal_alloc
+
+        total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
+        if total.is_positive():
+            is_covered = total >= (inst.balance - _COVERAGE_TOLERANCE)
+            allocations.append(Allocation(
+                installment_number=inst.number,
+                principal_allocated=principal_alloc,
+                interest_allocated=interest_alloc,
+                mora_allocated=mora_alloc,
+                fine_allocated=fine_alloc,
+                is_fully_covered=is_covered,
+            ))
+
+    _apply_residual(allocations, installments, fine_total, mora_total, interest_total, principal_total)
+    _apply_coverage_fixup(allocations, installments, ending_balance, principal_total)
+    return allocations
 
 
-def _reconcile_allocations(
+def _apply_residual(
     allocations: List[Allocation],
     installments: List[Installment],
     fine_total: Money,
@@ -356,12 +336,10 @@ def _reconcile_allocations(
     interest_total: Money,
     principal_total: Money,
 ) -> None:
-    """Adjust allocations so their sums exactly match the totals.
+    """Adjust the last allocation so ``sum(allocations)`` matches the totals.
 
-    Sub-cent allocations and spill can cause the totals to diverge
-    from ``sum(allocations)``.  This single sweep fixes the gap by
-    adjusting the last allocation.  If no allocations exist yet,
-    a new one is created for the last installment.
+    Loan-level accrual can exceed what installments absorb (rounding,
+    partial periods, overpayment).  This single sweep patches any gap.
     """
     sum_f = sum((a.fine_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
     sum_m = sum((a.mora_allocated.raw_amount for a in allocations), Money.zero().raw_amount)
@@ -399,6 +377,41 @@ def _reconcile_allocations(
         )
 
 
+def _apply_coverage_fixup(
+    allocations: List[Allocation],
+    installments: List[Installment],
+    ending_balance: Money,
+    principal_total: Money,
+) -> None:
+    """Override coverage flags when the loan is paid off.
+
+    If the post-payment balance is within tolerance of zero,
+    any allocation whose principal was fully allocated is
+    marked as fully covered.
+    """
+    post_balance = ending_balance - principal_total
+    if post_balance > _COVERAGE_TOLERANCE:
+        return
+
+    inst_by_number = {inst.number: inst for inst in installments}
+    for i, alloc in enumerate(allocations):
+        if alloc.is_fully_covered:
+            continue
+        inst = inst_by_number.get(alloc.installment_number)
+        if inst is None:
+            continue
+        principal_owed = inst.expected_principal - inst.principal_paid
+        if alloc.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
+            allocations[i] = Allocation(
+                installment_number=alloc.installment_number,
+                principal_allocated=alloc.principal_allocated,
+                interest_allocated=alloc.interest_allocated,
+                mora_allocated=alloc.mora_allocated,
+                fine_allocated=alloc.fine_allocated,
+                is_fully_covered=True,
+            )
+
+
 def allocate_payment_into_installments(
     amount: Money,
     installments: List[Installment],
@@ -409,61 +422,25 @@ def allocate_payment_into_installments(
 ) -> Tuple[Money, Money, Money, Money, List[Allocation]]:
     """Allocate a payment across installments in priority order.
 
-    Each installment is processed sequentially via
-    :func:`allocate_payment_into_installment`.  Installment 1's
-    obligations are fully addressed before installment 2 receives
-    anything.
+    Two-step process:
 
-    After the per-installment loop, any leftover money (spill) is
-    distributed into mora, interest, and principal totals.  A final
-    reconciliation sweep adjusts the last allocation so that the
-    totals always equal the sum of their per-allocation counterparts.
+    1. **Loan-level allocation** (:func:`allocate_payment`) determines
+       the totals: fine -> mora -> interest -> principal.
+    2. **Per-installment distribution** (:func:`distribute_into_installments`)
+       maps those totals to individual installments for reporting.
 
     Returns:
         (fine_total, mora_total, interest_total, principal_total, allocations)
     """
-    remaining = amount
-    fine_remaining = fine_cap
-    mora_remaining = mora_cap
-    interest_remaining = interest_cap
-    fine_total = Money.zero()
-    mora_total = Money.zero()
-    interest_total = Money.zero()
-    principal_total = Money.zero()
-    allocations: List[Allocation] = []
+    fine_paid, mora_paid, interest_paid, principal_paid = allocate_payment(
+        amount, fine_cap, mora_cap, interest_cap,
+    )
 
-    for inst in installments:
-        if not remaining.raw_amount:
-            break
+    allocations = distribute_into_installments(
+        installments, fine_paid, mora_paid, interest_paid, principal_paid, ending_balance,
+    )
 
-        allocation, remaining, fine_remaining, mora_remaining, interest_remaining = allocate_payment_into_installment(
-            inst, remaining, fine_remaining, mora_remaining, interest_remaining
-        )
-
-        if allocation.total_allocated.raw_amount <= 0:
-            continue
-
-        fine_total = fine_total + allocation.fine_allocated
-        mora_total = mora_total + allocation.mora_allocated
-        interest_total = interest_total + allocation.interest_allocated
-        principal_total = principal_total + allocation.principal_allocated
-
-        if allocation.total_allocated.is_positive():
-            allocations.append(allocation)
-
-    if remaining.raw_amount > 0:
-        mora_spill, interest_spill, principal_spill = _compute_spill(
-            remaining,
-            mora_remaining,
-            interest_remaining,
-        )
-        mora_total = mora_total + mora_spill
-        interest_total = interest_total + interest_spill
-        principal_total = principal_total + principal_spill
-
-    _reconcile_allocations(allocations, installments, fine_total, mora_total, interest_total, principal_total)
-    allocations = _fixup_coverage_flags(allocations, installments, ending_balance, principal_total)
-    return fine_total, mora_total, interest_total, principal_total, allocations
+    return fine_paid, mora_paid, interest_paid, principal_paid, allocations
 
 
 # ------------------------------------------------------------------

--- a/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
+++ b/tests/loan/settlements/late_payments/test_all_overdue_per_installment.py
@@ -3,9 +3,10 @@
 Scenario:
   - 6-installment loan (Mar-Aug 2025), all overdue by Aug 15
   - Single partial payment equal to one scheduled installment amount (354.34)
-  - Inst 1 should absorb fine, mora, interest, and partial principal
-  - Inst 2-4 receive contractual interest and fines (no principal) because the
-    interest cap now includes skipped installments' contractual interest
+  - Loan-level allocation prioritises: fines -> mora -> interest -> principal
+  - All six installments receive fines and interest allocations because the
+    loan-level step pays all accrued fines and interest before any principal
+  - Only inst 1 receives principal (what remains after fines, mora, interest)
 """
 
 from datetime import date, datetime, timezone
@@ -47,9 +48,9 @@ def overdue_settlement(all_overdue_loan):
 
 
 def test_settlement_fine_paid(overdue_settlement):
-    """Fines for inst 1-4 are paid from the interest reservation spill."""
+    """All six installments' fines are paid (loan-level priority: fines first)."""
     _, s = overdue_settlement
-    assert s.fine_paid == Money("28.35")
+    assert s.fine_paid == Money("42.52")
 
 
 def test_settlement_mora_paid(overdue_settlement):
@@ -59,30 +60,32 @@ def test_settlement_mora_paid(overdue_settlement):
 
 
 def test_settlement_interest_paid(overdue_settlement):
-    """Interest includes inst 1's contractual plus skipped installments."""
+    """Interest covers all six installments' contractual interest (loan-level)."""
     _, s = overdue_settlement
-    assert s.interest_paid == Money("104.80")
+    assert s.interest_paid == Money("126.06")
 
 
 def test_settlement_principal_paid(overdue_settlement):
-    """Less principal than before because more goes to interest and fines."""
+    """Principal is the residual after all fines, mora, and interest."""
     _, s = overdue_settlement
-    assert s.principal_paid == Money("112.99")
+    assert s.principal_paid == Money("77.55")
 
 
 def test_settlement_remaining_balance(overdue_settlement):
     _, s = overdue_settlement
-    assert s.remaining_balance == Money("1887.01")
+    assert s.remaining_balance == Money("1922.45")
 
 
-def test_four_installments_receive_allocation(overdue_settlement):
-    """Inst 1-4 receive allocations because the interest cap now spans skipped periods."""
+def test_six_installments_receive_allocation(overdue_settlement):
+    """All six installments receive allocations (fines and interest distributed to each)."""
     _, s = overdue_settlement
-    assert len(s.allocations) == 4
+    assert len(s.allocations) == 6
     assert s.allocations[0].installment_number == 1
     assert s.allocations[1].installment_number == 2
     assert s.allocations[2].installment_number == 3
     assert s.allocations[3].installment_number == 4
+    assert s.allocations[4].installment_number == 5
+    assert s.allocations[5].installment_number == 6
 
 
 def test_first_installment_allocation_breakdown(overdue_settlement):
@@ -91,7 +94,7 @@ def test_first_installment_allocation_breakdown(overdue_settlement):
     assert a.fine_allocated == Money("7.09")
     assert a.mora_allocated == Money("108.21")
     assert a.interest_allocated == Money("33.28")
-    assert a.principal_allocated == Money("112.99")
+    assert a.principal_allocated == Money("77.55")
     assert a.is_fully_covered is False
 
 
@@ -116,16 +119,16 @@ def test_third_installment_allocation_breakdown(overdue_settlement):
 
 
 def test_fourth_installment_allocation_breakdown(overdue_settlement):
-    """Inst 4 gets partial contractual interest and fine."""
+    """Inst 4 gets its full contractual interest and fine."""
     _, s = overdue_settlement
     a = s.allocations[3]
     assert a.fine_allocated == Money("7.09")
-    assert a.interest_allocated == Money("16.38")
+    assert a.interest_allocated == Money("18.91")
     assert a.principal_allocated == Money("0.00")
     assert a.is_fully_covered is False
 
 
 def test_fine_balance_after_payment(overdue_settlement):
-    """Two installments' fines (inst 5, inst 6) remain unpaid."""
+    """All fines are paid because loan-level allocation settles fines first."""
     loan, _ = overdue_settlement
-    assert loan.fine_balance == Money("14.17")
+    assert loan.fine_balance == Money("0.00")

--- a/tests/loan/settlements/late_payments/test_partial_payment_interest_loss.py
+++ b/tests/loan/settlements/late_payments/test_partial_payment_interest_loss.py
@@ -60,9 +60,9 @@ def test_total_interest_equals_scheduled(partial_then_full):
 
 
 def test_p1_collects_both_installments_interest(partial_then_full):
-    """P1 collects inst 1's full interest and part of inst 2's (both overdue)."""
+    """P1 collects all accrued interest (both installments' contractual interest)."""
     _, settlements = partial_then_full
-    assert settlements[0].interest_paid == Money("10.03")
+    assert settlements[0].interest_paid == Money("12.16")
 
 
 def test_p1_first_installment_gets_full_interest(partial_then_full):
@@ -73,26 +73,26 @@ def test_p1_first_installment_gets_full_interest(partial_then_full):
     assert a.interest_allocated == Money("8.14")
 
 
-def test_p1_second_installment_gets_partial_interest(partial_then_full):
-    """Inst 2 gets partial interest from P1 (what remains after inst 1)."""
+def test_p1_second_installment_gets_full_interest(partial_then_full):
+    """Inst 2 gets its full contractual interest from P1 (loan-level pays all interest first)."""
     _, settlements = partial_then_full
     a = settlements[0].allocations[1]
     assert a.installment_number == 2
-    assert a.interest_allocated == Money("1.89")
+    assert a.interest_allocated == Money("4.02")
 
 
-def test_p2_collects_remaining_interest(partial_then_full):
-    """P2 collects the remainder of inst 2's contractual interest."""
+def test_p2_collects_no_interest(partial_then_full):
+    """P2 has no remaining interest (P1 already collected all contractual interest)."""
     _, settlements = partial_then_full
-    assert settlements[1].interest_paid == Money("2.13")
+    assert settlements[1].interest_paid == Money("0.00")
 
 
-def test_p2_second_installment_gets_remaining_interest(partial_then_full):
-    """Inst 2's allocation in P2 has the remaining contractual interest."""
+def test_p2_second_installment_gets_no_interest(partial_then_full):
+    """Inst 2's allocation in P2 has zero interest (already collected in P1)."""
     _, settlements = partial_then_full
     inst2_allocs = [a for a in settlements[1].allocations if a.installment_number == 2]
     assert len(inst2_allocs) == 1
-    assert inst2_allocs[0].interest_allocated == Money("2.13")
+    assert inst2_allocs[0].interest_allocated == Money("0.00")
 
 
 def test_inst2_total_interest_equals_contractual(partial_then_full):


### PR DESCRIPTION
## Summary
- Replace the single-pass per-installment allocation (with reservation, spill, and reconciliation) with a two-step approach: loan-level math (`allocate_payment`) followed by per-installment distribution (`distribute_into_installments`)
- Eliminate `allocate_payment_into_installment`, `_compute_spill`, and `_reconcile_allocations`; replace with simpler `_apply_residual` and `_apply_coverage_fixup`
- Behavioral change: all fines and interest are now settled at the loan level before any principal, which charges more fines/interest per payment on heavily overdue loans

## Changes
- `engines.py`: New `allocate_payment` (4-line loan-level allocation), new `distribute_into_installments` (sequential fill from fixed totals), rewritten `allocate_payment_into_installments` as thin wrapper
- 12 test values updated across `test_all_overdue_per_installment.py` and `test_partial_payment_interest_loss.py` to reflect the new priority ordering
- `knowledge/loan.md`: Rewritten Payment Allocation, Forward Pass, and Key Learnings sections

## Test plan
- [x] All 1694 tests pass (`poetry run pytest`)
- [x] Settlement spill invariant tests pass (sum of allocations == settlement totals)
- [x] Coverage flags correct for full-payoff and partial-payment scenarios
- [x] Overpayment tracking unchanged

## Docs
- `knowledge/loan.md` updated to describe the two-step allocation design