### PR TITLE
fix: is_paid_off=True but allocation.is_fully_covered=False

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -136,7 +136,7 @@ The central algorithm in `engines.compute_state`. It processes a merged timeline
 After distributing loan-level totals into per-installment allocations, two adjustments run:
 
 1. **Residual** (`_apply_residual`): ensures `sum(allocations.X) == X_total` for each component. Loan-level accrual can exceed what installments absorb (rounding, partial periods, overpayment); the residual is added to the last allocation.
-2. **Coverage fixup** (`_apply_coverage_fixup`): if the post-payment balance is within tolerance of zero, any allocation whose principal was fully allocated is marked `is_fully_covered = True`.
+2. **Coverage fixup** (`_apply_coverage_fixup`): if the post-payment balance is within `BALANCE_TOLERANCE` of zero (i.e. `post_balance <= BALANCE_TOLERANCE`), any allocation whose principal was fully allocated within the same tolerance (`principal_allocated + BALANCE_TOLERANCE >= principal_owed`) is marked `is_fully_covered = True`. Both gates use the same tolerance so that a sub-cent residual that will be absorbed by `apply_tolerance_adjustment` does not leave the allocation in a state that contradicts `Loan.is_paid_off`.
 
 ## Dynamic Amortization Schedule
 
@@ -347,3 +347,23 @@ Internal dataclass returned by `compute_state`: `settlements`, `principal_balanc
 **Scope:** Both `Loan` and `BillingCycleLoan` were affected and fixed.
 
 **Lesson:** In a forward pass that processes events chronologically, the start of the next accrual period must be the *end* of the previous one, not the timestamp of the event that triggered it. When `interest_date` and `payment_date` diverge, using the wrong one as the accrual boundary creates invisible overlap.
+
+### Coverage fixup skipped when tolerance-adjustment absorbed residual (fixed 2026-04-23)
+
+**Symptom:** `pay_installment` was called with an amount that left a 1-cent principal residual (e.g. `19523.82` principal paid via `19919.86`, where schedule vs. forward-pass rounding left `0.01` unallocated). The subsequent `apply_tolerance_adjustment` added a synthetic `0.01` payment entry, so `Loan.is_paid_off` correctly returned `True` — but the Settlement returned by `pay_installment` still reported `allocation.is_fully_covered = False`, contradicting `is_paid_off`.
+
+**Root cause:** `_apply_coverage_fixup` in `engines/allocation.py` used two exact checks:
+
+1. Outer gate: `if post_balance.is_positive(): return` — skipped the fixup entirely for any positive residual, even a sub-cent one that the tolerance mechanism was about to absorb.
+2. Per-allocation check: `if alloc.principal_allocated >= principal_owed:` — failed by the same sub-cent even when the outer gate would have passed, because the missing `0.01` lived in that specific allocation.
+
+**Fix:** Both checks now use `BALANCE_TOLERANCE`:
+
+- Outer gate: `if post_balance > BALANCE_TOLERANCE: return`.
+- Per-allocation check: `if alloc.principal_allocated + BALANCE_TOLERANCE >= principal_owed:`.
+
+This aligns the coverage flag with the tolerance-adjustment mechanism: a residual small enough to be absorbed by a tolerance CashFlowItem is small enough to count as "fully covered" for the allocation that produced it.
+
+**What was *not* changed:** `Settlement.remaining_balance` still reports the truthful principal balance after the specific payment (e.g. `0.01`). The tolerance CashFlowItem appears as a separate, auditable Settlement in `loan.settlements`. Folding the tolerance amount into the returned Settlement was considered and rejected — it would have bumped `total_paid` above `payment_amount`, violating the allocation-completeness invariant asserted in `tests/loan/settlements/test_allocation_completeness.py`.
+
+**Lesson:** When two mechanisms (`_apply_coverage_fixup` and `apply_tolerance_adjustment`) both exist to handle the same class of rounding residual, they must use the same tolerance constant. Otherwise the tolerance mechanism silently fixes the loan-level view while leaving the settlement-level view in a contradictory state.

--- a/money_warp/engines/allocation.py
+++ b/money_warp/engines/allocation.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 from ..models import Allocation, Installment
 from ..money import Money
+from .constants import BALANCE_TOLERANCE
 
 
 def allocate_payment(
@@ -158,11 +159,13 @@ def _apply_coverage_fixup(
 ) -> None:
     """Override coverage flags when the loan is paid off.
 
-    If the post-payment balance is zero (or negative), any allocation
-    whose principal was fully allocated is marked as fully covered.
+    If the post-payment balance is zero, negative, or within
+    ``BALANCE_TOLERANCE`` (a sub-cent residual that will be absorbed
+    by the tolerance adjustment mechanism), any allocation whose
+    principal was fully allocated is marked as fully covered.
     """
     post_balance = ending_balance - principal_total
-    if post_balance.is_positive():
+    if post_balance > BALANCE_TOLERANCE:
         return
 
     inst_by_number = {inst.number: inst for inst in installments}
@@ -173,7 +176,7 @@ def _apply_coverage_fixup(
         if inst is None:
             continue
         principal_owed = inst.expected_principal - inst.principal_paid
-        if alloc.principal_allocated >= principal_owed:
+        if alloc.principal_allocated + BALANCE_TOLERANCE >= principal_owed:
             allocations[i] = Allocation(
                 installment_number=alloc.installment_number,
                 principal_allocated=alloc.principal_allocated,

--- a/tests/billing_cycle_loan/test_settlements.py
+++ b/tests/billing_cycle_loan/test_settlements.py
@@ -1,8 +1,16 @@
 """Tests for BillingCycleLoan payment settlements."""
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
-from money_warp import Money
+from money_warp import (
+    BillingCycleLoan,
+    InterestRate,
+    Money,
+    PriceScheduler,
+    Warp,
+)
+from money_warp.billing_cycle import MonthlyBillingCycle
 
 
 def test_on_time_payment_first_installment(simple_loan):
@@ -59,3 +67,32 @@ def test_allocation_installment_numbers(simple_loan):
     assert len(s.allocations) == 1
     assert s.allocations[0].installment_number == 1
     assert s.allocations[0].is_fully_covered is True
+
+
+def test_allocation_is_fully_covered_when_tolerance_absorbs_residual():
+    """Regression: is_paid_off=True must imply allocation.is_fully_covered=True.
+
+    Reproduces the reported scenario: a single-installment BillingCycleLoan
+    where forward-pass interest vs. schedule-level rounding leaves a
+    sub-cent principal residual, which is then absorbed by the tolerance
+    adjustment.  The loan becomes paid off but the settlement's allocation
+    used to still report is_fully_covered=False.
+    """
+    sao_paulo = ZoneInfo("America/Sao_Paulo")
+    loan = BillingCycleLoan(
+        principal=Money("19523.82"),
+        interest_rate=InterestRate("26.675% a.a."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[datetime(2025, 12, 12).date()],
+        ),
+        start_date=datetime(2025, 11, 11, tzinfo=sao_paulo),
+        num_installments=1,
+        disbursement_date=datetime(2025, 11, 11, tzinfo=sao_paulo),
+        scheduler=PriceScheduler,
+        tz=sao_paulo,
+    )
+
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=sao_paulo)) as w:
+        settlement = w.pay_installment(Money("19919.86"))
+        assert w.is_paid_off is True
+        assert settlement.allocations[-1].is_fully_covered is True

--- a/tests/loan/test_payment_tolerance.py
+++ b/tests/loan/test_payment_tolerance.py
@@ -206,6 +206,34 @@ def test_installment_is_fully_paid_after_tolerance_adjustment(three_installment_
 
 
 # ---------------------------------------------------------------------------
+# Coverage flag consistency with is_paid_off when tolerance absorbs residual
+# ---------------------------------------------------------------------------
+
+
+def test_allocation_is_fully_covered_when_tolerance_absorbs_residual():
+    """If is_paid_off is True, the allocation must report is_fully_covered=True.
+
+    Regression for the reported contradiction: a single-installment loan paid
+    by an amount that leaves a sub-cent principal residual.  The tolerance
+    adjustment absorbs the residual so the loan is paid off, but the
+    returned Settlement used to still say is_fully_covered=False.
+    """
+    loan = Loan(
+        Money("10000"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    schedule = loan.get_original_schedule()
+    short = schedule[0].payment_amount - Money("0.01")
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as warped:
+        settlement = warped.pay_installment(short)
+        assert warped.is_paid_off is True
+        assert settlement.allocations[-1].is_fully_covered is True
+
+
+# ---------------------------------------------------------------------------
 # Zero tolerance -- no adjustments
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fix the contradiction where `is_paid_off=True` but `allocation.is_fully_covered=False` when a sub-cent principal residual is absorbed by the tolerance-adjustment mechanism.
- Both the outer gate and per-allocation principal check in `_apply_coverage_fixup` now use `BALANCE_TOLERANCE` instead of exact zero, aligning the coverage flag with the tolerance-adjustment mechanism.
- Add regression tests for both `Loan` and `BillingCycleLoan` reproducing the reported scenario.

Closes #54

## Test plan

- [x] `test_allocation_is_fully_covered_when_tolerance_absorbs_residual` in `tests/loan/test_payment_tolerance.py` — generic single-installment Loan with 1-cent shortfall absorbed by tolerance.
- [x] `test_allocation_is_fully_covered_when_tolerance_absorbs_residual` in `tests/billing_cycle_loan/test_settlements.py` — exact user-reported scenario (BillingCycleLoan, 19523.82 principal, 26.675% a.a., paid 19919.86, Sao Paulo tz).
- [x] Targeted regression: `tests/loan/test_payment_tolerance.py`, `tests/loan/test_subcent_balance_bug.py`, `tests/loan/settlements/`, `tests/billing_cycle_loan/` — 237 passed.
- [x] Full suite: 5385 passed, 0 failures.
