### PR TITLE
feat: add configurable payment_tolerance to Loan

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -48,6 +48,22 @@ The forward pass merges payment events with fine observation dates into a sorted
 | `grace_period_days` | `int` | `0` | Days after due date before fines apply |
 | `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Rate used for mora (late) interest; defaults to the base rate |
 | `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora interest is computed (see Mora Strategy below) |
+| `payment_tolerance` | `Optional[Money]` | `Money("0.01")` | Per-installment rounding error tolerance (see Payment Tolerance below) |
+
+## Payment Tolerance
+
+External loan origination systems may introduce a small rounding error per installment (typically 1 cent in the PMT calculation). This error **accumulates** across installments -- installment N can be off by up to N times the per-installment error.
+
+The `payment_tolerance` parameter controls the per-installment error unit. The effective tolerance scales with the installment number:
+
+- **`Installment.is_fully_paid`**: `self.balance <= payment_tolerance * self.number`
+- **`Loan.is_paid_off`**: `current_balance <= payment_tolerance * len(due_dates)`
+
+This means installment 1 on a 24-installment loan tolerates 1 cent, while installment 24 tolerates 24 cents (at the default tolerance).
+
+The tolerance is threaded through the settlement engine (`compute_state`), where it also controls the principal snap-to-zero threshold and coverage fixup checks.
+
+Pass `payment_tolerance=Money("0")` for exact-match behavior. Pass a larger value (e.g., `Money("0.02")`) if the external system has a larger rounding error.
 
 ## Three-Date Payment Model
 

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -71,6 +71,7 @@ class BillingCycleLoan:
         mora_interest_rate: Optional[InterestRate] = None,
         mora_rate_resolver: Optional[MoraRateResolver] = None,
         mora_strategy: MoraStrategy = MoraStrategy.COMPOUND,
+        payment_tolerance: Optional[Money] = None,
     ) -> None:
         if principal.is_negative() or principal.is_zero():
             raise ValueError("Principal must be positive")
@@ -92,6 +93,7 @@ class BillingCycleLoan:
         self.scheduler = scheduler or PriceScheduler
         self.fine_rate = fine_rate if fine_rate is not None else InterestRate("2% annual")
         self.grace_period_days = grace_period_days
+        self.payment_tolerance = payment_tolerance if payment_tolerance is not None else Money("0.01")
 
         self._interest = InterestCalculator(
             interest_rate,
@@ -285,6 +287,7 @@ class BillingCycleLoan:
             base_mora_rate=self.mora_interest_rate,
             mora_rate_resolver=self.mora_rate_resolver,
             fine_observation_dates=self._fine_observation_dates,
+            payment_tolerance=self.payment_tolerance,
         )
 
     def _payment_entries(self) -> list:
@@ -313,6 +316,7 @@ class BillingCycleLoan:
             self.now(),
             self._interest,
             state.last_accrual_end,
+            payment_tolerance=self.payment_tolerance,
         )
 
     @property
@@ -396,8 +400,12 @@ class BillingCycleLoan:
 
     @property
     def is_paid_off(self) -> bool:
-        """Whether the loan is fully paid off."""
-        return self.current_balance.is_zero() or self.current_balance.is_negative()
+        """Whether the loan is fully paid off.
+
+        Tolerance accumulates across all installments to account for
+        per-installment rounding errors from external origination systems.
+        """
+        return self.current_balance <= self.payment_tolerance * len(self.due_dates)
 
     @property
     def overpaid(self) -> Money:

--- a/money_warp/billing_cycle_loan/engines.py
+++ b/money_warp/billing_cycle_loan/engines.py
@@ -85,9 +85,9 @@ def compute_state(
     payment_entries: list,
     as_of: datetime,
     base_mora_rate: InterestRate,
+    payment_tolerance: Money,
     mora_rate_resolver: Optional[MoraRateResolver] = None,
     fine_observation_dates: Optional[List[datetime]] = None,
-    payment_tolerance: Money = Money("0.01"),
 ) -> LoanState:
     """Forward pass for billing-cycle loans.
 

--- a/money_warp/billing_cycle_loan/engines.py
+++ b/money_warp/billing_cycle_loan/engines.py
@@ -87,6 +87,7 @@ def compute_state(
     base_mora_rate: InterestRate,
     mora_rate_resolver: Optional[MoraRateResolver] = None,
     fine_observation_dates: Optional[List[datetime]] = None,
+    payment_tolerance: Money = Money("0.01"),
 ) -> LoanState:
     """Forward pass for billing-cycle loans.
 
@@ -107,6 +108,7 @@ def compute_state(
         as_of=as_of,
         fine_observation_dates=fine_observation_dates,
         mora_rate_for_event=callback,
+        payment_tolerance=payment_tolerance,
     )
 
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -447,9 +447,7 @@ def _build_installments_snapshot(
         else:
             expected_mora = Money.zero()
 
-        result.append(
-            Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine, payment_tolerance)
-        )
+        result.append(Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine, payment_tolerance))
 
     return result
 

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -410,9 +410,8 @@ def _build_installments_snapshot(
     schedule: PaymentSchedule,
     fines_applied: Dict[date, Money],
     interest_calc: InterestCalculator,
-    last_payment_date: Optional[datetime] = None,
-    *,
     payment_tolerance: Money,
+    last_payment_date: Optional[datetime] = None,
 ) -> List[Installment]:
     """Build Installment objects from pre-computed allocation data."""
     covered = covered_due_date_count(principal_balance, schedule)
@@ -490,10 +489,9 @@ def compute_state(
     disbursement_date: datetime,
     payment_entries: list,
     as_of: datetime,
+    payment_tolerance: Money,
     fine_observation_dates: Optional[List[datetime]] = None,
     mora_rate_for_event: MoraRateCallback = None,
-    *,
-    payment_tolerance: Money,
 ) -> LoanState:
     """Forward pass: compute all settlements and derived state from payments.
 
@@ -640,7 +638,6 @@ def build_installments(
     as_of: datetime,
     interest_calc: InterestCalculator,
     last_accrual_end: datetime,
-    *,
     payment_tolerance: Money,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -25,7 +25,7 @@ from ..money import Money
 from ..scheduler import PaymentSchedule
 from ..tz import to_datetime
 from .allocation import Allocation
-from .installment import Installment
+from .installment import Installment, _DEFAULT_PAYMENT_TOLERANCE
 from .settlement import Settlement
 
 # ===================================================================
@@ -254,7 +254,7 @@ def distribute_into_installments(
 
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
         if total.is_positive():
-            is_covered = total >= (inst.balance - _COVERAGE_TOLERANCE)
+            is_covered = total >= (inst.balance - inst.payment_tolerance * inst.number)
             allocations.append(
                 Allocation(
                     installment_number=inst.number,
@@ -267,7 +267,8 @@ def distribute_into_installments(
             )
 
     _apply_residual(allocations, installments, fine_total, mora_total, interest_total, principal_total)
-    _apply_coverage_fixup(allocations, installments, ending_balance, principal_total)
+    tolerance = installments[0].payment_tolerance if installments else _DEFAULT_PAYMENT_TOLERANCE
+    _apply_coverage_fixup(allocations, installments, ending_balance, principal_total, tolerance)
     return allocations
 
 
@@ -325,6 +326,7 @@ def _apply_coverage_fixup(
     installments: List[Installment],
     ending_balance: Money,
     principal_total: Money,
+    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
 ) -> None:
     """Override coverage flags when the loan is paid off.
 
@@ -332,8 +334,10 @@ def _apply_coverage_fixup(
     any allocation whose principal was fully allocated is
     marked as fully covered.
     """
+    num_installments = len(installments)
+    loan_tolerance = payment_tolerance * num_installments
     post_balance = ending_balance - principal_total
-    if post_balance > _COVERAGE_TOLERANCE:
+    if post_balance > loan_tolerance:
         return
 
     inst_by_number = {inst.number: inst for inst in installments}
@@ -343,8 +347,9 @@ def _apply_coverage_fixup(
         inst = inst_by_number.get(alloc.installment_number)
         if inst is None:
             continue
+        inst_tolerance = payment_tolerance * inst.number
         principal_owed = inst.expected_principal - inst.principal_paid
-        if alloc.principal_allocated >= (principal_owed - _COVERAGE_TOLERANCE):
+        if alloc.principal_allocated >= (principal_owed - inst_tolerance):
             allocations[i] = Allocation(
                 installment_number=alloc.installment_number,
                 principal_allocated=alloc.principal_allocated,
@@ -407,6 +412,7 @@ def _build_installments_snapshot(
     fines_applied: Dict[date, Money],
     interest_calc: InterestCalculator,
     last_payment_date: Optional[datetime] = None,
+    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
 ) -> List[Installment]:
     """Build Installment objects from pre-computed allocation data."""
     covered = covered_due_date_count(principal_balance, schedule)
@@ -442,7 +448,9 @@ def _build_installments_snapshot(
         else:
             expected_mora = Money.zero()
 
-        result.append(Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine))
+        result.append(
+            Installment.from_schedule_entry(entry, allocs, expected_mora, expected_fine, payment_tolerance)
+        )
 
     return result
 
@@ -484,6 +492,7 @@ def compute_state(
     as_of: datetime,
     fine_observation_dates: Optional[List[datetime]] = None,
     mora_rate_for_event: MoraRateCallback = None,
+    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
 ) -> LoanState:
     """Forward pass: compute all settlements and derived state from payments.
 
@@ -558,6 +567,7 @@ def compute_state(
             fines_applied,
             interest_calc,
             last_payment_date=last_accrual_end,
+            payment_tolerance=payment_tolerance,
         )
 
         skipped = _skipped_contractual_interest(installments, next_due, interest_date.date())
@@ -582,7 +592,7 @@ def compute_state(
         if running_principal.is_negative():
             overpaid = overpaid + Money(-running_principal.raw_amount)
             running_principal = Money.zero()
-        elif running_principal.is_positive() and running_principal <= _COVERAGE_TOLERANCE:
+        elif running_principal.is_positive() and running_principal <= payment_tolerance * len(due_dates):
             running_principal = Money.zero()
 
         for a in allocations:
@@ -629,6 +639,7 @@ def build_installments(
     as_of: datetime,
     interest_calc: InterestCalculator,
     last_accrual_end: datetime,
+    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""
     allocs_by_number: Dict[int, List[Allocation]] = {}
@@ -644,4 +655,5 @@ def build_installments(
         fines_applied,
         interest_calc,
         last_payment_date=last_accrual_end,
+        payment_tolerance=payment_tolerance,
     )

--- a/money_warp/loan/engines.py
+++ b/money_warp/loan/engines.py
@@ -25,14 +25,13 @@ from ..money import Money
 from ..scheduler import PaymentSchedule
 from ..tz import to_datetime
 from .allocation import Allocation
-from .installment import Installment, _DEFAULT_PAYMENT_TOLERANCE
+from .installment import Installment
 from .settlement import Settlement
 
-# ===================================================================
-# Settlement engine
-# ===================================================================
-
-_COVERAGE_TOLERANCE = Money("0.01")
+# Sub-cent tolerance for internal balance comparisons (rounding artifacts
+# from our own calculations).  Distinct from the loan-level
+# ``payment_tolerance`` that handles external origination rounding.
+_BALANCE_TOLERANCE = Money("0.01")
 
 
 @dataclass(frozen=True)
@@ -60,7 +59,7 @@ def covered_due_date_count(
     """How many due dates are covered given a remaining principal balance."""
     covered = 0
     for entry in schedule:
-        if remaining_balance <= entry.ending_balance + _COVERAGE_TOLERANCE:
+        if remaining_balance <= entry.ending_balance + _BALANCE_TOLERANCE:
             covered += 1
         else:
             break
@@ -102,13 +101,13 @@ def _has_payment_near(
         return False
 
     exact = [p for p in payment_entries if p.datetime.date() == due_date and p.datetime <= as_of]
-    if sum((p.amount for p in exact), Money.zero()) >= (expected - _COVERAGE_TOLERANCE):
+    if sum((p.amount for p in exact), Money.zero()) >= (expected - _BALANCE_TOLERANCE):
         return True
 
     window_start = to_datetime(due_date - timedelta(days=_WINDOW_DAYS_BEFORE))
     window_end = min(as_of, to_datetime(due_date + timedelta(days=_WINDOW_DAYS_AFTER)))
     window = [p for p in payment_entries if window_start <= p.datetime <= window_end and p.datetime <= as_of]
-    return sum((p.amount for p in window), Money.zero()) >= (expected - _COVERAGE_TOLERANCE)
+    return sum((p.amount for p in window), Money.zero()) >= (expected - _BALANCE_TOLERANCE)
 
 
 def compute_fines_at(
@@ -267,7 +266,7 @@ def distribute_into_installments(
             )
 
     _apply_residual(allocations, installments, fine_total, mora_total, interest_total, principal_total)
-    tolerance = installments[0].payment_tolerance if installments else _DEFAULT_PAYMENT_TOLERANCE
+    tolerance = installments[0].payment_tolerance if installments else Money("0.01")
     _apply_coverage_fixup(allocations, installments, ending_balance, principal_total, tolerance)
     return allocations
 
@@ -326,7 +325,7 @@ def _apply_coverage_fixup(
     installments: List[Installment],
     ending_balance: Money,
     principal_total: Money,
-    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
+    payment_tolerance: Money,
 ) -> None:
     """Override coverage flags when the loan is paid off.
 
@@ -412,7 +411,8 @@ def _build_installments_snapshot(
     fines_applied: Dict[date, Money],
     interest_calc: InterestCalculator,
     last_payment_date: Optional[datetime] = None,
-    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
+    *,
+    payment_tolerance: Money,
 ) -> List[Installment]:
     """Build Installment objects from pre-computed allocation data."""
     covered = covered_due_date_count(principal_balance, schedule)
@@ -492,7 +492,8 @@ def compute_state(
     as_of: datetime,
     fine_observation_dates: Optional[List[datetime]] = None,
     mora_rate_for_event: MoraRateCallback = None,
-    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
+    *,
+    payment_tolerance: Money,
 ) -> LoanState:
     """Forward pass: compute all settlements and derived state from payments.
 
@@ -639,7 +640,8 @@ def build_installments(
     as_of: datetime,
     interest_calc: InterestCalculator,
     last_accrual_end: datetime,
-    payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
+    *,
+    payment_tolerance: Money,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""
     allocs_by_number: Dict[int, List[Allocation]] = {}

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -1,6 +1,6 @@
 """Installment data structure for loan repayment plans."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import List
 
@@ -8,7 +8,7 @@ from ..money import Money
 from ..scheduler import PaymentScheduleEntry
 from .allocation import Allocation
 
-_COVERAGE_TOLERANCE = Money("0.01")
+_DEFAULT_PAYMENT_TOLERANCE = Money("0.01")
 
 
 @dataclass(frozen=True)
@@ -35,6 +35,7 @@ class Installment:
     mora_paid: Money
     fine_paid: Money
     allocations: List[Allocation]
+    payment_tolerance: Money = field(default_factory=lambda: _DEFAULT_PAYMENT_TOLERANCE)
 
     @property
     def balance(self) -> Money:
@@ -46,8 +47,12 @@ class Installment:
 
     @property
     def is_fully_paid(self) -> bool:
-        """Whether this installment has been fully settled (within rounding tolerance)."""
-        return self.balance <= _COVERAGE_TOLERANCE
+        """Whether this installment has been fully settled.
+
+        Tolerance accumulates with the installment number to account for
+        per-installment rounding errors from external origination systems.
+        """
+        return self.balance <= self.payment_tolerance * self.number
 
     @classmethod
     def from_schedule_entry(
@@ -56,6 +61,7 @@ class Installment:
         allocations: List[Allocation],
         expected_mora: Money,
         expected_fine: Money,
+        payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
     ) -> "Installment":
         """Build an Installment from a scheduler's PaymentScheduleEntry."""
         principal_paid = Money(sum(a.principal_allocated.raw_amount for a in allocations))
@@ -77,4 +83,5 @@ class Installment:
             mora_paid=mora_paid,
             fine_paid=fine_paid,
             allocations=allocations,
+            payment_tolerance=payment_tolerance,
         )

--- a/money_warp/loan/installment.py
+++ b/money_warp/loan/installment.py
@@ -1,14 +1,12 @@
 """Installment data structure for loan repayment plans."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from typing import List
 
 from ..money import Money
 from ..scheduler import PaymentScheduleEntry
 from .allocation import Allocation
-
-_DEFAULT_PAYMENT_TOLERANCE = Money("0.01")
 
 
 @dataclass(frozen=True)
@@ -34,8 +32,8 @@ class Installment:
     interest_paid: Money
     mora_paid: Money
     fine_paid: Money
+    payment_tolerance: Money
     allocations: List[Allocation]
-    payment_tolerance: Money = field(default_factory=lambda: _DEFAULT_PAYMENT_TOLERANCE)
 
     @property
     def balance(self) -> Money:
@@ -61,7 +59,7 @@ class Installment:
         allocations: List[Allocation],
         expected_mora: Money,
         expected_fine: Money,
-        payment_tolerance: Money = _DEFAULT_PAYMENT_TOLERANCE,
+        payment_tolerance: Money,
     ) -> "Installment":
         """Build an Installment from a scheduler's PaymentScheduleEntry."""
         principal_paid = Money(sum(a.principal_allocated.raw_amount for a in allocations))

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -65,6 +65,7 @@ class Loan:
         mora_strategy: MoraStrategy = MoraStrategy.COMPOUND,
         taxes: Optional[List[BaseTax]] = None,
         is_grossed_up: bool = False,
+        payment_tolerance: Optional[Money] = None,
     ) -> None:
         if not due_dates:
             raise ValueError("At least one due date is required")
@@ -87,6 +88,7 @@ class Loan:
         self.scheduler = scheduler or PriceScheduler
         self.fine_rate = fine_rate if fine_rate is not None else InterestRate("2% annual")
         self.grace_period_days = grace_period_days
+        self.payment_tolerance = payment_tolerance if payment_tolerance is not None else Money("0.01")
         self.taxes: List[BaseTax] = taxes or []
         self.is_grossed_up = is_grossed_up
         self._tax_cache: Optional[Dict[str, TaxResult]] = None
@@ -315,6 +317,7 @@ class Loan:
             self._payment_entries(),
             self.now(),
             fine_observation_dates=self._fine_observation_dates,
+            payment_tolerance=self.payment_tolerance,
         )
 
     def _payment_entries(self) -> list:
@@ -343,6 +346,7 @@ class Loan:
             self.now(),
             self._interest,
             state.last_accrual_end,
+            payment_tolerance=self.payment_tolerance,
         )
 
     # ------------------------------------------------------------------
@@ -398,8 +402,12 @@ class Loan:
 
     @property
     def is_paid_off(self) -> bool:
-        """Whether the loan is fully paid off."""
-        return self.current_balance.is_zero() or self.current_balance.is_negative()
+        """Whether the loan is fully paid off.
+
+        Tolerance accumulates across all installments to account for
+        per-installment rounding errors from external origination systems.
+        """
+        return self.current_balance <= self.payment_tolerance * len(self.due_dates)
 
     @property
     def overpaid(self) -> Money:

--- a/tests/loan/test_installment.py
+++ b/tests/loan/test_installment.py
@@ -138,6 +138,7 @@ def test_from_schedule_entry_creates_correct_installment():
         allocations=[],
         expected_mora=Money.zero(),
         expected_fine=Money.zero(),
+        payment_tolerance=Money("0.01"),
     )
 
     assert inst.number == 1

--- a/tests/loan/test_payment_tolerance.py
+++ b/tests/loan/test_payment_tolerance.py
@@ -6,13 +6,11 @@ number so that installment N tolerates N * payment_tolerance.
 """
 
 from datetime import date, datetime, timezone
-from decimal import Decimal
 
 import pytest
 
 from money_warp import Installment, InterestRate, Loan, Money, Warp
 from money_warp.scheduler import PaymentScheduleEntry
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -23,10 +21,18 @@ from money_warp.scheduler import PaymentScheduleEntry
 def twelve_installment_loan():
     """12-installment loan with default 1-cent tolerance."""
     due_dates = [
-        date(2026, 3, 22), date(2026, 4, 22), date(2026, 5, 22),
-        date(2026, 6, 22), date(2026, 7, 22), date(2026, 8, 22),
-        date(2026, 9, 22), date(2026, 10, 22), date(2026, 11, 22),
-        date(2026, 12, 22), date(2027, 1, 22), date(2027, 2, 22),
+        date(2026, 3, 22),
+        date(2026, 4, 22),
+        date(2026, 5, 22),
+        date(2026, 6, 22),
+        date(2026, 7, 22),
+        date(2026, 8, 22),
+        date(2026, 9, 22),
+        date(2026, 10, 22),
+        date(2026, 11, 22),
+        date(2026, 12, 22),
+        date(2027, 1, 22),
+        date(2027, 2, 22),
     ]
     return Loan(
         Money("10000"),

--- a/tests/loan/test_payment_tolerance.py
+++ b/tests/loan/test_payment_tolerance.py
@@ -1,0 +1,336 @@
+"""Tests for the accumulated payment_tolerance feature.
+
+The external loan origination system can introduce a 1-cent rounding
+error per installment.  The tolerance accumulates with the installment
+number so that installment N tolerates N * payment_tolerance.
+"""
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from money_warp import Installment, InterestRate, Loan, Money, Warp
+from money_warp.scheduler import PaymentScheduleEntry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def twelve_installment_loan():
+    """12-installment loan with default 1-cent tolerance."""
+    due_dates = [
+        date(2026, 3, 22), date(2026, 4, 22), date(2026, 5, 22),
+        date(2026, 6, 22), date(2026, 7, 22), date(2026, 8, 22),
+        date(2026, 9, 22), date(2026, 10, 22), date(2026, 11, 22),
+        date(2026, 12, 22), date(2027, 1, 22), date(2027, 2, 22),
+    ]
+    return Loan(
+        Money("10000"),
+        InterestRate("1% m"),
+        due_dates,
+        disbursement_date=datetime(2026, 2, 22, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def three_installment_loan():
+    """3-installment loan for testing tolerance accumulation."""
+    return Loan(
+        Money("10000"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loan.payment_tolerance defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_payment_tolerance_is_one_cent(twelve_installment_loan):
+    assert twelve_installment_loan.payment_tolerance == Money("0.01")
+
+
+def test_custom_payment_tolerance():
+    loan = Loan(
+        Money("10000"),
+        InterestRate("1% m"),
+        [date(2026, 3, 22), date(2026, 4, 22)],
+        disbursement_date=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        payment_tolerance=Money("0.05"),
+    )
+    assert loan.payment_tolerance == Money("0.05")
+
+
+def test_zero_tolerance_gives_exact_matching():
+    loan = Loan(
+        Money("10000"),
+        InterestRate("1% m"),
+        [date(2026, 3, 22), date(2026, 4, 22)],
+        disbursement_date=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        payment_tolerance=Money("0"),
+    )
+    assert loan.payment_tolerance == Money("0")
+
+
+# ---------------------------------------------------------------------------
+# Installment.is_fully_paid -- accumulated tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_installment_carries_loan_payment_tolerance(twelve_installment_loan):
+    inst = twelve_installment_loan.installments[0]
+    assert inst.payment_tolerance == Money("0.01")
+
+
+def test_installment_tolerance_scales_with_number():
+    entry = PaymentScheduleEntry(
+        payment_number=5,
+        due_date=date(2025, 6, 1),
+        days_in_period=30,
+        beginning_balance=Money("5000"),
+        payment_amount=Money("1100"),
+        principal_payment=Money("1000"),
+        interest_payment=Money("100"),
+        ending_balance=Money("4000"),
+    )
+    inst = Installment.from_schedule_entry(
+        entry,
+        allocations=[],
+        expected_mora=Money.zero(),
+        expected_fine=Money.zero(),
+        payment_tolerance=Money("0.01"),
+    )
+    assert inst.is_fully_paid is False
+    assert inst.balance == Money("1100")
+
+
+def test_installment_1_tolerates_one_cent():
+    entry = PaymentScheduleEntry(
+        payment_number=1,
+        due_date=date(2025, 2, 1),
+        days_in_period=31,
+        beginning_balance=Money("10000"),
+        payment_amount=Money("100.01"),
+        principal_payment=Money("90.01"),
+        interest_payment=Money("10.00"),
+        ending_balance=Money("9909.99"),
+    )
+    from money_warp.loan.allocation import Allocation
+
+    alloc = Allocation(
+        installment_number=1,
+        principal_allocated=Money("90.01"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=True,
+    )
+    inst = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc],
+        expected_mora=Money.zero(),
+        expected_fine=Money("0.01"),
+        payment_tolerance=Money("0.01"),
+    )
+    assert inst.balance == Money("0.01")
+    assert inst.is_fully_paid is True
+
+
+def test_installment_1_rejects_two_cent_gap():
+    entry = PaymentScheduleEntry(
+        payment_number=1,
+        due_date=date(2025, 2, 1),
+        days_in_period=31,
+        beginning_balance=Money("10000"),
+        payment_amount=Money("100.02"),
+        principal_payment=Money("90.02"),
+        interest_payment=Money("10.00"),
+        ending_balance=Money("9909.98"),
+    )
+    from money_warp.loan.allocation import Allocation
+
+    alloc = Allocation(
+        installment_number=1,
+        principal_allocated=Money("90.02"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=True,
+    )
+    inst = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc],
+        expected_mora=Money.zero(),
+        expected_fine=Money("0.02"),
+        payment_tolerance=Money("0.01"),
+    )
+    assert inst.balance == Money("0.02")
+    assert inst.is_fully_paid is False
+
+
+def test_installment_12_tolerates_twelve_cents():
+    entry = PaymentScheduleEntry(
+        payment_number=12,
+        due_date=date(2026, 1, 22),
+        days_in_period=31,
+        beginning_balance=Money("900"),
+        payment_amount=Money("900.12"),
+        principal_payment=Money("890.12"),
+        interest_payment=Money("10.00"),
+        ending_balance=Money("0.00"),
+    )
+    from money_warp.loan.allocation import Allocation
+
+    alloc = Allocation(
+        installment_number=12,
+        principal_allocated=Money("890.12"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=True,
+    )
+    inst = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc],
+        expected_mora=Money.zero(),
+        expected_fine=Money("0.12"),
+        payment_tolerance=Money("0.01"),
+    )
+    assert inst.balance == Money("0.12")
+    assert inst.is_fully_paid is True
+
+
+def test_installment_12_rejects_thirteen_cents():
+    entry = PaymentScheduleEntry(
+        payment_number=12,
+        due_date=date(2026, 1, 22),
+        days_in_period=31,
+        beginning_balance=Money("900"),
+        payment_amount=Money("900.13"),
+        principal_payment=Money("890.13"),
+        interest_payment=Money("10.00"),
+        ending_balance=Money("0.00"),
+    )
+    from money_warp.loan.allocation import Allocation
+
+    alloc = Allocation(
+        installment_number=12,
+        principal_allocated=Money("890.13"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=True,
+    )
+    inst = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc],
+        expected_mora=Money.zero(),
+        expected_fine=Money("0.13"),
+        payment_tolerance=Money("0.01"),
+    )
+    assert inst.balance == Money("0.13")
+    assert inst.is_fully_paid is False
+
+
+# ---------------------------------------------------------------------------
+# Loan.is_paid_off -- loan-level tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_is_paid_off_after_full_repayment(three_installment_loan):
+    schedule = three_installment_loan.get_original_schedule()
+    for entry in schedule:
+        three_installment_loan.record_payment(
+            entry.payment_amount,
+            datetime(entry.due_date.year, entry.due_date.month, entry.due_date.day, tzinfo=timezone.utc),
+        )
+    assert three_installment_loan.is_paid_off is True
+
+
+def test_is_paid_off_tolerates_accumulated_error(twelve_installment_loan):
+    schedule = twelve_installment_loan.get_original_schedule()
+    with Warp(twelve_installment_loan, datetime(2027, 3, 1, tzinfo=timezone.utc)) as warped:
+        for entry in schedule:
+            warped.record_payment(
+                entry.payment_amount,
+                datetime(entry.due_date.year, entry.due_date.month, entry.due_date.day, tzinfo=timezone.utc),
+            )
+        assert warped.is_paid_off is True
+
+
+# ---------------------------------------------------------------------------
+# Custom tolerance -- larger than default
+# ---------------------------------------------------------------------------
+
+
+def test_custom_tolerance_propagates_to_installments():
+    loan = Loan(
+        Money("10000"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        payment_tolerance=Money("0.05"),
+    )
+    for inst in loan.installments:
+        assert inst.payment_tolerance == Money("0.05")
+
+
+# ---------------------------------------------------------------------------
+# Zero tolerance -- exact matching
+# ---------------------------------------------------------------------------
+
+
+def test_zero_tolerance_installment_requires_exact_payment():
+    entry = PaymentScheduleEntry(
+        payment_number=1,
+        due_date=date(2025, 2, 1),
+        days_in_period=31,
+        beginning_balance=Money("10000"),
+        payment_amount=Money("100.00"),
+        principal_payment=Money("90.00"),
+        interest_payment=Money("10.00"),
+        ending_balance=Money("9900"),
+    )
+    from money_warp.loan.allocation import Allocation
+
+    alloc = Allocation(
+        installment_number=1,
+        principal_allocated=Money("90.00"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=True,
+    )
+    inst_exact = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc],
+        expected_mora=Money.zero(),
+        expected_fine=Money.zero(),
+        payment_tolerance=Money("0"),
+    )
+    assert inst_exact.balance.is_zero()
+    assert inst_exact.is_fully_paid is True
+
+    alloc_short = Allocation(
+        installment_number=1,
+        principal_allocated=Money("89.99"),
+        interest_allocated=Money("10.00"),
+        mora_allocated=Money.zero(),
+        fine_allocated=Money.zero(),
+        is_fully_covered=False,
+    )
+    inst_short = Installment.from_schedule_entry(
+        entry,
+        allocations=[alloc_short],
+        expected_mora=Money.zero(),
+        expected_fine=Money.zero(),
+        payment_tolerance=Money("0"),
+    )
+    assert inst_short.balance == Money("0.01")
+    assert inst_short.is_fully_paid is False


### PR DESCRIPTION
## Summary
- Adds a `payment_tolerance` parameter to `Loan.__init__` (defaults to `Money("0.01")`) that controls per-installment rounding error tolerance from external origination systems
- Tolerance accumulates by installment number: installment N tolerates `payment_tolerance * N`
- Fixes `ONE_CENT` test constant from `Decimal("0.001")` to `Decimal("0.01")` in the external schedule verification tests

## Changes
- **`money_warp/loan/installment.py`**: Added `payment_tolerance` field to `Installment` dataclass; `is_fully_paid` now uses `self.payment_tolerance * self.number` instead of a flat constant
- **`money_warp/loan/loan.py`**: Added `payment_tolerance` constructor parameter; `is_paid_off` uses `payment_tolerance * len(due_dates)`
- **`money_warp/loan/engines.py`**: Threaded `payment_tolerance` through `compute_state`, `build_installments`, `_build_installments_snapshot`, `distribute_into_installments`, `_apply_coverage_fixup`, and the principal snap-to-zero check
- **`knowledge/loan.md`**: Documented the new parameter and accumulation model
- **`tests/loan/test_payment_tolerance.py`**: 13 new tests covering default, custom, and zero tolerance behavior

## Test plan
- [x] All 2097 tests pass (2084 existing + 13 new)
- [x] External schedule verification tests (28 cases) now pass with corrected ONE_CENT constant
- [x] Tolerance accumulation verified: inst 1 accepts 1 cent / rejects 2 cents; inst 12 accepts 12 cents / rejects 13 cents
- [x] Zero tolerance gives exact-match behavior
- [x] Custom tolerance propagates through to installments

## Docs
- Updated `knowledge/loan.md` with Payment Tolerance section and constructor parameter table entry