### PR TITLE
fix: eliminate interest double-counting in sequential early payments

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -222,7 +222,10 @@ Shared between Settlement (forward view) and Installment (reverse view).
 
 ### LoanState
 
-Internal dataclass returned by `compute_state`: `settlements`, `principal_balance`, `fines_applied`, `fines_paid_total`, `last_payment_date`.
+Internal dataclass returned by `compute_state`: `settlements`, `principal_balance`, `fines_applied`, `fines_paid_total`, `last_payment_date`, `last_accrual_end`, `overpaid`.
+
+- `last_payment_date` — when money last moved (user-facing via `Loan.last_payment_date`).
+- `last_accrual_end` — end of the last interest accrual period (`max(payment_date, interest_date)`). Used internally for interest computation and installment snapshot building. Prevents double-counting when `interest_date > payment_date`.
 
 ## Cash Flow
 
@@ -316,3 +319,15 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 **Original root cause:** The per-installment reservation held back principal from being allocated, creating "spill" that appeared in totals but not in allocations. Fixed with `_compute_spill` + `_reconcile_allocations`.
 
 **Permanent fix:** The two-step allocation refactor eliminated the reservation and spill entirely. The invariant now holds by construction: `distribute_into_installments` fills from exact loan-level totals, and `_apply_residual` handles only the residual gap (loan-level accrual exceeding per-installment expectations). Per-installment owed amounts are still clamped to non-negative (`max(owed, 0)`) to prevent negative allocations.
+
+### Interest double-counted on sequential early partial payments (fixed 2026-04-09)
+
+**Symptom:** Two sequential `pay_installment` calls before the due date produced a different (worse) outcome than a single combined payment of the same total. The second payment charged spurious interest for the overlap period between `payment_date` and `interest_date`, starving the current installment of principal and preventing full coverage.
+
+**Root cause:** `compute_state` set `last_payment_date = payment.datetime` after each payment. For early payments, `interest_date = max(payment_date, next_due_date) > payment_date`, so the accrual period `[last_payment_date, interest_date]` extended past the payment timestamp. The next payment then re-accrued interest from `payment_date` to its own `interest_date`, double-counting the overlap.
+
+**Fix:** Introduced `last_accrual_end` in the forward pass, set to `max(payment.datetime, interest_date)` after each payment. All subsequent interest computation, regular/mora splitting, and installment snapshot building use `last_accrual_end` instead of `last_payment_date`. The user-facing `Loan.last_payment_date` property is unchanged — `LoanState` now carries both fields.
+
+**Scope:** Both `Loan` and `BillingCycleLoan` were affected and fixed.
+
+**Lesson:** In a forward pass that processes events chronologically, the start of the next accrual period must be the *end* of the previous one, not the timestamp of the event that triggered it. When `interest_date` and `payment_date` diverge, using the wrong one as the accrual boundary creates invisible overlap.

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -312,7 +312,7 @@ class BillingCycleLoan:
             state.principal_balance,
             self.now(),
             self._interest,
-            state.last_payment_date,
+            state.last_accrual_end,
         )
 
     @property
@@ -343,7 +343,7 @@ class BillingCycleLoan:
     def _accrued_interest_components(self) -> tuple:
         """Return (regular, mora) accrued since last payment."""
         state = self._compute_state()
-        days = (self.now().date() - state.last_payment_date.date()).days
+        days = (self.now().date() - state.last_accrual_end.date()).days
 
         if state.principal_balance.is_positive() and days > 0:
             covered = covered_due_date_count(
@@ -363,7 +363,7 @@ class BillingCycleLoan:
                 days,
                 state.principal_balance,
                 next_due,
-                state.last_payment_date,
+                state.last_accrual_end,
                 mora_rate_override=mora_rate,
             )
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -44,6 +44,7 @@ class LoanState:
     fines_applied: Dict[date, Money]
     fines_paid_total: Money
     last_payment_date: datetime
+    last_accrual_end: datetime
     overpaid: Money
 
 
@@ -506,6 +507,7 @@ def compute_state(
     """
     running_principal = principal
     last_payment_date = disbursement_date
+    last_accrual_end = disbursement_date
     fines_applied: Dict[date, Money] = {}
     fines_paid_total = Money.zero()
     overpaid = Money.zero()
@@ -533,7 +535,7 @@ def compute_state(
             continue
 
         interest_date = payment.interest_date if payment.interest_date is not None else payment.datetime
-        days = max(0, (interest_date.date() - last_payment_date.date()).days)
+        days = max(0, (interest_date.date() - last_accrual_end.date()).days)
 
         covered = covered_due_date_count(running_principal, schedule)
         next_due = due_dates[covered] if covered < len(due_dates) else None
@@ -544,7 +546,7 @@ def compute_state(
             days,
             running_principal,
             next_due,
-            last_payment_date,
+            last_accrual_end,
             mora_rate_override=mora_override,
         )
 
@@ -555,7 +557,7 @@ def compute_state(
             schedule,
             fines_applied,
             interest_calc,
-            last_payment_date=last_payment_date,
+            last_payment_date=last_accrual_end,
         )
 
         skipped = _skipped_contractual_interest(installments, next_due, interest_date.date())
@@ -600,6 +602,7 @@ def compute_state(
         )
 
         last_payment_date = payment.datetime
+        last_accrual_end = max(payment.datetime, interest_date)
         processed_payments.append(payment)
 
     return LoanState(
@@ -608,6 +611,7 @@ def compute_state(
         fines_applied=fines_applied,
         fines_paid_total=fines_paid_total,
         last_payment_date=last_payment_date,
+        last_accrual_end=last_accrual_end,
         overpaid=overpaid,
     )
 
@@ -624,7 +628,7 @@ def build_installments(
     principal_balance: Money,
     as_of: datetime,
     interest_calc: InterestCalculator,
-    last_payment_date: datetime,
+    last_accrual_end: datetime,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""
     allocs_by_number: Dict[int, List[Allocation]] = {}
@@ -639,5 +643,5 @@ def build_installments(
         schedule,
         fines_applied,
         interest_calc,
-        last_payment_date=last_payment_date,
+        last_payment_date=last_accrual_end,
     )

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -342,7 +342,7 @@ class Loan:
             state.principal_balance,
             self.now(),
             self._interest,
-            state.last_payment_date,
+            state.last_accrual_end,
         )
 
     # ------------------------------------------------------------------
@@ -357,7 +357,7 @@ class Loan:
     def _accrued_interest_components(self) -> tuple:
         """Return (regular, mora) accrued interest since last payment."""
         state = self._compute_state()
-        days = (self.now().date() - state.last_payment_date.date()).days
+        days = (self.now().date() - state.last_accrual_end.date()).days
 
         if state.principal_balance.is_positive() and days > 0:
             covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
@@ -366,7 +366,7 @@ class Loan:
                 days,
                 state.principal_balance,
                 next_due,
-                state.last_payment_date,
+                state.last_accrual_end,
             )
 
         return Money.zero(), Money.zero()

--- a/tests/loan/settlements/late_payments/test_late_after_early_payment.py
+++ b/tests/loan/settlements/late_payments/test_late_after_early_payment.py
@@ -18,10 +18,10 @@ def test_late_after_early_settlement_totals(three_installment_loan):
             settlement = w2.pay_installment(Money("300.00"))
 
     assert settlement.fine_paid == Money("12.14")
-    assert settlement.mora_paid == Money("2.73")
-    assert settlement.interest_paid == Money("7.73")
-    assert settlement.principal_paid == Money("277.39")
-    assert settlement.remaining_balance == Money("223.46")
+    assert settlement.mora_paid == Money("2.72")
+    assert settlement.interest_paid == Money("5.40")
+    assert settlement.principal_paid == Money("279.74")
+    assert settlement.remaining_balance == Money("221.11")
 
 
 def test_late_after_early_allocation_count(three_installment_loan):
@@ -63,10 +63,10 @@ def test_late_after_early_second_installment(three_installment_loan):
     second = settlement.allocations[1]
     assert second.installment_number == 2
     assert second.principal_allocated == Money("200.80")
-    assert second.interest_allocated == Money("6.44")
+    assert second.interest_allocated == Money("5.40")
     assert second.fine_allocated == Money("6.07")
-    assert second.mora_allocated == Money("2.73")
-    assert second.is_fully_covered is True
+    assert second.mora_allocated == Money("2.72")
+    assert second.is_fully_covered is False
 
 
 def test_late_after_early_third_installment(three_installment_loan):
@@ -79,8 +79,8 @@ def test_late_after_early_third_installment(three_installment_loan):
 
     third = settlement.allocations[2]
     assert third.installment_number == 3
-    assert third.principal_allocated == Money("76.59")
-    assert third.interest_allocated == Money("1.29")
+    assert third.principal_allocated == Money("78.94")
+    assert third.interest_allocated == Money("0.00")
     assert third.fine_allocated == Money("0.00")
     assert third.mora_allocated == Money("0.00")
     assert third.is_fully_covered is False

--- a/tests/loan/settlements/up_to_date_payments/test_partial_payments.py
+++ b/tests/loan/settlements/up_to_date_payments/test_partial_payments.py
@@ -78,24 +78,24 @@ def test_p1_first_installment(six_partial_settlements):
 
 
 def test_p2_settlement_totals(six_partial_settlements):
-    """Second payment: small interest for 5-day period, rest to principal."""
+    """Second payment: no new interest (P1 already covered up to due date), all to principal."""
     _, settlements = six_partial_settlements
-    assert settlements[1].interest_paid == Money("2.15")
-    assert settlements[1].principal_paid == Money("97.85")
+    assert settlements[1].interest_paid == Money("0.00")
+    assert settlements[1].principal_paid == Money("100.00")
 
 
 def test_p2_allocation_count(six_partial_settlements):
-    """P2 touches 2 installments (inst 1 principal + inst 2 interest spillover)."""
+    """P2 touches 1 installment (inst 1 principal only, no interest spillover)."""
     _, settlements = six_partial_settlements
-    assert len(settlements[1].allocations) == 2
+    assert len(settlements[1].allocations) == 1
 
 
 def test_p2_first_installment(six_partial_settlements):
-    """Inst 1 gets principal portion — still not fully covered."""
+    """Inst 1 gets all principal — still not fully covered."""
     _, settlements = six_partial_settlements
     a = settlements[1].allocations[0]
     assert a.installment_number == 1
-    assert a.principal_allocated == Money("97.85")
+    assert a.principal_allocated == Money("100.00")
     assert a.interest_allocated == Money("0.00")
     assert a.is_fully_covered is False
 
@@ -108,7 +108,7 @@ def test_p3_completes_installment_one(six_partial_settlements):
     _, settlements = six_partial_settlements
     first_alloc = settlements[2].allocations[0]
     assert first_alloc.installment_number == 1
-    assert first_alloc.principal_allocated == Money("105.77")
+    assert first_alloc.principal_allocated == Money("103.62")
     assert first_alloc.is_fully_covered is True
 
 
@@ -116,51 +116,62 @@ def test_p3_completes_installment_one(six_partial_settlements):
 
 
 def test_p4_settlement_totals(six_partial_settlements):
-    """P4 between due dates: 6.40 interest, 193.60 principal."""
+    """P4 between due dates: 6.37 interest, 193.63 principal."""
     _, settlements = six_partial_settlements
-    assert settlements[3].interest_paid == Money("6.40")
-    assert settlements[3].principal_paid == Money("193.60")
+    assert settlements[3].interest_paid == Money("6.37")
+    assert settlements[3].principal_paid == Money("193.63")
 
 
 def test_p4_allocation_count(six_partial_settlements):
-    """P4 touches inst 2 (principal+interest) and inst 3 (interest spillover)."""
+    """P4 touches inst 2 only (interest + principal)."""
     _, settlements = six_partial_settlements
-    assert len(settlements[3].allocations) == 2
+    assert len(settlements[3].allocations) == 1
 
 
 def test_p4_second_installment(six_partial_settlements):
-    """Inst 2 gets bulk of P4 — not yet fully covered."""
+    """Inst 2 gets all of P4 — not yet fully covered."""
     _, settlements = six_partial_settlements
     a = settlements[3].allocations[0]
     assert a.installment_number == 2
-    assert a.principal_allocated == Money("193.60")
-    assert a.interest_allocated == Money("3.75")
+    assert a.principal_allocated == Money("193.63")
+    assert a.interest_allocated == Money("6.37")
     assert a.is_fully_covered is False
 
 
 # --- Payment 5: R$200 on Mar 1 (completes installment 2) ---
 
 
-def test_p5_completes_installment_two(six_partial_settlements):
-    """P5 on the second due date finishes off installment 2."""
+def test_p5_second_installment(six_partial_settlements):
+    """P5 on the second due date pays inst 2's remaining principal and spills to inst 3."""
     _, settlements = six_partial_settlements
     first_alloc = settlements[4].allocations[0]
     assert first_alloc.installment_number == 2
-    assert first_alloc.principal_allocated == Money("99.89")
-    assert first_alloc.is_fully_covered is True
+    assert first_alloc.principal_allocated == Money("97.17")
+    assert first_alloc.interest_allocated == Money("0.00")
+    assert first_alloc.is_fully_covered is False
 
 
 # --- Payment 6: R$200 on Apr 1 (inst 3 remains partially unpaid) ---
 
 
-def test_p6_third_installment_not_covered(six_partial_settlements):
-    """Inst 3 gets all of P6 plus interest spill — still NOT fully covered."""
+def test_p6_third_installment_allocation(six_partial_settlements):
+    """Inst 3 gets principal + interest from P6."""
+    _, settlements = six_partial_settlements
+    a = settlements[5].allocations[1]
+    assert a.installment_number == 3
+    assert a.principal_allocated == Money("197.65")
+    assert a.interest_allocated == Money("2.28")
+    assert a.is_fully_covered is True
+
+
+def test_p6_finishes_second_installment(six_partial_settlements):
+    """P6 also covers inst 2's remaining interest (0.07)."""
     _, settlements = six_partial_settlements
     a = settlements[5].allocations[0]
-    assert a.installment_number == 3
-    assert a.principal_allocated == Money("197.59")
-    assert a.interest_allocated == Money("2.41")
-    assert a.is_fully_covered is False
+    assert a.installment_number == 2
+    assert a.interest_allocated == Money("0.07")
+    assert a.principal_allocated == Money("0.00")
+    assert a.is_fully_covered is True
 
 
 # --- Final state ---

--- a/tests/loan/settlements/up_to_date_payments/test_sequential_partial_early_payments.py
+++ b/tests/loan/settlements/up_to_date_payments/test_sequential_partial_early_payments.py
@@ -1,0 +1,178 @@
+"""Regression tests: sequential partial payments must match a single combined payment.
+
+Scenario: borrower pays inst#1 in two chunks (both before the due date).
+The two sequential payments must produce the same financial outcome as one
+combined payment of the same total amount.
+
+Bug (fixed): the forward pass used ``payment.datetime`` as the start of the
+next interest accrual period.  When ``interest_date > payment_date`` (early
+payments where interest accrues to the due date), the gap between
+``payment_date`` and ``interest_date`` was double-counted as interest on the
+second payment, starving inst#1 of principal and preventing full coverage.
+"""
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, PriceScheduler, Warp
+
+
+@pytest.fixture
+def six_installment_loan():
+    """Loan matching the production scenario that exposed the bug."""
+    return Loan(
+        principal=Money("21169.56"),
+        interest_rate=InterestRate("3.19% a.m."),
+        due_dates=[
+            date(2025, 11, 12),
+            date(2025, 12, 12),
+            date(2026, 1, 12),
+            date(2026, 2, 12),
+            date(2026, 3, 12),
+            date(2026, 4, 12),
+        ],
+        disbursement_date=datetime(2025, 10, 9, 18, 0, tzinfo=UTC),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("1% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+    )
+
+
+@pytest.fixture
+def warp_dt():
+    return datetime(2025, 11, 10, 18, 0, tzinfo=UTC)
+
+
+# --- Single combined payment baseline ---
+
+
+@pytest.fixture
+def single_payment_result(six_installment_loan, warp_dt):
+    """Pay the full amount (3,976.40) in one shot."""
+    with Warp(six_installment_loan, warp_dt) as w:
+        settlement = w.pay_installment(Money("3976.40"))
+        return w, settlement
+
+
+def test_single_payment_interest(single_payment_result):
+    _, settlement = single_payment_result
+    assert settlement.interest_paid == Money("756.27")
+
+
+def test_single_payment_principal(single_payment_result):
+    _, settlement = single_payment_result
+    assert settlement.principal_paid == Money("3220.13")
+
+
+def test_single_payment_inst1_fully_covered(single_payment_result):
+    _, settlement = single_payment_result
+    a = settlement.allocations[0]
+    assert a.installment_number == 1
+    assert a.interest_allocated == Money("756.27")
+    assert a.principal_allocated == Money("3189.36")
+    assert a.is_fully_covered is True
+
+
+def test_single_payment_inst1_fully_paid(single_payment_result):
+    loan, _ = single_payment_result
+    assert loan.installments[0].is_fully_paid is True
+    assert loan.installments[0].balance == Money("0.00")
+
+
+def test_single_payment_spill_to_inst2(single_payment_result):
+    _, settlement = single_payment_result
+    a = settlement.allocations[1]
+    assert a.installment_number == 2
+    assert a.principal_allocated == Money("30.77")
+    assert a.interest_allocated == Money("0.00")
+
+
+# --- Two sequential partial payments ---
+
+
+@pytest.fixture
+def two_payment_result(six_installment_loan, warp_dt):
+    """Pay in two chunks at the same warp time: 3,932.03 then 44.37."""
+    with Warp(six_installment_loan, warp_dt) as w1:
+        s1 = w1.pay_installment(Money("3932.03"))
+        with Warp(w1, warp_dt) as w2:
+            s2 = w2.pay_installment(Money("44.37"))
+            return w2, s1, s2
+
+
+def test_first_partial_interest(two_payment_result):
+    _, s1, _ = two_payment_result
+    assert s1.interest_paid == Money("756.27")
+
+
+def test_first_partial_principal(two_payment_result):
+    _, s1, _ = two_payment_result
+    assert s1.principal_paid == Money("3175.76")
+
+
+def test_first_partial_inst1_not_yet_covered(two_payment_result):
+    _, s1, _ = two_payment_result
+    a = s1.allocations[0]
+    assert a.installment_number == 1
+    assert a.is_fully_covered is False
+
+
+def test_second_partial_no_double_counted_interest(two_payment_result):
+    """The top-up payment must not charge extra interest for the overlap period."""
+    _, _, s2 = two_payment_result
+    assert s2.interest_paid == Money("0.00")
+
+
+def test_second_partial_full_principal(two_payment_result):
+    """All of the top-up goes to principal reduction."""
+    _, _, s2 = two_payment_result
+    assert s2.principal_paid == Money("44.37")
+
+
+def test_second_partial_inst1_fully_covered(two_payment_result):
+    _, _, s2 = two_payment_result
+    a = s2.allocations[0]
+    assert a.installment_number == 1
+    assert a.principal_allocated == Money("13.60")
+    assert a.interest_allocated == Money("0.00")
+    assert a.is_fully_covered is True
+
+
+def test_second_partial_spill_to_inst2(two_payment_result):
+    """Remaining principal spills to inst#2, matching the single-payment case."""
+    _, _, s2 = two_payment_result
+    a = s2.allocations[1]
+    assert a.installment_number == 2
+    assert a.principal_allocated == Money("30.77")
+    assert a.interest_allocated == Money("0.00")
+
+
+def test_sequential_inst1_fully_paid(two_payment_result):
+    loan, _, _ = two_payment_result
+    assert loan.installments[0].is_fully_paid is True
+    assert loan.installments[0].balance == Money("0.00")
+
+
+# --- Equivalence: sequential vs single ---
+
+
+def test_combined_principal_matches_single(single_payment_result, two_payment_result):
+    """Total principal paid across both partials equals the single payment."""
+    _, single_s = single_payment_result
+    _, s1, s2 = two_payment_result
+    assert s1.principal_paid + s2.principal_paid == single_s.principal_paid
+
+
+def test_combined_interest_matches_single(single_payment_result, two_payment_result):
+    """Total interest paid across both partials equals the single payment."""
+    _, single_s = single_payment_result
+    _, s1, s2 = two_payment_result
+    assert s1.interest_paid + s2.interest_paid == single_s.interest_paid
+
+
+def test_remaining_balance_matches_single(single_payment_result, two_payment_result):
+    """Final principal balance is identical regardless of payment splitting."""
+    single_loan, _ = single_payment_result
+    seq_loan, _, _ = two_payment_result
+    assert seq_loan.principal_balance == single_loan.principal_balance

--- a/tests/loan/test_settlement_spill.py
+++ b/tests/loan/test_settlement_spill.py
@@ -99,9 +99,9 @@ def test_catchup_settlement_exact_totals(catchup_loan):
     with Warp(catchup_loan, datetime(2026, 5, 25, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(Money(5000))
 
-    assert settlement.principal_paid == Money("4512.07")
-    assert settlement.interest_paid == Money("294.98")
-    assert settlement.mora_paid == Money("106.58")
+    assert settlement.principal_paid == Money("4585.44")
+    assert settlement.interest_paid == Money("223.41")
+    assert settlement.mora_paid == Money("104.78")
     assert settlement.fine_paid == Money("86.38")
     assert settlement.remaining_balance == Money("0.00")
 


### PR DESCRIPTION
## Summary
- Fix interest double-counting when multiple early `pay_installment` calls are made before the due date
- Sequential partial payments now produce the same financial outcome as a single combined payment of the same total
- Applies to both `Loan` and `BillingCycleLoan`

## Changes
- Introduced `last_accrual_end` field in `LoanState` to track the end of the last interest accrual period, separate from `last_payment_date` (when money moved)
- `compute_state` forward pass uses `last_accrual_end = max(payment.datetime, interest_date)` instead of `payment.datetime` for interest computation, regular/mora split, and installment snapshots
- Updated `build_installments`, `Loan._accrued_interest_components`, and `BillingCycleLoan._accrued_interest_components` to use the new boundary
- Updated 3 existing test files whose assertions included the double-counted interest
- Added 16-test regression suite (`test_sequential_partial_early_payments.py`) verifying equivalence between sequential and single payments

## Root cause
The forward pass set `last_payment_date = payment.datetime` after each payment. For early payments, `interest_date = max(payment_date, next_due)` extends past the payment timestamp. The next payment re-accrued interest from `payment_date` to its `interest_date`, double-counting the overlap period.

## Test plan
- [x] All 1755 existing tests pass (5 xfailed)
- [x] New regression test verifies two-payment vs single-payment equivalence
- [x] Exact-value assertions on all allocation fields

## Docs
- Updated `knowledge/loan.md` with Key Learnings entry and LoanState documentation