### PR TITLE
feat: add BillingCycleLoan with variable mora rate per cycle

### DIFF
--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -7,6 +7,7 @@ MoneyWarp is a Time Value of Money library built around the metaphor of "time-wa
 ```
 money_warp/
 ├── __init__.py            # Public API exports
+├── engines.py             # Shared building blocks (InterestCalculator, MoraStrategy, MoraRateCallback)
 ├── money.py               # Money (high-precision currency)
 ├── rate.py                # Rate (signed base) + CompoundingFrequency + YearSize
 ├── interest_rate.py       # InterestRate (non-negative refinement of Rate)
@@ -19,12 +20,17 @@ money_warp/
 ├── billing_cycle/
 │   ├── base.py            # BaseBillingCycle (abstract)
 │   └── monthly.py         # MonthlyBillingCycle (fixed calendar day)
+├── billing_cycle_loan/
+│   ├── billing_cycle_loan.py  # BillingCycleLoan facade
+│   ├── engines.py             # BCL-specific: mora rate resolution + statements
+│   ├── mora_rate_resolver.py  # MoraRateResolver protocol
+│   └── statement.py           # BillingCycleLoanStatement dataclass
 ├── credit_card/
 │   ├── credit_card.py     # CreditCard state machine
 │   └── statement.py       # Statement (frozen derived view)
 ├── loan/
 │   ├── loan.py            # Loan facade
-│   ├── engines.py         # InterestCalculator + pure functions (forward pass, fines, allocation)
+│   ├── engines.py         # Unified forward pass, fines, allocation (imports from root engines)
 │   ├── tvm.py             # TVM standalone functions (PV, IRR, anticipation)
 │   ├── allocation.py      # Allocation dataclass (per-installment payment breakdown)
 │   ├── installment.py     # Installment dataclass
@@ -90,7 +96,8 @@ Equality between `CashFlowItem` and `CashFlowEntry` uses Python's reflected-equa
 
 `Loan` is a facade that orchestrates three focused components:
 
-- **`engines.py`** — `InterestCalculator` (stateless interest math, regular + mora split) plus pure functions that compute all derived state: forward pass (`compute_state`), fine detection (`compute_fines_at`), per-installment allocation, and installment building.
+- **`engines.py`** (root) — shared building blocks: `InterestCalculator` (stateless interest math), `MoraStrategy`, `MoraRateCallback`. No `loan/` dependency — avoids circular imports.
+- **`loan/engines.py`** — unified forward pass (`compute_state` with optional `mora_rate_for_event` callback), fine detection (`compute_fines_at`), per-installment allocation, and installment building. Imports shared types from root.
 - **`tvm.py`** — standalone functions for PV, IRR, and anticipation (eliminates circular imports).
 
 `Loan.cashflow` is the single source of truth — expected schedule items and actual payment items live in one `CashFlow`. All derived state (settlements, installments, balances, fines) is computed on demand via a forward pass. Schedule generation (`generate_expected_cash_flow`, `get_original_schedule`, `get_amortization_schedule`) stays in `Loan`.

--- a/knowledge/billing_cycle_loan.md
+++ b/knowledge/billing_cycle_loan.md
@@ -1,0 +1,94 @@
+# Billing Cycle Loan
+
+The `BillingCycleLoan` models a personal loan where principal is amortized on a fixed schedule (Price / SAC) but payment timing is driven by credit-card-like billing cycles. Unlike the standard `Loan`, the mora interest rate can change per billing cycle via a user-supplied callable.
+
+## Architecture
+
+`BillingCycleLoan` follows the same CashFlow-emergence philosophy as `Loan`: a single `CashFlow` is the source of truth, and all financial state (settlements, installments, balances, fines, statements) is derived on demand by a forward pass.
+
+### Components
+
+- **`BillingCycleLoan`** (facade) — wires billing cycle, scheduler, interest calculator, and mora rate resolver. Provides payment methods and property views.
+- **`BaseBillingCycle`** — existing factory that generates closing dates and due dates. Enhanced with optional explicit `due_dates` and a `due_dates_between()` method.
+- **`MoraRateResolver`** (protocol) — callable `(date, InterestRate) -> InterestRate` that adjusts the mora rate per cycle. The first argument is the cycle's closing date; the second is the base mora rate.
+- **`InterestCalculator`** — reused from `loan/engines.py`, enhanced with `mora_rate_override` parameter.
+- **`billing_cycle_loan/engines.py`** — adapted forward pass that resolves mora rate per cycle and delegates allocation/distribution/fines to `loan/engines.py`.
+- **`BillingCycleLoanStatement`** — per-period view combining schedule expectations with actual payments, mora rate used, and fine activity.
+
+### Key Differences from Loan
+
+| Aspect | Loan | BillingCycleLoan |
+|---|---|---|
+| Due dates | Explicit `List[date]` | Derived from `BillingCycle` (or explicit on the cycle) |
+| Mora rate | Fixed `InterestRate` | Base rate + optional `MoraRateResolver` per cycle |
+| Statements | None | `BillingCycleLoanStatement` per billing period |
+| Closing dates | N/A | From `BillingCycle`, drives statement periods |
+
+## Constructor Parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `principal` | `Money` | required | Must be positive |
+| `interest_rate` | `InterestRate` | required | Annual contractual rate |
+| `billing_cycle` | `BaseBillingCycle` | required | Generates closing and due dates |
+| `start_date` | `datetime` | required | Start of first billing period |
+| `num_installments` | `int` | required | Number of amortization periods |
+| `disbursement_date` | `Optional[datetime]` | `now()` | Must be before first due date |
+| `scheduler` | `Optional[Type[BaseScheduler]]` | `PriceScheduler` | Amortization strategy |
+| `fine_rate` | `Optional[InterestRate]` | `InterestRate("2% annual")` | Fine rate on missed payments |
+| `grace_period_days` | `int` | `0` | Days after due date before fines |
+| `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Base mora rate |
+| `mora_rate_resolver` | `Optional[MoraRateResolver]` | `None` | Per-cycle mora adjustment |
+| `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora compounds |
+
+## Mora Rate Resolution
+
+Two parameters work together:
+
+1. **`mora_interest_rate`** — the base rate, used directly when no resolver is provided (constant, identical to `Loan`).
+2. **`mora_rate_resolver`** — optional callable `(closing_date: date, base_mora_rate: InterestRate) -> InterestRate`. Called at each payment event to resolve the cycle-specific mora rate. The resolver receives the base rate and can adjust, replace, or pass it through.
+
+Resolution happens in `resolve_mora_rate()`: the function maps the current installment's due date to its billing cycle's closing date, then calls the resolver with that closing date and the base rate.
+
+## Due Date Derivation
+
+Due dates are owned by the billing cycle, not the loan. `BaseBillingCycle` was enhanced with:
+
+- Optional `due_dates: List[date]` constructor parameter — explicit override.
+- `due_dates_between(start, end)` method — returns explicit dates (filtered by range) or derives from `closing_dates_between` + `due_date_for`.
+
+The `BillingCycleLoan` constructor calls `billing_cycle.due_dates_between(...)` and truncates to `num_installments`.
+
+## Forward Pass
+
+`billing_cycle_loan.engines.compute_state` is an adapted version of `loan.engines.compute_state`. The only structural difference: at each payment event, it resolves the mora rate for the current billing cycle and passes it as `mora_rate_override` to `InterestCalculator.compute_accrued_interest`.
+
+All other engine functions are reused directly from `loan/engines.py`: `allocate_payment`, `distribute_into_installments`, `compute_fines_at`, `covered_due_date_count`, `_build_event_timeline`, `_build_installments_snapshot`, `_skipped_contractual_interest`.
+
+## Statements
+
+`build_statements` produces one `BillingCycleLoanStatement` per billing period. Each statement shows:
+
+- Schedule expectations (expected payment, principal, interest)
+- The mora rate resolved for that cycle
+- Mora and fines charged
+- Payments received in the period (between closing dates)
+- Opening and closing principal balance
+
+Statements are a reporting view — they don't affect the financial computation.
+
+## Payment Methods
+
+- **`record_payment(amount, payment_date, interest_date=None)`** — full control, same as `Loan`.
+- **`pay_installment(amount)`** — sugar method using `now()`. Interest accrual depends on timing (early/on-time/late), same semantics as `Loan.pay_installment`.
+
+## Warp Integration
+
+`BillingCycleLoan` has `_time_ctx` and `_on_warp`, so `Warp` works out of the box. Warping materialises fines at the target date.
+
+## Key Design Decisions
+
+- **No duplication of engine logic**: the adapted forward pass reuses 90%+ of `loan/engines.py` functions. Only mora rate resolution is new.
+- **Resolver is optional**: without it, behavior is identical to a `Loan` with billing-cycle-derived due dates.
+- **Billing cycle owns all date logic**: the loan never receives explicit `due_dates` — it always derives them from the billing cycle. To customize due dates, pass them to the billing cycle constructor.
+- **`InterestCalculator.compute_accrued_interest` gained `mora_rate_override`**: backward-compatible (optional param), allows per-call mora rate without duplicating the calculator.

--- a/knowledge/billing_cycle_loan.md
+++ b/knowledge/billing_cycle_loan.md
@@ -11,8 +11,9 @@ The `BillingCycleLoan` models a personal loan where principal is amortized on a 
 - **`BillingCycleLoan`** (facade) — wires billing cycle, scheduler, interest calculator, and mora rate resolver. Provides payment methods and property views.
 - **`BaseBillingCycle`** — existing factory that generates closing dates and due dates. Enhanced with optional explicit `due_dates` and a `due_dates_between()` method.
 - **`MoraRateResolver`** (protocol) — callable `(date, InterestRate) -> InterestRate` that adjusts the mora rate per cycle. The first argument is the cycle's closing date; the second is the base mora rate.
-- **`InterestCalculator`** — reused from `loan/engines.py`, enhanced with `mora_rate_override` parameter.
-- **`billing_cycle_loan/engines.py`** — adapted forward pass that resolves mora rate per cycle and delegates allocation/distribution/fines to `loan/engines.py`.
+- **`engines.py`** (root) — shared building blocks (`InterestCalculator`, `MoraStrategy`, `MoraRateCallback`) used by both `Loan` and `BillingCycleLoan`. No dependency on domain objects.
+- **`loan/engines.py`** — unified forward pass (`compute_state`) with an optional `mora_rate_for_event` callback, plus all allocation, fine, and installment logic. `Loan` omits the callback; `BillingCycleLoan` passes one.
+- **`billing_cycle_loan/engines.py`** — thin product-specific layer: `resolve_mora_rate`, `make_mora_callback`, a wrapper `compute_state` that builds the callback and delegates, and `build_statements`.
 - **`BillingCycleLoanStatement`** — per-period view combining schedule expectations with actual payments, mora rate used, and fine activity.
 
 ### Key Differences from Loan
@@ -61,9 +62,7 @@ The `BillingCycleLoan` constructor calls `billing_cycle.due_dates_between(...)` 
 
 ## Forward Pass
 
-`billing_cycle_loan.engines.compute_state` is an adapted version of `loan.engines.compute_state`. The only structural difference: at each payment event, it resolves the mora rate for the current billing cycle and passes it as `mora_rate_override` to `InterestCalculator.compute_accrued_interest`.
-
-All other engine functions are reused directly from `loan/engines.py`: `allocate_payment`, `distribute_into_installments`, `compute_fines_at`, `covered_due_date_count`, `_build_event_timeline`, `_build_installments_snapshot`, `_skipped_contractual_interest`.
+There is a single unified `compute_state` in `loan/engines.py` with an optional `mora_rate_for_event: MoraRateCallback` parameter. `Loan` calls it without the callback (default mora rate). `BillingCycleLoan`'s `billing_cycle_loan/engines.py` builds a callback via `make_mora_callback` that resolves the per-cycle mora rate and delegates to the same unified function. No forward-pass logic is duplicated.
 
 ## Statements
 
@@ -88,7 +87,8 @@ Statements are a reporting view — they don't affect the financial computation.
 
 ## Key Design Decisions
 
-- **No duplication of engine logic**: the adapted forward pass reuses 90%+ of `loan/engines.py` functions. Only mora rate resolution is new.
+- **No duplication of engine logic**: `loan/engines.py` has a single unified `compute_state` with a `MoraRateCallback` hook. BCL injects its per-cycle resolver via the callback; `Loan` omits it. All allocation, fine, and installment functions are shared.
+- **Three-layer engine architecture**: `engines.py` (root) → `loan/engines.py` → `billing_cycle_loan/engines.py`. Root has standalone types (no `loan/` dependency, avoids circular imports). Loan engines have the full forward pass. BCL engines add product-specific wrappers.
 - **Resolver is optional**: without it, behavior is identical to a `Loan` with billing-cycle-derived due dates.
 - **Billing cycle owns all date logic**: the loan never receives explicit `due_dates` — it always derives them from the billing cycle. To customize due dates, pass them to the billing cycle constructor.
 - **`InterestCalculator.compute_accrued_interest` gained `mora_rate_override`**: backward-compatible (optional param), allows per-call mora rate without duplicating the calculator.

--- a/money_warp/__init__.py
+++ b/money_warp/__init__.py
@@ -1,6 +1,7 @@
 """MoneyWarp - Bend time. Model cash."""
 
 from money_warp.billing_cycle import BaseBillingCycle, MonthlyBillingCycle
+from money_warp.billing_cycle_loan import BillingCycleLoan, BillingCycleLoanStatement, MoraRateResolver
 from money_warp.cash_flow import (
     CashFlow,
     CashFlowEntry,
@@ -57,7 +58,10 @@ from money_warp.warp import InvalidDateError, NestedWarpError, Warp, WarpError
 
 __all__ = [
     "BaseBillingCycle",
+    "BillingCycleLoan",
+    "BillingCycleLoanStatement",
     "MonthlyBillingCycle",
+    "MoraRateResolver",
     "CreditCard",
     "Statement",
     "Money",

--- a/money_warp/billing_cycle/base.py
+++ b/money_warp/billing_cycle/base.py
@@ -1,9 +1,9 @@
 """Base billing cycle abstraction for periodic statement generation."""
 
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
-from typing import List
+from typing import List, Optional
 
 from ..cash_flow import CashFlow
 from ..money import Money
@@ -21,7 +21,19 @@ class BaseBillingCycle(ABC):
     Statement building is concrete: it relies on the abstract date
     methods and the cash-flow query API, so it works for every
     implementation.
+
+    Args:
+        due_dates: Optional explicit due dates.  When provided, these
+            override the dates that would be computed from closing dates
+            via :meth:`due_date_for`.  Useful when the payment schedule
+            has non-standard due dates that don't follow the closing-day
+            offset rule.
     """
+
+    def __init__(self, due_dates: Optional[List[date]] = None) -> None:
+        self._explicit_due_dates: Optional[List[date]] = (
+            sorted(due_dates) if due_dates else None
+        )
 
     @abstractmethod
     def closing_dates_between(self, start: datetime, end: datetime) -> List[datetime]:
@@ -34,6 +46,22 @@ class BaseBillingCycle(ABC):
     @abstractmethod
     def due_date_for(self, closing_date: datetime) -> datetime:
         """Payment due date for a given statement closing date."""
+
+    def due_dates_between(self, start: datetime, end: datetime) -> List[date]:
+        """Return payment due dates for all cycles in ``[start, end]``.
+
+        When explicit *due_dates* were provided at construction, returns
+        those falling strictly after *start* and at or before *end*.
+        Otherwise derives them from :meth:`closing_dates_between` and
+        :meth:`due_date_for`.
+        """
+        if self._explicit_due_dates is not None:
+            start_d = start.date() if isinstance(start, datetime) else start
+            end_d = end.date() if isinstance(end, datetime) else end
+            return [d for d in self._explicit_due_dates if start_d < d <= end_d]
+
+        closing_dates = self.closing_dates_between(start, end)
+        return [self.due_date_for(cd).date() for cd in closing_dates]
 
     # ------------------------------------------------------------------
     # Statement building

--- a/money_warp/billing_cycle/monthly.py
+++ b/money_warp/billing_cycle/monthly.py
@@ -1,7 +1,7 @@
 """Monthly billing cycle — statements close on a fixed day each month."""
 
-from datetime import datetime, timedelta
-from typing import List
+from datetime import date, datetime, timedelta
+from typing import List, Optional
 
 from dateutil.relativedelta import relativedelta
 
@@ -16,9 +16,17 @@ class MonthlyBillingCycle(BaseBillingCycle):
         closing_day: Day of month (1-28) when the statement closes.
         payment_due_days: Number of days after closing for the payment
             due date.  Defaults to 15.
+        due_dates: Optional explicit due dates that override the computed
+            ones.  See :class:`BaseBillingCycle` for details.
     """
 
-    def __init__(self, closing_day: int = 1, payment_due_days: int = 15) -> None:
+    def __init__(
+        self,
+        closing_day: int = 1,
+        payment_due_days: int = 15,
+        due_dates: Optional[List[date]] = None,
+    ) -> None:
+        super().__init__(due_dates=due_dates)
         if not 1 <= closing_day <= 28:
             raise ValueError("closing_day must be between 1 and 28")
         if payment_due_days < 1:

--- a/money_warp/billing_cycle_loan/__init__.py
+++ b/money_warp/billing_cycle_loan/__init__.py
@@ -1,0 +1,11 @@
+"""Billing-cycle loan — fixed amortization with billing-cycle payment timing."""
+
+from .billing_cycle_loan import BillingCycleLoan
+from .mora_rate_resolver import MoraRateResolver
+from .statement import BillingCycleLoanStatement
+
+__all__ = [
+    "BillingCycleLoan",
+    "BillingCycleLoanStatement",
+    "MoraRateResolver",
+]

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -1,0 +1,579 @@
+"""BillingCycleLoan -- fixed amortization with billing-cycle payment timing."""
+
+import warnings
+from datetime import date, datetime
+from typing import Dict, List, Optional, Type
+
+from ..billing_cycle import BaseBillingCycle
+from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
+from ..interest_rate import InterestRate
+from ..loan.engines import (
+    InterestCalculator,
+    LoanState,
+    MoraStrategy,
+    build_installments,
+    covered_due_date_count,
+    is_payment_late,
+)
+from ..loan.installment import Installment
+from ..loan.settlement import Settlement
+from ..money import Money
+from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
+from ..time_context import TimeContext
+from ..tz import to_datetime, tz_aware
+from .engines import build_statements, compute_state, resolve_mora_rate
+from .mora_rate_resolver import MoraRateResolver
+from .statement import BillingCycleLoanStatement
+
+
+class BillingCycleLoan:
+    """Loan with fixed amortization and credit-card-like billing cycles.
+
+    Combines a traditional amortization schedule (Price / SAC) with
+    billing-cycle timing (monthly close + due date) and a mora
+    interest rate that can change per cycle via a callable resolver.
+
+    The CashFlow is the single source of truth, just like ``Loan``.
+    Settlements, installments, balances, and fines are all derived on
+    demand by a forward pass.
+
+    Args:
+        principal: Loan principal amount (must be positive).
+        interest_rate: Annual contractual interest rate.
+        billing_cycle: Billing cycle factory that generates closing and
+            due dates.
+        start_date: Start of the first billing period.  Closing dates
+            are generated after this date.
+        num_installments: Number of installments in the amortization.
+        disbursement_date: When funds are released.  Defaults to
+            ``now()``.  Must be before the first due date.
+        scheduler: Amortization strategy.  Defaults to
+            :class:`PriceScheduler`.
+        fine_rate: Rate for computing fines on missed payments.
+            Defaults to ``2% annual``.
+        grace_period_days: Days after due date before fines apply.
+        mora_interest_rate: Base mora rate.  Defaults to
+            *interest_rate*.
+        mora_rate_resolver: Optional callable that adjusts the base
+            mora rate per billing cycle.  Receives
+            ``(closing_date, base_mora_rate)`` and returns the
+            effective ``InterestRate`` for that cycle.
+        mora_strategy: How mora interest compounds.  Defaults to
+            :attr:`MoraStrategy.COMPOUND`.
+    """
+
+    @tz_aware
+    def __init__(
+        self,
+        principal: Money,
+        interest_rate: InterestRate,
+        billing_cycle: BaseBillingCycle,
+        start_date: datetime,
+        num_installments: int,
+        disbursement_date: Optional[datetime] = None,
+        scheduler: Optional[Type[BaseScheduler]] = None,
+        fine_rate: Optional[InterestRate] = None,
+        grace_period_days: int = 0,
+        mora_interest_rate: Optional[InterestRate] = None,
+        mora_rate_resolver: Optional[MoraRateResolver] = None,
+        mora_strategy: MoraStrategy = MoraStrategy.COMPOUND,
+    ) -> None:
+        if principal.is_negative() or principal.is_zero():
+            raise ValueError("Principal must be positive")
+        if num_installments < 1:
+            raise ValueError("num_installments must be at least 1")
+        if grace_period_days < 0:
+            raise ValueError("Grace period days must be non-negative")
+
+        self._time_ctx = TimeContext()
+
+        self.principal = principal
+        self.interest_rate = interest_rate
+        self.billing_cycle = billing_cycle
+        self.start_date = start_date
+        self.num_installments = num_installments
+        self.mora_interest_rate = mora_interest_rate or interest_rate
+        self.mora_rate_resolver = mora_rate_resolver
+        self.mora_strategy = mora_strategy
+        self.scheduler = scheduler or PriceScheduler
+        self.fine_rate = fine_rate if fine_rate is not None else InterestRate("2% annual")
+        self.grace_period_days = grace_period_days
+
+        self._interest = InterestCalculator(
+            interest_rate, self.mora_interest_rate, mora_strategy,
+        )
+        self._fine_observation_dates: List[datetime] = []
+
+        self._closing_dates = self._derive_closing_dates()
+        self.due_dates = self._derive_due_dates()
+
+        self.disbursement_date = (
+            disbursement_date if disbursement_date is not None else self._time_ctx.now()
+        )
+        if self.disbursement_date.date() >= self.due_dates[0]:
+            raise ValueError("disbursement_date must be before the first due date")
+
+        self.cashflow = self._build_initial_cashflow()
+
+    # ------------------------------------------------------------------
+    # Date derivation
+    # ------------------------------------------------------------------
+
+    def _derive_closing_dates(self) -> List[datetime]:
+        """Generate closing dates from the billing cycle."""
+        from dateutil.relativedelta import relativedelta
+
+        far_end = self.start_date + relativedelta(months=self.num_installments + 2)
+        all_dates = self.billing_cycle.closing_dates_between(self.start_date, far_end)
+        return all_dates[: self.num_installments]
+
+    def _derive_due_dates(self) -> List[date]:
+        """Derive payment due dates from the billing cycle.
+
+        When the billing cycle has explicit due dates, use a wide
+        enough end boundary so that due dates falling after the last
+        closing date (the normal case — due = close + offset) are
+        not accidentally excluded.
+        """
+        from dateutil.relativedelta import relativedelta
+
+        last_closing = (
+            self._closing_dates[-1] if self._closing_dates else self.start_date
+        )
+        search_end = last_closing + relativedelta(months=1)
+        explicit = self.billing_cycle.due_dates_between(self.start_date, search_end)
+        if explicit:
+            return explicit[: self.num_installments]
+
+        return [
+            self.billing_cycle.due_date_for(cd).date()
+            for cd in self._closing_dates
+        ]
+
+    @property
+    def closing_dates(self) -> List[datetime]:
+        """Closing dates for each billing period."""
+        return list(self._closing_dates)
+
+    # ------------------------------------------------------------------
+    # CashFlow construction
+    # ------------------------------------------------------------------
+
+    def _build_initial_cashflow(self) -> CashFlow:
+        """Build the initial CashFlow with expected items from the schedule."""
+        items: List[CashFlowItem] = []
+        ctx = self._time_ctx
+        expected = CashFlowType.EXPECTED
+
+        items.append(
+            CashFlowItem(
+                self.principal,
+                self.disbursement_date,
+                "Loan disbursement",
+                "disbursement",
+                kind=expected,
+                time_context=ctx,
+            )
+        )
+
+        schedule = self.get_original_schedule()
+        for entry in schedule:
+            due_dt = to_datetime(entry.due_date)
+            items.append(
+                CashFlowItem(
+                    Money(-entry.interest_payment.raw_amount),
+                    due_dt,
+                    f"Interest payment {entry.payment_number}",
+                    "interest",
+                    kind=expected,
+                    time_context=ctx,
+                )
+            )
+            items.append(
+                CashFlowItem(
+                    Money(-entry.principal_payment.raw_amount),
+                    due_dt,
+                    f"Principal payment {entry.payment_number}",
+                    "principal",
+                    kind=expected,
+                    time_context=ctx,
+                )
+            )
+
+        return CashFlow(items)
+
+    # ------------------------------------------------------------------
+    # Payment recording
+    # ------------------------------------------------------------------
+
+    @tz_aware
+    def record_payment(
+        self,
+        amount: Money,
+        payment_date: datetime,
+        interest_date: Optional[datetime] = None,
+        description: Optional[str] = None,
+    ) -> Settlement:
+        """Record a payment and return the derived settlement.
+
+        Args:
+            amount: Payment amount (must be positive).
+            payment_date: When the money moved.
+            interest_date: Cutoff for interest accrual.  Defaults to
+                *payment_date*.
+            description: Optional description.
+        """
+        if amount.is_negative() or amount.is_zero():
+            raise ValueError("Payment amount must be positive")
+
+        if interest_date is None:
+            interest_date = payment_date
+
+        self.cashflow.add_item(
+            CashFlowItem(
+                amount,
+                payment_date,
+                description or f"Payment on {payment_date.date()}",
+                "payment",
+                time_context=self._time_ctx,
+                interest_date=interest_date,
+            )
+        )
+
+        return self.settlements[-1]
+
+    def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
+        """Pay the next installment.
+
+        Interest accrual depends on timing:
+
+        - Early / on-time: accrues up to the due date.
+        - Late: accrues up to ``now()`` (mora kicks in).
+
+        When all installments are already paid the payment is recorded
+        as an overpayment.
+        """
+        payment_date = self.now()
+
+        if self._covered_due_date_count() >= len(self.due_dates):
+            warnings.warn(
+                f"All installments already paid. Recording {amount} as overpayment.",
+                stacklevel=2,
+            )
+            return self.record_payment(
+                amount,
+                payment_date=payment_date,
+                interest_date=payment_date,
+                description=description or "Overpayment",
+            )
+
+        next_due = self._next_unpaid_due_date()
+        interest_date = max(payment_date, to_datetime(next_due))
+        return self.record_payment(
+            amount,
+            payment_date=payment_date,
+            interest_date=interest_date,
+            description=description,
+        )
+
+    # ------------------------------------------------------------------
+    # Derived state
+    # ------------------------------------------------------------------
+
+    def _compute_state(self) -> LoanState:
+        """Run the forward pass with per-cycle mora rate resolution."""
+        return compute_state(
+            self.principal,
+            self._interest,
+            self.get_original_schedule(),
+            self.due_dates,
+            self._closing_dates,
+            self.fine_rate,
+            self.grace_period_days,
+            self.disbursement_date,
+            self._payment_entries(),
+            self.now(),
+            base_mora_rate=self.mora_interest_rate,
+            mora_rate_resolver=self.mora_rate_resolver,
+            fine_observation_dates=self._fine_observation_dates,
+        )
+
+    def _payment_entries(self) -> list:
+        """Payment CashFlowEntry objects, sorted by datetime."""
+        entries = [e for e in self.cashflow.items() if "payment" in e.category]
+        return sorted(entries, key=lambda e: e.datetime)
+
+    # ------------------------------------------------------------------
+    # Settlements and installments
+    # ------------------------------------------------------------------
+
+    @property
+    def settlements(self) -> List[Settlement]:
+        """All settlements (derived from CashFlow)."""
+        return self._compute_state().settlements
+
+    @property
+    def installments(self) -> List[Installment]:
+        """Installment view (derived from CashFlow)."""
+        state = self._compute_state()
+        return build_installments(
+            self.get_original_schedule(),
+            state.settlements,
+            state.fines_applied,
+            state.principal_balance,
+            self.now(),
+            self._interest,
+            state.last_payment_date,
+        )
+
+    @property
+    def statements(self) -> List[BillingCycleLoanStatement]:
+        """Billing-period statements (one per cycle)."""
+        state = self._compute_state()
+        return build_statements(
+            self.get_original_schedule(),
+            self.due_dates,
+            self._closing_dates,
+            self.billing_cycle,
+            state.settlements,
+            state.fines_applied,
+            self.principal,
+            self.mora_interest_rate,
+            self.mora_rate_resolver,
+        )
+
+    # ------------------------------------------------------------------
+    # Balance properties
+    # ------------------------------------------------------------------
+
+    @property
+    def principal_balance(self) -> Money:
+        """Outstanding principal."""
+        return self._compute_state().principal_balance
+
+    def _accrued_interest_components(self) -> tuple:
+        """Return (regular, mora) accrued since last payment."""
+        state = self._compute_state()
+        days = (self.now().date() - state.last_payment_date.date()).days
+
+        if state.principal_balance.is_positive() and days > 0:
+            covered = covered_due_date_count(
+                state.principal_balance, self.get_original_schedule(),
+            )
+            next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
+
+            mora_rate = resolve_mora_rate(
+                self.due_dates,
+                self._closing_dates,
+                next_due,
+                self.mora_interest_rate,
+                self.mora_rate_resolver,
+            )
+            return self._interest.compute_accrued_interest(
+                days,
+                state.principal_balance,
+                next_due,
+                state.last_payment_date,
+                mora_rate_override=mora_rate,
+            )
+
+        return Money.zero(), Money.zero()
+
+    @property
+    def interest_balance(self) -> Money:
+        """Regular accrued interest since last payment."""
+        return self._accrued_interest_components()[0]
+
+    @property
+    def mora_interest_balance(self) -> Money:
+        """Mora accrued interest since last payment."""
+        return self._accrued_interest_components()[1]
+
+    @property
+    def fine_balance(self) -> Money:
+        """Unpaid fines."""
+        state = self._compute_state()
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values()))
+            if state.fines_applied
+            else Money.zero()
+        )
+        outstanding = total_fines - state.fines_paid_total
+        return outstanding if outstanding.is_positive() else Money.zero()
+
+    @property
+    def current_balance(self) -> Money:
+        """Total outstanding balance."""
+        return (
+            self.principal_balance
+            + self.interest_balance
+            + self.mora_interest_balance
+            + self.fine_balance
+        )
+
+    @property
+    def is_paid_off(self) -> bool:
+        """Whether the loan is fully paid off."""
+        return self.current_balance.is_zero() or self.current_balance.is_negative()
+
+    @property
+    def overpaid(self) -> Money:
+        """Total amount paid beyond obligations."""
+        return self._compute_state().overpaid
+
+    # ------------------------------------------------------------------
+    # Fine-related
+    # ------------------------------------------------------------------
+
+    @property
+    def fines_applied(self) -> Dict[date, Money]:
+        """Fine amounts applied per due date."""
+        return self._compute_state().fines_applied
+
+    @property
+    def total_fines(self) -> Money:
+        """Total fines applied."""
+        fines = self.fines_applied
+        if not fines:
+            return Money.zero()
+        return Money(sum(f.raw_amount for f in fines.values()))
+
+    @tz_aware
+    def is_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
+        """Check if a payment is late considering the grace period."""
+        check = as_of_date if as_of_date is not None else self.now()
+        return is_payment_late(due_date, self.grace_period_days, check)
+
+    def _on_warp(self, target_date: datetime) -> None:
+        """Hook called by Warp after overriding TimeContext."""
+        self._fine_observation_dates.append(target_date)
+
+    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
+        """Compute and record fine observations as of a date.
+
+        Returns the amount of NEW fines applied.
+        """
+        as_of = as_of_date if as_of_date is not None else self.now()
+        old_total = self.total_fines
+        self._fine_observation_dates.append(as_of)
+        new_total = self.total_fines
+        return new_total - old_total
+
+    # ------------------------------------------------------------------
+    # Payment info
+    # ------------------------------------------------------------------
+
+    @property
+    def last_payment_date(self) -> datetime:
+        """Date of the last payment, or disbursement date if none."""
+        return self._compute_state().last_payment_date
+
+    def now(self) -> datetime:
+        """Current datetime (Warp-aware)."""
+        return self._time_ctx.now()
+
+    def days_since_last_payment(self) -> int:
+        """Days since the last payment."""
+        return (self.now().date() - self.last_payment_date.date()).days
+
+    def _covered_due_date_count(self) -> int:
+        return covered_due_date_count(self.principal_balance, self.get_original_schedule())
+
+    def _next_unpaid_due_date(self) -> date:
+        covered = self._covered_due_date_count()
+        if covered >= len(self.due_dates):
+            raise ValueError("All due dates have been paid")
+        return self.due_dates[covered]
+
+    # ------------------------------------------------------------------
+    # Schedule
+    # ------------------------------------------------------------------
+
+    def get_original_schedule(self) -> PaymentSchedule:
+        """The original amortization schedule (static, ignores payments)."""
+        return self.scheduler.generate_schedule(
+            self.principal,
+            self.interest_rate,
+            self.due_dates,
+            self.disbursement_date,
+        )
+
+    def get_amortization_schedule(self) -> PaymentSchedule:
+        """Current schedule: recorded past entries + projected future."""
+        state = self._compute_state()
+        if not state.settlements:
+            return self.get_original_schedule()
+
+        actual_entries: List[PaymentScheduleEntry] = []
+        prev_balance = self.principal
+        prev_date = self.disbursement_date
+
+        for i, s in enumerate(state.settlements):
+            days = (s.payment_date.date() - prev_date.date()).days
+            actual_entries.append(
+                PaymentScheduleEntry(
+                    payment_number=i + 1,
+                    due_date=s.payment_date.date(),
+                    days_in_period=days,
+                    beginning_balance=prev_balance,
+                    payment_amount=s.interest_paid + s.mora_paid + s.principal_paid,
+                    principal_payment=s.principal_paid,
+                    interest_payment=s.interest_paid + s.mora_paid,
+                    ending_balance=s.remaining_balance,
+                )
+            )
+            prev_balance = s.remaining_balance
+            prev_date = s.payment_date
+
+        covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
+        remaining_due_dates = self.due_dates[covered:]
+        if not remaining_due_dates:
+            return PaymentSchedule(entries=actual_entries)
+
+        if state.principal_balance.is_zero() or state.principal_balance.is_negative():
+            return PaymentSchedule(entries=actual_entries)
+
+        projected_schedule = self.scheduler.generate_schedule(
+            state.principal_balance,
+            self.interest_rate,
+            remaining_due_dates,
+            state.last_payment_date,
+        )
+
+        projected_entries: List[PaymentScheduleEntry] = []
+        for entry in projected_schedule:
+            projected_entries.append(
+                PaymentScheduleEntry(
+                    payment_number=len(actual_entries) + entry.payment_number,
+                    due_date=entry.due_date,
+                    days_in_period=entry.days_in_period,
+                    beginning_balance=entry.beginning_balance,
+                    payment_amount=entry.payment_amount,
+                    principal_payment=entry.principal_payment,
+                    interest_payment=entry.interest_payment,
+                    ending_balance=entry.ending_balance,
+                )
+            )
+
+        return PaymentSchedule(entries=actual_entries + projected_entries)
+
+    # ------------------------------------------------------------------
+    # Dunder
+    # ------------------------------------------------------------------
+
+    def __str__(self) -> str:
+        fine_info = f", fines={self.fine_balance}" if self.fine_balance.is_positive() else ""
+        return (
+            f"BillingCycleLoan(principal={self.principal}, rate={self.interest_rate}, "
+            f"payments={self.num_installments}, balance={self.current_balance}{fine_info})"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"BillingCycleLoan(principal={self.principal!r}, "
+            f"interest_rate={self.interest_rate!r}, "
+            f"billing_cycle={self.billing_cycle!r}, "
+            f"num_installments={self.num_installments!r}, "
+            f"mora_interest_rate={self.mora_interest_rate!r}, "
+            f"mora_strategy={self.mora_strategy!r})"
+        )

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -6,15 +6,9 @@ from typing import Dict, List, Optional, Type
 
 from ..billing_cycle import BaseBillingCycle
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
+from ..engines import InterestCalculator, MoraStrategy
 from ..interest_rate import InterestRate
-from ..loan.engines import (
-    InterestCalculator,
-    LoanState,
-    MoraStrategy,
-    build_installments,
-    covered_due_date_count,
-    is_payment_late,
-)
+from ..loan.engines import LoanState, build_installments, covered_due_date_count, is_payment_late
 from ..loan.installment import Installment
 from ..loan.settlement import Settlement
 from ..money import Money
@@ -100,16 +94,16 @@ class BillingCycleLoan:
         self.grace_period_days = grace_period_days
 
         self._interest = InterestCalculator(
-            interest_rate, self.mora_interest_rate, mora_strategy,
+            interest_rate,
+            self.mora_interest_rate,
+            mora_strategy,
         )
         self._fine_observation_dates: List[datetime] = []
 
         self._closing_dates = self._derive_closing_dates()
         self.due_dates = self._derive_due_dates()
 
-        self.disbursement_date = (
-            disbursement_date if disbursement_date is not None else self._time_ctx.now()
-        )
+        self.disbursement_date = disbursement_date if disbursement_date is not None else self._time_ctx.now()
         if self.disbursement_date.date() >= self.due_dates[0]:
             raise ValueError("disbursement_date must be before the first due date")
 
@@ -137,18 +131,13 @@ class BillingCycleLoan:
         """
         from dateutil.relativedelta import relativedelta
 
-        last_closing = (
-            self._closing_dates[-1] if self._closing_dates else self.start_date
-        )
+        last_closing = self._closing_dates[-1] if self._closing_dates else self.start_date
         search_end = last_closing + relativedelta(months=1)
         explicit = self.billing_cycle.due_dates_between(self.start_date, search_end)
         if explicit:
             return explicit[: self.num_installments]
 
-        return [
-            self.billing_cycle.due_date_for(cd).date()
-            for cd in self._closing_dates
-        ]
+        return [self.billing_cycle.due_date_for(cd).date() for cd in self._closing_dates]
 
     @property
     def closing_dates(self) -> List[datetime]:
@@ -358,7 +347,8 @@ class BillingCycleLoan:
 
         if state.principal_balance.is_positive() and days > 0:
             covered = covered_due_date_count(
-                state.principal_balance, self.get_original_schedule(),
+                state.principal_balance,
+                self.get_original_schedule(),
             )
             next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
 
@@ -394,9 +384,7 @@ class BillingCycleLoan:
         """Unpaid fines."""
         state = self._compute_state()
         total_fines = (
-            Money(sum(f.raw_amount for f in state.fines_applied.values()))
-            if state.fines_applied
-            else Money.zero()
+            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
         )
         outstanding = total_fines - state.fines_paid_total
         return outstanding if outstanding.is_positive() else Money.zero()
@@ -404,12 +392,7 @@ class BillingCycleLoan:
     @property
     def current_balance(self) -> Money:
         """Total outstanding balance."""
-        return (
-            self.principal_balance
-            + self.interest_balance
-            + self.mora_interest_balance
-            + self.fine_balance
-        )
+        return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
 
     @property
     def is_paid_off(self) -> bool:

--- a/money_warp/billing_cycle_loan/engines.py
+++ b/money_warp/billing_cycle_loan/engines.py
@@ -1,0 +1,294 @@
+"""Forward pass and statement builder for billing-cycle loans.
+
+Reuses allocation, distribution, fine, and coverage logic from
+:mod:`money_warp.loan.engines`.  The main difference is that the
+mora interest rate is resolved per billing cycle via an optional
+:class:`MoraRateResolver`.
+"""
+
+from datetime import date, datetime
+from typing import Dict, List, Optional, Tuple
+
+from ..billing_cycle import BaseBillingCycle
+from ..interest_rate import InterestRate
+from ..loan.engines import (
+    InterestCalculator,
+    LoanState,
+    _build_event_timeline,
+    _build_installments_snapshot,
+    _skipped_contractual_interest,
+    allocate_payment_into_installments,
+    compute_fines_at,
+    covered_due_date_count,
+)
+from ..loan.settlement import Settlement
+from ..money import Money
+from ..scheduler import PaymentSchedule
+from .mora_rate_resolver import MoraRateResolver
+from .statement import BillingCycleLoanStatement
+
+_COVERAGE_TOLERANCE = Money("0.01")
+
+
+# ------------------------------------------------------------------
+# Mora rate resolution
+# ------------------------------------------------------------------
+
+
+def resolve_mora_rate(
+    due_dates: List[date],
+    closing_dates: List[datetime],
+    current_due: Optional[date],
+    base_mora_rate: InterestRate,
+    resolver: Optional[MoraRateResolver],
+) -> InterestRate:
+    """Return the mora rate for the cycle that owns *current_due*.
+
+    Finds the closing date whose due date matches *current_due*,
+    then passes it to the resolver.  Falls back to *base_mora_rate*
+    when no resolver is provided or the due date cannot be mapped.
+    """
+    if resolver is None or current_due is None:
+        return base_mora_rate
+
+    for i, dd in enumerate(due_dates):
+        if dd == current_due and i < len(closing_dates):
+            return resolver(closing_dates[i].date(), base_mora_rate)
+
+    return base_mora_rate
+
+
+# ------------------------------------------------------------------
+# Forward pass
+# ------------------------------------------------------------------
+
+
+def compute_state(
+    principal: Money,
+    interest_calc: InterestCalculator,
+    schedule: PaymentSchedule,
+    due_dates: List[date],
+    closing_dates: List[datetime],
+    fine_rate: InterestRate,
+    grace_period_days: int,
+    disbursement_date: datetime,
+    payment_entries: list,
+    as_of: datetime,
+    base_mora_rate: InterestRate,
+    mora_rate_resolver: Optional[MoraRateResolver] = None,
+    fine_observation_dates: Optional[List[datetime]] = None,
+) -> LoanState:
+    """Forward pass adapted for billing-cycle loans.
+
+    Identical to :func:`money_warp.loan.engines.compute_state` except
+    that the mora rate is resolved per billing cycle via
+    *mora_rate_resolver* instead of using a fixed rate.
+    """
+    running_principal = principal
+    last_payment_date = disbursement_date
+    fines_applied: Dict[date, Money] = {}
+    fines_paid_total = Money.zero()
+    overpaid = Money.zero()
+    settlements = []
+    allocs_by_number: Dict[int, list] = {}
+    processed_payments: list = []
+
+    events = _build_event_timeline(payment_entries, fine_observation_dates)
+
+    for event_dt, is_payment, payment in events:
+        if event_dt > as_of:
+            break
+
+        fines_applied = compute_fines_at(
+            event_dt,
+            due_dates,
+            schedule,
+            fine_rate,
+            grace_period_days,
+            fines_applied,
+            processed_payments,
+        )
+
+        if not is_payment:
+            continue
+
+        interest_date = (
+            payment.interest_date
+            if payment.interest_date is not None
+            else payment.datetime
+        )
+        days = max(0, (interest_date.date() - last_payment_date.date()).days)
+
+        covered = covered_due_date_count(running_principal, schedule)
+        next_due = due_dates[covered] if covered < len(due_dates) else None
+
+        mora_rate = resolve_mora_rate(
+            due_dates, closing_dates, next_due, base_mora_rate, mora_rate_resolver,
+        )
+
+        regular, mora = interest_calc.compute_accrued_interest(
+            days,
+            running_principal,
+            next_due,
+            last_payment_date,
+            mora_rate_override=mora_rate,
+        )
+
+        installments = _build_installments_snapshot(
+            allocs_by_number,
+            running_principal,
+            payment.datetime,
+            schedule,
+            fines_applied,
+            interest_calc,
+            last_payment_date=last_payment_date,
+        )
+
+        skipped = _skipped_contractual_interest(installments, next_due, interest_date.date())
+        interest_cap = Money(regular.raw_amount + skipped.raw_amount)
+
+        total_fines = (
+            Money(sum(f.raw_amount for f in fines_applied.values()))
+            if fines_applied
+            else Money.zero()
+        )
+        fine_balance = total_fines - fines_paid_total
+        if fine_balance.is_negative():
+            fine_balance = Money.zero()
+
+        fine_paid, mora_paid, interest_paid, principal_paid, allocations = (
+            allocate_payment_into_installments(
+                payment.amount,
+                installments,
+                running_principal,
+                fine_cap=fine_balance,
+                interest_cap=interest_cap,
+                mora_cap=mora,
+            )
+        )
+
+        fines_paid_total = fines_paid_total + fine_paid
+        running_principal = running_principal - principal_paid
+        if running_principal.is_negative():
+            overpaid = overpaid + Money(-running_principal.raw_amount)
+            running_principal = Money.zero()
+        elif running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE:
+            running_principal = Money.zero()
+
+        for a in allocations:
+            allocs_by_number.setdefault(a.installment_number, []).append(a)
+
+        settlements.append(
+            Settlement(
+                payment_amount=payment.amount,
+                payment_date=payment.datetime,
+                fine_paid=fine_paid,
+                interest_paid=interest_paid,
+                mora_paid=mora_paid,
+                principal_paid=principal_paid,
+                remaining_balance=running_principal,
+                allocations=allocations,
+            )
+        )
+
+        last_payment_date = payment.datetime
+        processed_payments.append(payment)
+
+    return LoanState(
+        settlements=settlements,
+        principal_balance=running_principal,
+        fines_applied=fines_applied,
+        fines_paid_total=fines_paid_total,
+        last_payment_date=last_payment_date,
+        overpaid=overpaid,
+    )
+
+
+# ------------------------------------------------------------------
+# Statement builder
+# ------------------------------------------------------------------
+
+
+def build_statements(
+    schedule: PaymentSchedule,
+    due_dates: List[date],
+    closing_dates: List[datetime],
+    billing_cycle: BaseBillingCycle,
+    settlements: List,
+    fines_applied: Dict[date, Money],
+    principal: Money,
+    base_mora_rate: InterestRate,
+    mora_rate_resolver: Optional[MoraRateResolver] = None,
+) -> List[BillingCycleLoanStatement]:
+    """Build one :class:`BillingCycleLoanStatement` per billing period.
+
+    Walks closing dates, maps each to its schedule entry and
+    settlements, and produces a statement showing expected vs actual
+    activity for the period.
+    """
+    result: List[BillingCycleLoanStatement] = []
+    running_balance = principal
+
+    schedule_by_due: Dict[date, object] = {}
+    for entry in schedule:
+        schedule_by_due[entry.due_date] = entry
+
+    settlement_by_date: Dict[date, List] = {}
+    for s in settlements:
+        key = s.payment_date.date()
+        settlement_by_date.setdefault(key, []).append(s)
+
+    for idx, closing_date in enumerate(closing_dates):
+        if idx >= len(due_dates):
+            break
+
+        dd = due_dates[idx]
+        due_dt = billing_cycle.due_date_for(closing_date)
+        entry = schedule_by_due.get(dd)
+
+        expected_payment = entry.payment_amount if entry else Money.zero()
+        expected_principal = entry.principal_payment if entry else Money.zero()
+        expected_interest = entry.interest_payment if entry else Money.zero()
+
+        mora_rate = resolve_mora_rate(
+            due_dates, closing_dates, dd, base_mora_rate, mora_rate_resolver,
+        )
+
+        fine_charged = fines_applied.get(dd, Money.zero())
+
+        prev_closing = closing_dates[idx - 1] if idx > 0 else None
+        payments_received = Money.zero()
+        mora_charged = Money.zero()
+        for s_list in settlement_by_date.values():
+            for s in s_list:
+                in_period = (
+                    (prev_closing is None or s.payment_date > prev_closing)
+                    and s.payment_date <= closing_date
+                )
+                if in_period:
+                    payments_received = payments_received + s.payment_amount
+                    mora_charged = mora_charged + s.mora_paid
+
+        opening_balance = running_balance
+        running_balance = running_balance - expected_principal
+        if running_balance.is_negative():
+            running_balance = Money.zero()
+
+        result.append(
+            BillingCycleLoanStatement(
+                period_number=idx + 1,
+                closing_date=closing_date,
+                due_date=due_dt,
+                opening_balance=opening_balance,
+                expected_payment=expected_payment,
+                expected_principal=expected_principal,
+                expected_interest=expected_interest,
+                mora_rate=mora_rate,
+                mora_charged=mora_charged,
+                fine_charged=fine_charged,
+                payments_received=payments_received,
+                closing_balance=running_balance,
+            )
+        )
+
+    return result

--- a/money_warp/billing_cycle_loan/engines.py
+++ b/money_warp/billing_cycle_loan/engines.py
@@ -1,34 +1,24 @@
-"""Forward pass and statement builder for billing-cycle loans.
+"""Billing-cycle loan engine — product-specific logic only.
 
-Reuses allocation, distribution, fine, and coverage logic from
-:mod:`money_warp.loan.engines`.  The main difference is that the
-mora interest rate is resolved per billing cycle via an optional
-:class:`MoraRateResolver`.
+Mora rate resolution and statement building live here.
+The forward pass and all allocation logic come from
+:mod:`money_warp.loan.engines`.  Shared building blocks come from
+:mod:`money_warp.engines`.
 """
 
 from datetime import date, datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional
 
 from ..billing_cycle import BaseBillingCycle
+from ..engines import InterestCalculator, MoraRateCallback
 from ..interest_rate import InterestRate
-from ..loan.engines import (
-    InterestCalculator,
-    LoanState,
-    _build_event_timeline,
-    _build_installments_snapshot,
-    _skipped_contractual_interest,
-    allocate_payment_into_installments,
-    compute_fines_at,
-    covered_due_date_count,
-)
+from ..loan.engines import LoanState
+from ..loan.engines import compute_state as _compute_state
 from ..loan.settlement import Settlement
 from ..money import Money
 from ..scheduler import PaymentSchedule
 from .mora_rate_resolver import MoraRateResolver
 from .statement import BillingCycleLoanStatement
-
-_COVERAGE_TOLERANCE = Money("0.01")
-
 
 # ------------------------------------------------------------------
 # Mora rate resolution
@@ -58,8 +48,28 @@ def resolve_mora_rate(
     return base_mora_rate
 
 
+def make_mora_callback(
+    due_dates: List[date],
+    closing_dates: List[datetime],
+    base_mora_rate: InterestRate,
+    resolver: Optional[MoraRateResolver],
+) -> MoraRateCallback:
+    """Build a :data:`~money_warp.engines.MoraRateCallback` for the forward pass.
+
+    Returns ``None`` when no resolver is set (the unified
+    ``compute_state`` then uses the calculator's default rate).
+    """
+    if resolver is None:
+        return None
+
+    def _callback(next_due: Optional[date]) -> Optional[InterestRate]:
+        return resolve_mora_rate(due_dates, closing_dates, next_due, base_mora_rate, resolver)
+
+    return _callback
+
+
 # ------------------------------------------------------------------
-# Forward pass
+# Forward pass (delegates to unified compute_state)
 # ------------------------------------------------------------------
 
 
@@ -78,129 +88,25 @@ def compute_state(
     mora_rate_resolver: Optional[MoraRateResolver] = None,
     fine_observation_dates: Optional[List[datetime]] = None,
 ) -> LoanState:
-    """Forward pass adapted for billing-cycle loans.
+    """Forward pass for billing-cycle loans.
 
-    Identical to :func:`money_warp.loan.engines.compute_state` except
-    that the mora rate is resolved per billing cycle via
-    *mora_rate_resolver* instead of using a fixed rate.
+    Wraps :func:`money_warp.loan.engines.compute_state` with a
+    ``mora_rate_for_event`` callback that resolves the mora rate
+    per billing cycle.
     """
-    running_principal = principal
-    last_payment_date = disbursement_date
-    fines_applied: Dict[date, Money] = {}
-    fines_paid_total = Money.zero()
-    overpaid = Money.zero()
-    settlements = []
-    allocs_by_number: Dict[int, list] = {}
-    processed_payments: list = []
-
-    events = _build_event_timeline(payment_entries, fine_observation_dates)
-
-    for event_dt, is_payment, payment in events:
-        if event_dt > as_of:
-            break
-
-        fines_applied = compute_fines_at(
-            event_dt,
-            due_dates,
-            schedule,
-            fine_rate,
-            grace_period_days,
-            fines_applied,
-            processed_payments,
-        )
-
-        if not is_payment:
-            continue
-
-        interest_date = (
-            payment.interest_date
-            if payment.interest_date is not None
-            else payment.datetime
-        )
-        days = max(0, (interest_date.date() - last_payment_date.date()).days)
-
-        covered = covered_due_date_count(running_principal, schedule)
-        next_due = due_dates[covered] if covered < len(due_dates) else None
-
-        mora_rate = resolve_mora_rate(
-            due_dates, closing_dates, next_due, base_mora_rate, mora_rate_resolver,
-        )
-
-        regular, mora = interest_calc.compute_accrued_interest(
-            days,
-            running_principal,
-            next_due,
-            last_payment_date,
-            mora_rate_override=mora_rate,
-        )
-
-        installments = _build_installments_snapshot(
-            allocs_by_number,
-            running_principal,
-            payment.datetime,
-            schedule,
-            fines_applied,
-            interest_calc,
-            last_payment_date=last_payment_date,
-        )
-
-        skipped = _skipped_contractual_interest(installments, next_due, interest_date.date())
-        interest_cap = Money(regular.raw_amount + skipped.raw_amount)
-
-        total_fines = (
-            Money(sum(f.raw_amount for f in fines_applied.values()))
-            if fines_applied
-            else Money.zero()
-        )
-        fine_balance = total_fines - fines_paid_total
-        if fine_balance.is_negative():
-            fine_balance = Money.zero()
-
-        fine_paid, mora_paid, interest_paid, principal_paid, allocations = (
-            allocate_payment_into_installments(
-                payment.amount,
-                installments,
-                running_principal,
-                fine_cap=fine_balance,
-                interest_cap=interest_cap,
-                mora_cap=mora,
-            )
-        )
-
-        fines_paid_total = fines_paid_total + fine_paid
-        running_principal = running_principal - principal_paid
-        if running_principal.is_negative():
-            overpaid = overpaid + Money(-running_principal.raw_amount)
-            running_principal = Money.zero()
-        elif running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE:
-            running_principal = Money.zero()
-
-        for a in allocations:
-            allocs_by_number.setdefault(a.installment_number, []).append(a)
-
-        settlements.append(
-            Settlement(
-                payment_amount=payment.amount,
-                payment_date=payment.datetime,
-                fine_paid=fine_paid,
-                interest_paid=interest_paid,
-                mora_paid=mora_paid,
-                principal_paid=principal_paid,
-                remaining_balance=running_principal,
-                allocations=allocations,
-            )
-        )
-
-        last_payment_date = payment.datetime
-        processed_payments.append(payment)
-
-    return LoanState(
-        settlements=settlements,
-        principal_balance=running_principal,
-        fines_applied=fines_applied,
-        fines_paid_total=fines_paid_total,
-        last_payment_date=last_payment_date,
-        overpaid=overpaid,
+    callback = make_mora_callback(due_dates, closing_dates, base_mora_rate, mora_rate_resolver)
+    return _compute_state(
+        principal=principal,
+        interest_calc=interest_calc,
+        schedule=schedule,
+        due_dates=due_dates,
+        fine_rate=fine_rate,
+        grace_period_days=grace_period_days,
+        disbursement_date=disbursement_date,
+        payment_entries=payment_entries,
+        as_of=as_of,
+        fine_observation_dates=fine_observation_dates,
+        mora_rate_for_event=callback,
     )
 
 
@@ -214,7 +120,7 @@ def build_statements(
     due_dates: List[date],
     closing_dates: List[datetime],
     billing_cycle: BaseBillingCycle,
-    settlements: List,
+    settlements: List[Settlement],
     fines_applied: Dict[date, Money],
     principal: Money,
     base_mora_rate: InterestRate,
@@ -251,7 +157,11 @@ def build_statements(
         expected_interest = entry.interest_payment if entry else Money.zero()
 
         mora_rate = resolve_mora_rate(
-            due_dates, closing_dates, dd, base_mora_rate, mora_rate_resolver,
+            due_dates,
+            closing_dates,
+            dd,
+            base_mora_rate,
+            mora_rate_resolver,
         )
 
         fine_charged = fines_applied.get(dd, Money.zero())
@@ -261,10 +171,7 @@ def build_statements(
         mora_charged = Money.zero()
         for s_list in settlement_by_date.values():
             for s in s_list:
-                in_period = (
-                    (prev_closing is None or s.payment_date > prev_closing)
-                    and s.payment_date <= closing_date
-                )
+                in_period = (prev_closing is None or s.payment_date > prev_closing) and s.payment_date <= closing_date
                 if in_period:
                     payments_received = payments_received + s.payment_amount
                     mora_charged = mora_charged + s.mora_paid

--- a/money_warp/billing_cycle_loan/mora_rate_resolver.py
+++ b/money_warp/billing_cycle_loan/mora_rate_resolver.py
@@ -1,0 +1,22 @@
+"""Protocol for resolving mora interest rates per billing cycle."""
+
+from datetime import date
+from typing import Protocol, runtime_checkable
+
+from ..interest_rate import InterestRate
+
+
+@runtime_checkable
+class MoraRateResolver(Protocol):
+    """Callable that returns the mora rate for a given billing cycle.
+
+    Receives the cycle's reference date (typically the closing date)
+    and the base mora rate configured on the loan.  Returns the
+    ``InterestRate`` to use for mora computation in that cycle.
+
+    Implementations are free to ignore the base rate and return an
+    entirely independent value, or to adjust it (e.g. add a spread
+    on top of an external index).
+    """
+
+    def __call__(self, reference_date: date, base_mora_rate: InterestRate) -> InterestRate: ...

--- a/money_warp/billing_cycle_loan/statement.py
+++ b/money_warp/billing_cycle_loan/statement.py
@@ -1,0 +1,30 @@
+"""Billing-cycle loan statement — one per billing period."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ..interest_rate import InterestRate
+from ..money import Money
+
+
+@dataclass(frozen=True)
+class BillingCycleLoanStatement:
+    """Snapshot of a single billing period for a billing-cycle loan.
+
+    Combines the amortization schedule view (expected principal /
+    interest) with the actual payment activity and any mora / fine
+    charges for the period.
+    """
+
+    period_number: int
+    closing_date: datetime
+    due_date: datetime
+    opening_balance: Money
+    expected_payment: Money
+    expected_principal: Money
+    expected_interest: Money
+    mora_rate: InterestRate
+    mora_charged: Money
+    fine_charged: Money
+    payments_received: Money
+    closing_balance: Money

--- a/money_warp/engines.py
+++ b/money_warp/engines.py
@@ -1,0 +1,104 @@
+"""Shared engine building blocks for loan products.
+
+Types and classes that are used by multiple product modules
+(``loan``, ``billing_cycle_loan``) live here to avoid circular
+imports.  The full forward-pass logic and allocation helpers stay
+in :mod:`money_warp.loan.engines` (which imports from here).
+"""
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Callable, Optional, Tuple
+
+from .interest_rate import InterestRate
+from .money import Money
+
+# ===================================================================
+# Mora strategy
+# ===================================================================
+
+
+class MoraStrategy(Enum):
+    """Strategy for computing mora (late) interest.
+
+    SIMPLE: mora rate is applied to the outstanding principal only.
+    COMPOUND: mora rate is applied to principal + accrued regular interest.
+    """
+
+    SIMPLE = "simple"
+    COMPOUND = "compound"
+
+
+# ===================================================================
+# Interest calculator
+# ===================================================================
+
+
+class InterestCalculator:
+    """Pure interest math — no mutable state, no time context.
+
+    Holds three immutable rate parameters and computes accrued interest
+    split into regular and mora components.
+    """
+
+    def __init__(
+        self,
+        interest_rate: InterestRate,
+        mora_interest_rate: InterestRate,
+        mora_strategy: MoraStrategy = MoraStrategy.COMPOUND,
+    ) -> None:
+        self.interest_rate = interest_rate
+        self.mora_interest_rate = mora_interest_rate
+        self.mora_strategy = mora_strategy
+
+    def compute_accrued_interest(
+        self,
+        days: int,
+        principal_balance: Money,
+        due_date: Optional[date] = None,
+        last_payment_date: Optional[datetime] = None,
+        mora_rate_override: Optional[InterestRate] = None,
+    ) -> Tuple[Money, Money]:
+        """Compute accrued interest split into regular and mora components.
+
+        Returns (regular_accrued, mora_accrued). All interest is regular when
+        due_date is not provided or the payment is not late.
+
+        Args:
+            mora_rate_override: When provided, used instead of
+                ``self.mora_interest_rate`` for this single computation.
+                Existing callers that omit it get the original behaviour.
+        """
+        mora_rate = mora_rate_override or self.mora_interest_rate
+
+        if due_date is None or last_payment_date is None:
+            return self.interest_rate.accrue(principal_balance, days), Money.zero()
+
+        regular_days = (due_date - last_payment_date.date()).days
+
+        if regular_days <= 0:
+            return Money.zero(), mora_rate.accrue(principal_balance, days)
+
+        if regular_days >= days:
+            return self.interest_rate.accrue(principal_balance, days), Money.zero()
+
+        mora_days = days - regular_days
+        regular_accrued = self.interest_rate.accrue(principal_balance, regular_days)
+
+        if self.mora_strategy == MoraStrategy.COMPOUND:
+            mora_accrued = mora_rate.accrue(principal_balance + regular_accrued, mora_days)
+        else:
+            mora_accrued = mora_rate.accrue(principal_balance, mora_days)
+
+        return regular_accrued, mora_accrued
+
+
+# ===================================================================
+# Mora rate callback type
+# ===================================================================
+
+#: Optional callback that resolves a mora rate override for a given
+#: payment event.  Receives the *next_due* date (or ``None`` when all
+#: installments are covered) and returns an ``InterestRate`` to use,
+#: or ``None`` to fall back to the calculator's default.
+MoraRateCallback = Optional[Callable[[Optional[date]], Optional[InterestRate]]]

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -59,20 +59,27 @@ class InterestCalculator:
         principal_balance: Money,
         due_date: Optional[date] = None,
         last_payment_date: Optional[datetime] = None,
+        mora_rate_override: Optional[InterestRate] = None,
     ) -> Tuple[Money, Money]:
         """Compute accrued interest split into regular and mora components.
 
         Returns (regular_accrued, mora_accrued). All interest is regular when
-        due_date is not provided or the payment is not late. Uses
-        ``mora_interest_rate`` and ``mora_strategy`` for the mora portion.
+        due_date is not provided or the payment is not late.
+
+        Args:
+            mora_rate_override: When provided, used instead of
+                ``self.mora_interest_rate`` for this single computation.
+                Existing callers that omit it get the original behaviour.
         """
+        mora_rate = mora_rate_override or self.mora_interest_rate
+
         if due_date is None or last_payment_date is None:
             return self.interest_rate.accrue(principal_balance, days), Money.zero()
 
         regular_days = (due_date - last_payment_date.date()).days
 
         if regular_days <= 0:
-            return Money.zero(), self.mora_interest_rate.accrue(principal_balance, days)
+            return Money.zero(), mora_rate.accrue(principal_balance, days)
 
         if regular_days >= days:
             return self.interest_rate.accrue(principal_balance, days), Money.zero()
@@ -81,9 +88,9 @@ class InterestCalculator:
         regular_accrued = self.interest_rate.accrue(principal_balance, regular_days)
 
         if self.mora_strategy == MoraStrategy.COMPOUND:
-            mora_accrued = self.mora_interest_rate.accrue(principal_balance + regular_accrued, mora_days)
+            mora_accrued = mora_rate.accrue(principal_balance + regular_accrued, mora_days)
         else:
-            mora_accrued = self.mora_interest_rate.accrue(principal_balance, mora_days)
+            mora_accrued = mora_rate.accrue(principal_balance, mora_days)
 
         return regular_accrued, mora_accrued
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -5,13 +5,21 @@ components.  Settlement computation replays payments against the
 schedule using a forward pass.  Each payment is allocated in two
 steps: loan-level math (fine -> mora -> interest -> principal)
 followed by per-installment distribution for reporting.
+
+Shared building blocks (:class:`InterestCalculator`,
+:class:`MoraStrategy`) are defined in :mod:`money_warp.engines`
+and re-exported here for backward compatibility.
 """
 
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
+from ..engines import (  # noqa: F401 – re-export
+    InterestCalculator,
+    MoraRateCallback,
+    MoraStrategy,
+)
 from ..interest_rate import InterestRate
 from ..money import Money
 from ..scheduler import PaymentSchedule
@@ -19,81 +27,6 @@ from ..tz import to_datetime
 from .allocation import Allocation
 from .installment import Installment
 from .settlement import Settlement
-
-# ===================================================================
-# Interest calculator
-# ===================================================================
-
-
-class MoraStrategy(Enum):
-    """Strategy for computing mora (late) interest.
-
-    SIMPLE: mora rate is applied to the outstanding principal only.
-    COMPOUND: mora rate is applied to principal + accrued regular interest.
-    """
-
-    SIMPLE = "simple"
-    COMPOUND = "compound"
-
-
-class InterestCalculator:
-    """Pure interest math — no mutable state, no time context.
-
-    Holds three immutable rate parameters and computes accrued interest
-    split into regular and mora components.
-    """
-
-    def __init__(
-        self,
-        interest_rate: InterestRate,
-        mora_interest_rate: InterestRate,
-        mora_strategy: MoraStrategy = MoraStrategy.COMPOUND,
-    ) -> None:
-        self.interest_rate = interest_rate
-        self.mora_interest_rate = mora_interest_rate
-        self.mora_strategy = mora_strategy
-
-    def compute_accrued_interest(
-        self,
-        days: int,
-        principal_balance: Money,
-        due_date: Optional[date] = None,
-        last_payment_date: Optional[datetime] = None,
-        mora_rate_override: Optional[InterestRate] = None,
-    ) -> Tuple[Money, Money]:
-        """Compute accrued interest split into regular and mora components.
-
-        Returns (regular_accrued, mora_accrued). All interest is regular when
-        due_date is not provided or the payment is not late.
-
-        Args:
-            mora_rate_override: When provided, used instead of
-                ``self.mora_interest_rate`` for this single computation.
-                Existing callers that omit it get the original behaviour.
-        """
-        mora_rate = mora_rate_override or self.mora_interest_rate
-
-        if due_date is None or last_payment_date is None:
-            return self.interest_rate.accrue(principal_balance, days), Money.zero()
-
-        regular_days = (due_date - last_payment_date.date()).days
-
-        if regular_days <= 0:
-            return Money.zero(), mora_rate.accrue(principal_balance, days)
-
-        if regular_days >= days:
-            return self.interest_rate.accrue(principal_balance, days), Money.zero()
-
-        mora_days = days - regular_days
-        regular_accrued = self.interest_rate.accrue(principal_balance, regular_days)
-
-        if self.mora_strategy == MoraStrategy.COMPOUND:
-            mora_accrued = mora_rate.accrue(principal_balance + regular_accrued, mora_days)
-        else:
-            mora_accrued = mora_rate.accrue(principal_balance, mora_days)
-
-        return regular_accrued, mora_accrued
-
 
 # ===================================================================
 # Settlement engine
@@ -321,14 +254,16 @@ def distribute_into_installments(
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
         if total.is_positive():
             is_covered = total >= (inst.balance - _COVERAGE_TOLERANCE)
-            allocations.append(Allocation(
-                installment_number=inst.number,
-                principal_allocated=principal_alloc,
-                interest_allocated=interest_alloc,
-                mora_allocated=mora_alloc,
-                fine_allocated=fine_alloc,
-                is_fully_covered=is_covered,
-            ))
+            allocations.append(
+                Allocation(
+                    installment_number=inst.number,
+                    principal_allocated=principal_alloc,
+                    interest_allocated=interest_alloc,
+                    mora_allocated=mora_alloc,
+                    fine_allocated=fine_alloc,
+                    is_fully_covered=is_covered,
+                )
+            )
 
     _apply_residual(allocations, installments, fine_total, mora_total, interest_total, principal_total)
     _apply_coverage_fixup(allocations, installments, ending_balance, principal_total)
@@ -440,11 +375,19 @@ def allocate_payment_into_installments(
         (fine_total, mora_total, interest_total, principal_total, allocations)
     """
     fine_paid, mora_paid, interest_paid, principal_paid = allocate_payment(
-        amount, fine_cap, mora_cap, interest_cap,
+        amount,
+        fine_cap,
+        mora_cap,
+        interest_cap,
     )
 
     allocations = distribute_into_installments(
-        installments, fine_paid, mora_paid, interest_paid, principal_paid, ending_balance,
+        installments,
+        fine_paid,
+        mora_paid,
+        interest_paid,
+        principal_paid,
+        ending_balance,
     )
 
     return fine_paid, mora_paid, interest_paid, principal_paid, allocations
@@ -539,6 +482,7 @@ def compute_state(
     payment_entries: list,
     as_of: datetime,
     fine_observation_dates: Optional[List[datetime]] = None,
+    mora_rate_for_event: MoraRateCallback = None,
 ) -> LoanState:
     """Forward pass: compute all settlements and derived state from payments.
 
@@ -549,8 +493,16 @@ def compute_state(
     Fines are computed at each payment date AND at any explicit
     ``fine_observation_dates`` (from Warp or calculate_late_fines calls).
     Without observation dates, fines are only computed when payments
-    are processed -- matching the old behavior where fines required
-    an explicit trigger.
+    are processed.
+
+    Args:
+        mora_rate_for_event: Optional callback ``(next_due) -> InterestRate``
+            called before each interest computation.  When it returns a
+            non-``None`` value, that rate is passed as
+            ``mora_rate_override`` to the interest calculator.  Used by
+            ``BillingCycleLoan`` to resolve per-cycle mora rates.
+            ``Loan`` omits this (``None``), getting the calculator's
+            default mora rate.
     """
     running_principal = principal
     last_payment_date = disbursement_date
@@ -586,11 +538,14 @@ def compute_state(
         covered = covered_due_date_count(running_principal, schedule)
         next_due = due_dates[covered] if covered < len(due_dates) else None
 
+        mora_override = mora_rate_for_event(next_due) if mora_rate_for_event else None
+
         regular, mora = interest_calc.compute_accrued_interest(
             days,
             running_principal,
             next_due,
             last_payment_date,
+            mora_rate_override=mora_override,
         )
 
         installments = _build_installments_snapshot(

--- a/tests/billing_cycle_loan/conftest.py
+++ b/tests/billing_cycle_loan/conftest.py
@@ -1,0 +1,60 @@
+"""Shared fixtures for billing-cycle loan tests."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import BillingCycleLoan, InterestRate, Money
+from money_warp.billing_cycle import MonthlyBillingCycle
+from money_warp.loan.engines import MoraStrategy
+
+
+@pytest.fixture
+def billing_cycle():
+    """Monthly billing cycle: closes on the 28th, due 15 days later."""
+    return MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+
+
+@pytest.fixture
+def simple_loan(billing_cycle):
+    """3-installment billing-cycle loan, no mora resolver.
+
+    Principal: 3000, Rate: 12% annual, Start: 2025-01-01.
+    Closing dates: Jan 28, Feb 28, Mar 28.
+    Due dates: Feb 12, Mar 15, Apr 12.
+    Disbursement: 2025-01-01.
+    """
+    return BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=billing_cycle,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def variable_mora_loan(billing_cycle):
+    """3-installment loan with a variable mora resolver.
+
+    The resolver doubles the base mora rate for any cycle closing
+    after Feb 28, simulating an external index jump.
+    """
+
+    def resolver(ref_date: date, base: InterestRate) -> InterestRate:
+        if ref_date > date(2025, 2, 28):
+            return InterestRate(f"{base.as_decimal() * 2 * 100}% a")
+        return base
+
+    return BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=billing_cycle,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("12% a"),
+        mora_rate_resolver=resolver,
+        mora_strategy=MoraStrategy.COMPOUND,
+    )

--- a/tests/billing_cycle_loan/test_billing_cycle_due_dates.py
+++ b/tests/billing_cycle_loan/test_billing_cycle_due_dates.py
@@ -1,0 +1,54 @@
+"""Tests for BaseBillingCycle.due_dates_between."""
+
+from datetime import date, datetime, timezone
+
+from money_warp.billing_cycle import MonthlyBillingCycle
+
+
+def test_derived_due_dates_from_closing_dates():
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+    result = bc.due_dates_between(
+        datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime(2025, 4, 30, tzinfo=timezone.utc),
+    )
+    assert result == [
+        date(2025, 2, 12),
+        date(2025, 3, 15),
+        date(2025, 4, 12),
+        date(2025, 5, 13),
+    ]
+
+
+def test_explicit_due_dates_override():
+    explicit = [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15, due_dates=explicit)
+    result = bc.due_dates_between(
+        datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime(2025, 4, 30, tzinfo=timezone.utc),
+    )
+    assert result == [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+
+
+def test_explicit_due_dates_filtered_by_range():
+    explicit = [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15, due_dates=explicit)
+    result = bc.due_dates_between(
+        datetime(2025, 2, 15, tzinfo=timezone.utc),
+        datetime(2025, 3, 15, tzinfo=timezone.utc),
+    )
+    assert result == [date(2025, 3, 10)]
+
+
+def test_explicit_due_dates_sorted():
+    unsorted = [date(2025, 4, 10), date(2025, 2, 10), date(2025, 3, 10)]
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15, due_dates=unsorted)
+    result = bc.due_dates_between(
+        datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime(2025, 5, 1, tzinfo=timezone.utc),
+    )
+    assert result == [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+
+
+def test_no_explicit_due_dates_returns_none():
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+    assert bc._explicit_due_dates is None

--- a/tests/billing_cycle_loan/test_creation.py
+++ b/tests/billing_cycle_loan/test_creation.py
@@ -1,0 +1,82 @@
+"""Tests for BillingCycleLoan construction and date derivation."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import BillingCycleLoan, InterestRate, Money
+from money_warp.billing_cycle import MonthlyBillingCycle
+
+
+def test_due_dates_derived_from_billing_cycle(simple_loan):
+    assert simple_loan.due_dates == [
+        date(2025, 2, 12),
+        date(2025, 3, 15),
+        date(2025, 4, 12),
+    ]
+
+
+def test_closing_dates_derived_from_billing_cycle(simple_loan):
+    closing = [cd.date() for cd in simple_loan.closing_dates]
+    assert closing == [
+        date(2025, 1, 28),
+        date(2025, 2, 28),
+        date(2025, 3, 28),
+    ]
+
+
+def test_explicit_due_dates_on_billing_cycle():
+    explicit = [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15, due_dates=explicit)
+    loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=bc,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    assert loan.due_dates == [date(2025, 2, 10), date(2025, 3, 10), date(2025, 4, 10)]
+
+
+def test_principal_must_be_positive(billing_cycle):
+    with pytest.raises(ValueError, match="Principal must be positive"):
+        BillingCycleLoan(
+            principal=Money("0.00"),
+            interest_rate=InterestRate("12% a"),
+            billing_cycle=billing_cycle,
+            start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            num_installments=3,
+        )
+
+
+def test_num_installments_must_be_positive(billing_cycle):
+    with pytest.raises(ValueError, match="num_installments must be at least 1"):
+        BillingCycleLoan(
+            principal=Money("3000.00"),
+            interest_rate=InterestRate("12% a"),
+            billing_cycle=billing_cycle,
+            start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            num_installments=0,
+        )
+
+
+def test_disbursement_must_be_before_first_due(billing_cycle):
+    with pytest.raises(ValueError, match="disbursement_date must be before"):
+        BillingCycleLoan(
+            principal=Money("3000.00"),
+            interest_rate=InterestRate("12% a"),
+            billing_cycle=billing_cycle,
+            start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            num_installments=3,
+            disbursement_date=datetime(2025, 3, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_mora_defaults_to_interest_rate(simple_loan):
+    assert simple_loan.mora_interest_rate == simple_loan.interest_rate
+
+
+def test_original_schedule_has_correct_num_entries(simple_loan):
+    schedule = simple_loan.get_original_schedule()
+    assert len(schedule) == 3

--- a/tests/billing_cycle_loan/test_late_payments.py
+++ b/tests/billing_cycle_loan/test_late_payments.py
@@ -1,0 +1,35 @@
+"""Tests for late payments and fines on billing-cycle loans."""
+
+from datetime import datetime, timezone
+
+from money_warp import Money
+
+
+def test_late_payment_incurs_mora_and_fine(simple_loan):
+    s = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+    assert s.fine_paid == Money("20.45")
+    assert s.mora_paid == Money("18.93")
+    assert s.interest_paid == Money("39.38")
+    assert s.principal_paid == Money("943.82")
+
+
+def test_late_payment_remaining_balance(simple_loan):
+    s = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+    assert s.remaining_balance == Money("2056.18")
+
+
+def test_late_payment_allocation_not_fully_covered(simple_loan):
+    s = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+    assert s.allocations[0].is_fully_covered is False
+
+
+def test_fines_applied_after_observation(simple_loan):
+    fines = simple_loan.calculate_late_fines(datetime(2025, 3, 1, tzinfo=timezone.utc))
+    assert fines == Money("20.45")
+    assert simple_loan.fine_balance == Money("20.45")

--- a/tests/billing_cycle_loan/test_schedule.py
+++ b/tests/billing_cycle_loan/test_schedule.py
@@ -1,0 +1,27 @@
+"""Tests for BillingCycleLoan amortization schedule."""
+
+from money_warp import Money
+
+
+def test_original_schedule_payment_amounts(simple_loan):
+    schedule = simple_loan.get_original_schedule()
+    assert schedule[0].payment_amount == Money("1022.58")
+    assert schedule[1].payment_amount == Money("1022.58")
+    assert schedule[2].payment_amount == Money("1022.58")
+
+
+def test_original_schedule_principal_interest_split(simple_loan):
+    schedule = simple_loan.get_original_schedule()
+    assert schedule[0].principal_payment == Money("983.20")
+    assert schedule[0].interest_payment == Money("39.38")
+    assert schedule[1].principal_payment == Money("1003.07")
+    assert schedule[1].interest_payment == Money("19.51")
+    assert schedule[2].principal_payment == Money("1013.73")
+    assert schedule[2].interest_payment == Money("8.85")
+
+
+def test_original_schedule_ending_balance(simple_loan):
+    schedule = simple_loan.get_original_schedule()
+    assert schedule[0].ending_balance == Money("2016.80")
+    assert schedule[1].ending_balance == Money("1013.73")
+    assert schedule[2].ending_balance == Money("0.00")

--- a/tests/billing_cycle_loan/test_settlements.py
+++ b/tests/billing_cycle_loan/test_settlements.py
@@ -1,0 +1,57 @@
+"""Tests for BillingCycleLoan payment settlements."""
+
+from datetime import datetime, timezone
+
+from money_warp import Money
+
+
+def test_on_time_payment_first_installment(simple_loan):
+    s = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("0.00")
+    assert s.interest_paid == Money("39.38")
+    assert s.principal_paid == Money("983.20")
+    assert s.remaining_balance == Money("2016.80")
+
+
+def test_on_time_payment_all_installments(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 4, 12, tzinfo=timezone.utc))
+
+    assert simple_loan.is_paid_off is True
+    assert len(simple_loan.settlements) == 3
+
+
+def test_on_time_second_settlement_values(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    s2 = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc),
+    )
+    assert s2.fine_paid == Money("0.00")
+    assert s2.mora_paid == Money("0.00")
+    assert s2.interest_paid == Money("19.51")
+    assert s2.principal_paid == Money("1003.07")
+
+
+def test_on_time_third_settlement_values(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc))
+    s3 = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 4, 12, tzinfo=timezone.utc),
+    )
+    assert s3.fine_paid == Money("0.00")
+    assert s3.mora_paid == Money("0.00")
+    assert s3.interest_paid == Money("8.85")
+    assert s3.principal_paid == Money("1013.73")
+
+
+def test_allocation_installment_numbers(simple_loan):
+    s = simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    assert len(s.allocations) == 1
+    assert s.allocations[0].installment_number == 1
+    assert s.allocations[0].is_fully_covered is True

--- a/tests/billing_cycle_loan/test_statements.py
+++ b/tests/billing_cycle_loan/test_statements.py
@@ -1,0 +1,81 @@
+"""Tests for BillingCycleLoanStatement generation."""
+
+from datetime import date, datetime, timezone
+
+from money_warp import InterestRate, Money
+
+
+def test_statements_count_matches_installments(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 4, 12, tzinfo=timezone.utc))
+
+    stmts = simple_loan.statements
+    assert len(stmts) == 3
+
+
+def test_statement_period_numbers(simple_loan):
+    stmts = simple_loan.statements
+    assert [s.period_number for s in stmts] == [1, 2, 3]
+
+
+def test_statement_closing_dates(simple_loan):
+    stmts = simple_loan.statements
+    assert stmts[0].closing_date.date() == date(2025, 1, 28)
+    assert stmts[1].closing_date.date() == date(2025, 2, 28)
+    assert stmts[2].closing_date.date() == date(2025, 3, 28)
+
+
+def test_statement_due_dates(simple_loan):
+    stmts = simple_loan.statements
+    assert stmts[0].due_date.date() == date(2025, 2, 12)
+    assert stmts[1].due_date.date() == date(2025, 3, 15)
+    assert stmts[2].due_date.date() == date(2025, 4, 12)
+
+
+def test_statement_expected_amounts(simple_loan):
+    stmts = simple_loan.statements
+    assert stmts[0].expected_payment == Money("1022.58")
+    assert stmts[0].expected_principal == Money("983.20")
+    assert stmts[0].expected_interest == Money("39.38")
+
+
+def test_statement_opening_and_closing_balances(simple_loan):
+    stmts = simple_loan.statements
+    assert stmts[0].opening_balance == Money("3000.00")
+    assert stmts[0].closing_balance == Money("2016.80")
+    assert stmts[1].opening_balance == Money("2016.80")
+    assert stmts[1].closing_balance == Money("1013.73")
+    assert stmts[2].opening_balance == Money("1013.73")
+    assert stmts[2].closing_balance == Money("0.00")
+
+
+def test_statement_mora_rate_constant(simple_loan):
+    stmts = simple_loan.statements
+    for s in stmts:
+        assert s.mora_rate == InterestRate("12% a")
+
+
+def test_statement_mora_rate_variable(variable_mora_loan):
+    stmts = variable_mora_loan.statements
+    assert stmts[0].mora_rate == InterestRate("12% a")
+    assert stmts[1].mora_rate == InterestRate("12% a")
+    assert stmts[2].mora_rate == InterestRate("24% a")
+
+
+def test_statement_payments_received_on_time(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc))
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 4, 12, tzinfo=timezone.utc))
+
+    stmts = simple_loan.statements
+    assert stmts[0].payments_received == Money("0.00")
+    assert stmts[1].payments_received == Money("1022.58")
+    assert stmts[2].payments_received == Money("1022.58")
+
+
+def test_statement_no_mora_on_time(simple_loan):
+    simple_loan.record_payment(Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc))
+    stmts = simple_loan.statements
+    for s in stmts:
+        assert s.mora_charged == Money("0.00")

--- a/tests/billing_cycle_loan/test_variable_mora.py
+++ b/tests/billing_cycle_loan/test_variable_mora.py
@@ -1,0 +1,116 @@
+"""Tests for variable mora rate resolution via MoraRateResolver."""
+
+from datetime import date, datetime, timezone
+
+from money_warp import BillingCycleLoan, InterestRate, Money
+from money_warp.billing_cycle import MonthlyBillingCycle
+from money_warp.loan.engines import MoraStrategy
+
+
+def test_variable_mora_same_as_constant_when_resolver_passes_through():
+    """When the resolver returns the base rate unchanged, results match constant."""
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+    passthrough = lambda ref, base: base
+
+    loan_var = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=bc,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("12% a"),
+        mora_rate_resolver=passthrough,
+    )
+    loan_const = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=bc,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("12% a"),
+    )
+
+    late_dt = datetime(2025, 3, 4, tzinfo=timezone.utc)
+    sv = loan_var.record_payment(Money("1022.58"), late_dt)
+    sc = loan_const.record_payment(Money("1022.58"), late_dt)
+
+    assert sv.mora_paid == sc.mora_paid
+    assert sv.interest_paid == sc.interest_paid
+    assert sv.principal_paid == sc.principal_paid
+
+
+def test_doubled_mora_charges_more_than_constant(variable_mora_loan):
+    """When mora doubles after Feb 28, late inst 3 (cycle Mar 28) charges more."""
+    variable_mora_loan.record_payment(
+        Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    variable_mora_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc),
+    )
+
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+    constant_loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=bc,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("12% a"),
+    )
+    constant_loan.record_payment(
+        Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    constant_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 15, tzinfo=timezone.utc),
+    )
+
+    late_dt = datetime(2025, 5, 1, tzinfo=timezone.utc)
+    sv = variable_mora_loan.record_payment(Money("1100.00"), late_dt)
+    sc = constant_loan.record_payment(Money("1100.00"), late_dt)
+
+    assert sv.mora_paid == Money("11.51")
+    assert sc.mora_paid == Money("6.05")
+    assert sv.mora_paid > sc.mora_paid
+
+
+def test_variable_mora_late_first_installment_uses_base_rate(variable_mora_loan):
+    """Cycle 1 closes Jan 28 (before Feb 28 threshold), so base rate applies."""
+    s = variable_mora_loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+    assert s.fine_paid == Money("20.45")
+    assert s.mora_paid == Money("18.93")
+    assert s.interest_paid == Money("39.38")
+
+
+def test_resolver_receives_closing_date_and_base_rate():
+    """Verify the resolver is called with the correct arguments."""
+    calls = []
+
+    def tracking_resolver(ref_date: date, base: InterestRate) -> InterestRate:
+        calls.append((ref_date, base))
+        return base
+
+    bc = MonthlyBillingCycle(closing_day=28, payment_due_days=15)
+    loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=bc,
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        mora_interest_rate=InterestRate("18% a"),
+        mora_rate_resolver=tracking_resolver,
+    )
+
+    loan.record_payment(
+        Money("1022.58"), datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+
+    assert len(calls) >= 1
+    ref_date, base = calls[0]
+    assert ref_date == date(2025, 1, 28)
+    assert base == InterestRate("18% a")

--- a/tests/billing_cycle_loan/test_warp.py
+++ b/tests/billing_cycle_loan/test_warp.py
@@ -1,0 +1,37 @@
+"""Tests for Warp (time travel) integration with BillingCycleLoan."""
+
+from datetime import datetime, timezone
+
+from money_warp import Money, Warp
+
+
+def test_warp_produces_correct_type(simple_loan):
+    with Warp(simple_loan, "2025-06-01") as warped:
+        assert type(warped).__name__ == "BillingCycleLoan"
+
+
+def test_warp_materialises_fines(simple_loan):
+    with Warp(simple_loan, "2025-06-01") as warped:
+        assert warped.total_fines == Money("61.35")
+        assert warped.fine_balance == Money("61.35")
+
+
+def test_warp_does_not_mutate_original(simple_loan):
+    original_balance = simple_loan.fine_balance
+    with Warp(simple_loan, "2025-06-01") as warped:
+        _ = warped.fine_balance
+    assert simple_loan.fine_balance == original_balance
+
+
+def test_warp_principal_unchanged_without_payments(simple_loan):
+    with Warp(simple_loan, "2025-06-01") as warped:
+        assert warped.principal_balance == Money("3000.00")
+
+
+def test_warp_with_payments(simple_loan):
+    simple_loan.record_payment(
+        Money("1022.58"), datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    with Warp(simple_loan, "2025-06-01") as warped:
+        assert warped.principal_balance == Money("2016.80")
+        assert warped.total_fines == Money("40.90")


### PR DESCRIPTION
## Summary
- New `BillingCycleLoan` product type combining fixed amortization (Price/SAC) with credit-card-like billing cycles
- Mora interest rate can change per billing cycle via a `MoraRateResolver` callable that receives `(closing_date, base_rate)` and returns the effective rate
- Per-period `BillingCycleLoanStatement` for reporting (expected amounts, mora rate used, payments received, balances)

## Changes
- `BaseBillingCycle`: added optional `due_dates` constructor param and `due_dates_between()` method
- `InterestCalculator.compute_accrued_interest`: added `mora_rate_override` parameter (backward-compatible)
- New `money_warp/billing_cycle_loan/` package: facade, adapted forward pass, statement dataclass, MoraRateResolver protocol
- Exported `BillingCycleLoan`, `BillingCycleLoanStatement`, `MoraRateResolver` from top-level `money_warp`
- Knowledge file: `knowledge/billing_cycle_loan.md`

## Test plan
- [x] All 1738 existing tests pass (no regressions)
- [x] 44 new tests: creation/validation, schedule generation, on-time and late settlements, variable mora resolution, statements, due_dates_between, Warp integration
- [ ] Verify variable mora charges more than constant when resolver doubles the rate
- [ ] Verify resolver receives correct closing date and base rate arguments

## Docs
- `knowledge/billing_cycle_loan.md` added with full architecture, API surface, and design decisions