### PR TITLE
fix: is_fully_covered=False when payment is R$0.01 short

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -367,3 +367,13 @@ This aligns the coverage flag with the tolerance-adjustment mechanism: a residua
 **What was *not* changed:** `Settlement.remaining_balance` still reports the truthful principal balance after the specific payment (e.g. `0.01`). The tolerance CashFlowItem appears as a separate, auditable Settlement in `loan.settlements`. Folding the tolerance amount into the returned Settlement was considered and rejected — it would have bumped `total_paid` above `payment_amount`, violating the allocation-completeness invariant asserted in `tests/loan/settlements/test_allocation_completeness.py`.
 
 **Lesson:** When two mechanisms (`_apply_coverage_fixup` and `apply_tolerance_adjustment`) both exist to handle the same class of rounding residual, they must use the same tolerance constant. Otherwise the tolerance mechanism silently fixes the loan-level view while leaving the settlement-level view in a contradictory state.
+
+### Per-installment is_fully_covered had no tolerance on multi-installment loans (fixed 2026-04-23)
+
+**Symptom:** When a payment covered an installment within R$0.01, `allocation.is_fully_covered` returned `False`. This affected 126 installments across production loans, all with exactly `mw_gap=0.01`.
+
+**Root cause:** The initial per-installment coverage check in `distribute_into_installments` used an exact comparison: `is_covered = total >= inst.balance`. The existing `_apply_coverage_fixup` only triggers when the **entire loan** is nearly paid off (`post_balance <= BALANCE_TOLERANCE`). For multi-installment loans where only one installment is paid R$0.01 short, the remaining loan balance is far above tolerance, so the fixup never fires.
+
+**Fix:** Added `BALANCE_TOLERANCE` to the per-installment coverage check: `is_covered = total + BALANCE_TOLERANCE >= inst.balance`. This is consistent with how `_apply_coverage_fixup` already uses the same constant for principal-level checks.
+
+**Lesson:** Tolerance must be applied at the point where the decision is made, not only in a downstream fixup that may not run. A fixup gated on loan-level state cannot correct per-installment flags when only one installment is affected.

--- a/money_warp/engines/allocation.py
+++ b/money_warp/engines/allocation.py
@@ -85,7 +85,7 @@ def distribute_into_installments(
 
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
         if total.is_positive():
-            is_covered = total >= inst.balance
+            is_covered = total + BALANCE_TOLERANCE >= inst.balance
             allocations.append(
                 Allocation(
                     installment_number=inst.number,

--- a/tests/billing_cycle_loan/test_settlements.py
+++ b/tests/billing_cycle_loan/test_settlements.py
@@ -69,6 +69,38 @@ def test_allocation_installment_numbers(simple_loan):
     assert s.allocations[0].is_fully_covered is True
 
 
+def test_allocation_is_fully_covered_with_one_cent_gap_multi_installment():
+    """is_fully_covered=True when payment is R$0.01 short on a multi-installment BCL.
+
+    The _apply_coverage_fixup only triggers when the entire loan is nearly
+    paid off.  For a mid-loan installment the initial per-installment check
+    must apply BALANCE_TOLERANCE directly.
+    """
+    sao_paulo = ZoneInfo("America/Sao_Paulo")
+    loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("26.675% a.a."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[
+                datetime(2025, 12, 18).date(),
+                datetime(2026, 1, 18).date(),
+                datetime(2026, 2, 18).date(),
+            ],
+        ),
+        start_date=datetime(2025, 11, 13, tzinfo=sao_paulo),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 13, tzinfo=sao_paulo),
+        scheduler=PriceScheduler,
+        tz=sao_paulo,
+    )
+    schedule = loan.get_original_schedule()
+    short = schedule.entries[0].payment_amount - Money("0.01")
+
+    with Warp(loan, datetime(2025, 12, 18, tzinfo=sao_paulo)) as w:
+        settlement = w.pay_installment(short)
+        assert settlement.allocations[0].is_fully_covered is True
+
+
 def test_allocation_is_fully_covered_when_tolerance_absorbs_residual():
     """Regression: is_paid_off=True must imply allocation.is_fully_covered=True.
 

--- a/tests/billing_cycle_loan/test_settlements.py
+++ b/tests/billing_cycle_loan/test_settlements.py
@@ -102,6 +102,33 @@ def test_allocation_is_fully_covered_with_one_cent_gap_multi_installment():
         assert settlement.allocations[0].is_fully_covered is True
 
 
+def test_allocation_not_fully_covered_with_two_cent_gap_multi_installment():
+    """is_fully_covered=False when payment is R$0.02 short — beyond tolerance."""
+    sao_paulo = ZoneInfo("America/Sao_Paulo")
+    loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("26.675% a.a."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[
+                datetime(2025, 12, 18).date(),
+                datetime(2026, 1, 18).date(),
+                datetime(2026, 2, 18).date(),
+            ],
+        ),
+        start_date=datetime(2025, 11, 13, tzinfo=sao_paulo),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 13, tzinfo=sao_paulo),
+        scheduler=PriceScheduler,
+        tz=sao_paulo,
+    )
+    schedule = loan.get_original_schedule()
+    short = schedule.entries[0].payment_amount - Money("0.02")
+
+    with Warp(loan, datetime(2025, 12, 18, tzinfo=sao_paulo)) as w:
+        settlement = w.pay_installment(short)
+        assert settlement.allocations[0].is_fully_covered is False
+
+
 def test_allocation_is_fully_covered_when_tolerance_absorbs_residual():
     """Regression: is_paid_off=True must imply allocation.is_fully_covered=True.
 

--- a/tests/billing_cycle_loan/test_settlements.py
+++ b/tests/billing_cycle_loan/test_settlements.py
@@ -1,6 +1,7 @@
 """Tests for BillingCycleLoan payment settlements."""
 
 from datetime import datetime, timezone
+
 from zoneinfo import ZoneInfo
 
 from money_warp import (

--- a/tests/loan/test_payment_tolerance.py
+++ b/tests/loan/test_payment_tolerance.py
@@ -259,6 +259,22 @@ def test_allocation_is_fully_covered_with_one_cent_gap_multi_installment():
         assert settlement.allocations[0].is_fully_covered is True
 
 
+def test_allocation_not_fully_covered_with_two_cent_gap_multi_installment():
+    """is_fully_covered=False when payment is R$0.02 short — beyond tolerance."""
+    loan = Loan(
+        Money("10000"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    schedule = loan.get_original_schedule()
+    short = schedule[0].payment_amount - Money("0.02")
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as warped:
+        settlement = warped.pay_installment(short)
+        assert settlement.allocations[0].is_fully_covered is False
+
+
 def test_zero_tolerance_never_adds_adjustment():
     loan = Loan(
         Money("10000"),

--- a/tests/loan/test_payment_tolerance.py
+++ b/tests/loan/test_payment_tolerance.py
@@ -238,6 +238,27 @@ def test_allocation_is_fully_covered_when_tolerance_absorbs_residual():
 # ---------------------------------------------------------------------------
 
 
+def test_allocation_is_fully_covered_with_one_cent_gap_multi_installment():
+    """is_fully_covered=True when payment is R$0.01 short on a multi-installment loan.
+
+    The _apply_coverage_fixup only helps when the entire loan is nearly paid
+    off.  For a mid-loan installment the per-installment check must apply the
+    BALANCE_TOLERANCE itself.
+    """
+    loan = Loan(
+        Money("10000"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    schedule = loan.get_original_schedule()
+    short = schedule[0].payment_amount - Money("0.01")
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as warped:
+        settlement = warped.pay_installment(short)
+        assert settlement.allocations[0].is_fully_covered is True
+
+
 def test_zero_tolerance_never_adds_adjustment():
     loan = Loan(
         Money("10000"),


### PR DESCRIPTION
## Summary

- Added `BALANCE_TOLERANCE` (1 cent) to the per-installment `is_fully_covered` check in `distribute_into_installments`. The existing `_apply_coverage_fixup` only fires when the entire loan is nearly paid off, leaving mid-loan installments with a 1-cent gap incorrectly marked as not fully covered.
- Added regression tests for both `Loan` and `BillingCycleLoan` with multi-installment scenarios.
- Updated `knowledge/loan.md` with a Key Learnings entry.

Closes #56

## Test plan

- [x] New test `test_allocation_is_fully_covered_with_one_cent_gap_multi_installment` in `tests/loan/test_payment_tolerance.py` — 3-installment Loan, first installment paid R$0.01 short
- [x] New test `test_allocation_is_fully_covered_with_one_cent_gap_multi_installment` in `tests/billing_cycle_loan/test_settlements.py` — 3-installment BillingCycleLoan, first installment paid R$0.01 short
- [x] Both tests confirmed failing (RED) before fix, passing (GREEN) after
- [x] Full loan + billing_cycle_loan suite: 4,272 tests pass, 0 regressions