### PR TITLE
Implement CreditCard.get_cash_flow()

### DIFF
--- a/knowledge/credit_card.md
+++ b/knowledge/credit_card.md
@@ -41,6 +41,15 @@ Date-range queries in `_sum_category_between` are data slicing (category sums wi
 
 All validate positive amounts. `purchase` also checks `credit_limit` if set. `date` defaults to `self.now()` (Warp-aware). Transaction methods do NOT close billing cycles — cycle closing is lazy, triggered only by derived properties.
 
+## get_cash_flow()
+
+`get_cash_flow() -> List[CashFlowEntry]` returns a signed cash-flow view of all resolved transactions. Triggers `_close_billing_cycles()` first to materialise interest and fines, then iterates resolved entries:
+
+- Debits (purchase, interest_charge, fine_charge) — returned with original positive amount
+- Credits (payment, refund) — returned with negated (negative) amount
+
+Items are sorted by datetime. Uses `dataclasses.replace()` to create copies of frozen `CashFlowEntry` objects with flipped signs — does not mutate the underlying cash flow.
+
 ## CashFlowItem Categories
 
 | Category | Effect on Balance | Origin |

--- a/money_warp/credit_card/credit_card.py
+++ b/money_warp/credit_card/credit_card.py
@@ -1,11 +1,12 @@
 """CreditCard — revolving credit modeled as a cash-flow state machine."""
 
+from dataclasses import replace
 from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 
 from ..billing_cycle import BaseBillingCycle, MonthlyBillingCycle, Statement
-from ..cash_flow import CashFlow, CashFlowItem
+from ..cash_flow import CashFlow, CashFlowEntry, CashFlowItem
 from ..interest_rate import InterestRate
 from ..money import Money
 from ..time_context import TimeContext
@@ -218,6 +219,21 @@ class CreditCard:
         """Whether the balance is zero (or overpaid)."""
         bal = self.current_balance
         return bal.is_zero() or bal.is_negative()
+
+    def get_cash_flow(self) -> List[CashFlowEntry]:
+        """Return a signed cash-flow view of all resolved transactions.
+
+        Debits (purchases, interest, fines) are positive.
+        Credits (payments, refunds) are negated to negative.
+        Items are sorted by datetime.
+        """
+        self._close_billing_cycles()
+        result = []
+        for entry in self.cash_flow.items():
+            if not entry.category.isdisjoint(_CREDIT_CATEGORIES):
+                entry = replace(entry, amount=-entry.amount)
+            result.append(entry)
+        return sorted(result, key=lambda e: e.datetime)
 
     @property
     def statements(self) -> List[Statement]:

--- a/tests/credit_card/test_cash_flow.py
+++ b/tests/credit_card/test_cash_flow.py
@@ -2,14 +2,9 @@
 
 from datetime import datetime, timezone
 
-import pytest
-
 from money_warp import Money, Warp
 
-xfail_cash_flow = pytest.mark.xfail(reason="get_cash_flow() not yet implemented")
 
-
-@xfail_cash_flow
 def test_cash_flow_contains_purchase(card):
     card.purchase(Money("100.00"), datetime(2024, 1, 5, tzinfo=timezone.utc), "Test")
     with Warp(card, datetime(2024, 1, 6, tzinfo=timezone.utc)) as w:
@@ -20,7 +15,6 @@ def test_cash_flow_contains_purchase(card):
         assert "purchase" in items[0].category
 
 
-@xfail_cash_flow
 def test_cash_flow_payment_is_negative(card):
     card.pay(Money("200.00"), datetime(2024, 1, 5, tzinfo=timezone.utc))
     with Warp(card, datetime(2024, 1, 6, tzinfo=timezone.utc)) as w:
@@ -29,7 +23,6 @@ def test_cash_flow_payment_is_negative(card):
         assert items[0].amount == Money("-200.00")
 
 
-@xfail_cash_flow
 def test_cash_flow_refund_is_negative(card):
     card.refund(Money("50.00"), datetime(2024, 1, 5, tzinfo=timezone.utc))
     with Warp(card, datetime(2024, 1, 6, tzinfo=timezone.utc)) as w:
@@ -38,7 +31,6 @@ def test_cash_flow_refund_is_negative(card):
         assert items[0].amount == Money("-50.00")
 
 
-@xfail_cash_flow
 def test_cash_flow_includes_interest_charge(card):
     card.purchase(Money("1000.00"), datetime(2024, 1, 10, tzinfo=timezone.utc))
     with Warp(card, datetime(2024, 2, 29, tzinfo=timezone.utc)) as w:
@@ -48,7 +40,6 @@ def test_cash_flow_includes_interest_charge(card):
         assert interest_items[0].amount.is_positive()
 
 
-@xfail_cash_flow
 def test_cash_flow_includes_fine_charge(card):
     card.purchase(Money("500.00"), datetime(2024, 1, 10, tzinfo=timezone.utc))
     with Warp(card, datetime(2024, 2, 29, tzinfo=timezone.utc)) as w:


### PR DESCRIPTION
## Summary

- Adds `get_cash_flow()` method to `CreditCard` that returns a signed cash-flow view (debits positive, credits negated), sorted by datetime
- Removes xfail markers from 5 tests that were waiting for this method — all now pass
- Updates knowledge documentation

Closes #62

## Test plan

- [x] 5 previously xfailed tests now pass (`tests/credit_card/test_cash_flow.py`)
- [x] Full test suite passes (5473 tests, 0 failures)
- [x] No linter errors introduced