### PR TITLE
Parallelize slow external validation tests with pytest-xdist

### DIFF
--- a/knowledge/environment.md
+++ b/knowledge/environment.md
@@ -35,7 +35,8 @@ poetry run pytest               # all tests pass
 ## Daily Workflow
 
 ```bash
-poetry run pytest                         # run tests
+poetry run pytest                         # run tests (fast suite)
+poetry run pytest -m slow -n auto         # run slow tests in parallel (pytest-xdist)
 poetry run black .                        # format
 poetry run isort .                        # sort imports
 poetry run ruff check .                   # lint

--- a/poetry.lock
+++ b/poetry.lock
@@ -721,6 +721,21 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -2723,6 +2738,27 @@ psycopg = ">=3.0.0"
 pytest = ">=8.2"
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3853,4 +3889,4 @@ sa = ["sqlalchemy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "082139099738744a59d7257db846b963ebe5a0066c0fb2bc80140346580e73fa"
+content-hash = "15563e3bc3ff12d8f0b5388e3c929f6f2178a9e4a3ac81fb9490c7bc27c1b94a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ sqlalchemy = "^2.0"
 factory-boy = "^3.3.3"
 pytest-postgresql = "^8.0.0"
 psycopg = {extras = ["binary"], version = "^3.3.3"}
+pytest-xdist = "^3.8.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"


### PR DESCRIPTION
## Summary

- Added `pytest-xdist` as a dev dependency to enable parallel test execution
- The slow external validation suite (2200 cases) drops from **~57 minutes to ~9 minutes** with `-n auto` on 8 cores
- No changes to test logic — each case is stateless and naturally parallelizable

Closes #47

## Test plan

- [x] `poetry run pytest -m slow -n auto` — all 2200 slow tests pass in parallel (~9 min)
- [x] `poetry run pytest` — all 4106 fast tests pass (serial, unchanged behavior)
- [x] No shared mutable state between test cases confirmed