### PR TITLE
fix: derive closing dates before first due date when start_date is after closing day

### DIFF
--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -137,11 +137,17 @@ class BillingCycleLoan:
         from dateutil.relativedelta import relativedelta
 
         far_end = self.start_date + relativedelta(months=self.num_installments + 2)
-        all_dates = self.billing_cycle.closing_dates_between(self.start_date, far_end)
 
         explicit = self.billing_cycle.explicit_due_dates
         if explicit is not None:
             target = explicit[: self.num_installments]
+            earliest_due_dt = self._time_ctx.to_datetime(target[0])
+            search_start = min(self.start_date, earliest_due_dt - relativedelta(months=1))
+            all_dates = self.billing_cycle.closing_dates_between(search_start, far_end)
+        else:
+            all_dates = self.billing_cycle.closing_dates_between(self.start_date, far_end)
+
+        if explicit is not None:
             selected: List[datetime] = []
             for dd in target:
                 match = None

--- a/tests/billing_cycle_loan/test_creation.py
+++ b/tests/billing_cycle_loan/test_creation.py
@@ -98,3 +98,41 @@ def test_mora_defaults_to_interest_rate(simple_loan):
 def test_original_schedule_has_correct_num_entries(simple_loan):
     schedule = simple_loan.get_original_schedule()
     assert len(schedule) == 3
+
+
+def test_first_due_date_before_first_closing_date():
+    """Loan with start_date between closing_day and first due date must not crash."""
+    from zoneinfo import ZoneInfo
+
+    SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+    bc = MonthlyBillingCycle(
+        due_dates=[
+            date(2025, 11, 20),
+            date(2025, 12, 20),
+            date(2026, 1, 20),
+            date(2026, 2, 20),
+        ],
+    )
+    loan = BillingCycleLoan(
+        principal=Money(1000),
+        interest_rate=InterestRate("3% a.m."),
+        billing_cycle=bc,
+        start_date=datetime(2025, 11, 12, tzinfo=SAO_PAULO),
+        num_installments=4,
+        disbursement_date=datetime(2025, 11, 12, tzinfo=SAO_PAULO),
+        tz=SAO_PAULO,
+    )
+    assert loan.due_dates == [
+        date(2025, 11, 20),
+        date(2025, 12, 20),
+        date(2026, 1, 20),
+        date(2026, 2, 20),
+    ]
+    closing = [cd.date() for cd in loan.closing_dates]
+    assert closing == [
+        date(2025, 11, 1),
+        date(2025, 12, 1),
+        date(2026, 1, 1),
+        date(2026, 2, 1),
+    ]
+    assert len(loan.get_original_schedule()) == 4


### PR DESCRIPTION
## Summary

- When explicit due dates exist and `start_date` falls between the closing day and the first due date (e.g. start Nov 12, closing_day=1, first due Nov 20), `_derive_closing_dates()` failed with `ValueError: Could not find a closing date for each explicit due date: expected 4, found 3` because `closing_dates_between()` starts strictly after `start_date`, missing the Nov 1 closing date.
- Extended the search range backward to `min(start_date, earliest_due - 1 month)` so the candidate pool always includes a closing date preceding the first due date. The non-explicit path is untouched.
- Added `test_first_due_date_before_first_closing_date` reproducing the exact bug scenario from the report.

## Test plan

- [x] New test `test_first_due_date_before_first_closing_date` fails without the fix (RED) and passes with it (GREEN)
- [x] Full `tests/billing_cycle_loan/` suite passes (46 tests, 0 regressions)
- [x] Full project test suite passes (4133 passed, 5 xfailed)