### PR TITLE
Reorganize invariant tests from tests/engines/ to tests/invariants/

### DIFF
--- a/.cursor/rules/test-patterns.mdc
+++ b/.cursor/rules/test-patterns.mdc
@@ -32,6 +32,7 @@ These rules apply whenever you create or modify test files.
 - Descriptive function names: `test_<action>_<scenario>`
 - One test, one purpose
 - Brief docstring on each test function
+- **Exception**: `tests/invariants/` is a cross-cutting directory for Hypothesis-based property tests that verify domain invariants (allocation sums, balance non-negativity, schedule identities, sequential coverage). These tests exercise the full stack rather than a single module, so they do not mirror a specific source directory.
 
 ## Mandatory Security Tests
 
@@ -48,6 +49,7 @@ Never ask whether to include these. If the endpoint is protected, they are requi
 
 - Use `@pytest.mark.parametrize` with clear `ids` when tests share the same logic but differ in input/output
 - Use `@pytest.fixture` for repeated setup logic (never standalone helper functions)
+- For Hypothesis tests that cannot use pytest fixtures: shared strategies and builder functions live in `tests/invariants/strategies.py` (made importable via `conftest.py` sys.path registration)
 - Use `hypothesis` (`@given()`) for property-based testing of validators and numeric logic
 
 ## Factory-Boy

--- a/.cursor/rules/test-patterns.mdc
+++ b/.cursor/rules/test-patterns.mdc
@@ -49,7 +49,7 @@ Never ask whether to include these. If the endpoint is protected, they are requi
 
 - Use `@pytest.mark.parametrize` with clear `ids` when tests share the same logic but differ in input/output
 - Use `@pytest.fixture` for repeated setup logic (never standalone helper functions)
-- For Hypothesis tests that cannot use pytest fixtures: shared strategies and builder functions live in `tests/invariants/strategies.py` (made importable via `conftest.py` sys.path registration)
+- For Hypothesis tests that cannot use pytest fixtures: shared strategies and builder functions live in `tests/invariants/strategies.py` (importable via relative imports since the directory is a package with `__init__.py`)
 - Use `hypothesis` (`@given()`) for property-based testing of validators and numeric logic
 
 ## Factory-Boy

--- a/knowledge/engines.md
+++ b/knowledge/engines.md
@@ -61,6 +61,21 @@ from ..models import AnticipationResult, Installment, Settlement
 Product-specific engines only contain wiring unique to that product:
 - `billing_cycle_loan/engines.py`: mora rate resolution, `compute_state` wrapper (adds mora callback), statement building.
 
+## Invariant Tests
+
+Property-based invariant tests live in `tests/invariants/`, not `tests/engines/`. This is intentional: these tests verify cross-cutting domain invariants that exercise the full stack (Loan/BCL + Warp + engines), not individual engine functions.
+
+| File | Invariants |
+|------|-----------|
+| `test_schedule.py` | (1-2) Amortization sums to principal, ends at zero; per-row balance and payment identities |
+| `test_balance.py` | (3, 5) Principal balance never negative; installment balances nonneg; `is_fully_paid` implies zero |
+| `test_allocation.py` | (4) Settlement components nonneg and sum to payment amount |
+| `test_allocation_completeness.py` | Per-component allocation sums match settlement totals across all installments |
+| `test_interest.py` | (6-8) Interest monotonicity; covered due-date count non-decreasing; zero mora on/before due date |
+| `test_sequential_coverage.py` | Coverage flags monotonically ordered; no money leaks past uncovered installments |
+
+Shared Hypothesis strategies and helpers (`build_loan`, `make_payment_amount`, etc.) live in `tests/invariants/strategies.py`. The `conftest.py` adds the directory to `sys.path` so test files can import strategies directly.
+
 ## Key Learnings / Gotchas
 
 - **Import order in `__init__.py`**: The re-export order in `engines/__init__.py` doesn't need to match the dependency order -- Python handles submodule loading correctly as long as no circular chain exists.

--- a/tests/invariants/conftest.py
+++ b/tests/invariants/conftest.py
@@ -1,0 +1,10 @@
+"""Shared Hypothesis strategies and helpers for invariant tests.
+
+conftest.py adds this directory to sys.path so test files can import
+the strategies module directly.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/tests/invariants/conftest.py
+++ b/tests/invariants/conftest.py
@@ -1,8 +1,4 @@
-"""Shared Hypothesis strategies and helpers for invariant tests.
-
-conftest.py adds this directory to sys.path so test files can import
-the strategies module directly.
-"""
+"""Make the strategies module importable by adding this directory to sys.path."""
 
 import sys
 from pathlib import Path

--- a/tests/invariants/conftest.py
+++ b/tests/invariants/conftest.py
@@ -1,6 +1,0 @@
-"""Make the strategies module importable by adding this directory to sys.path."""
-
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent))

--- a/tests/invariants/strategies.py
+++ b/tests/invariants/strategies.py
@@ -29,10 +29,7 @@ def build_loan(
     num_installments: int,
     scheduler: type,
 ) -> Loan:
-    due_dates = [
-        (DISBURSEMENT + timedelta(days=30 * (i + 1))).date()
-        for i in range(num_installments)
-    ]
+    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
     return Loan(
         Money(str(principal)),
         InterestRate(f"{annual_rate}% a"),

--- a/tests/invariants/strategies.py
+++ b/tests/invariants/strategies.py
@@ -1,0 +1,47 @@
+"""Shared Hypothesis strategies and helpers for invariant tests."""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from hypothesis import strategies as st
+
+from money_warp import (
+    InterestRate,
+    InvertedPriceScheduler,
+    Loan,
+    Money,
+    PriceScheduler,
+)
+
+DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
+annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
+num_installments_st = st.integers(min_value=2, max_value=12)
+payment_fraction_st = st.floats(min_value=0.05, max_value=1.0)
+scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
+days_offset_st = st.integers(min_value=-25, max_value=90)
+
+
+def build_loan(
+    principal: Decimal,
+    annual_rate: Decimal,
+    num_installments: int,
+    scheduler: type,
+) -> Loan:
+    due_dates = [
+        (DISBURSEMENT + timedelta(days=30 * (i + 1))).date()
+        for i in range(num_installments)
+    ]
+    return Loan(
+        Money(str(principal)),
+        InterestRate(f"{annual_rate}% a"),
+        due_dates,
+        disbursement_date=DISBURSEMENT,
+        scheduler=scheduler,
+    )
+
+
+def make_payment_amount(balance: Money, fraction: float) -> Money:
+    raw = (balance.raw_amount * Decimal(str(fraction))).quantize(Decimal("0.01"))
+    return Money(str(raw))

--- a/tests/invariants/test_allocation.py
+++ b/tests/invariants/test_allocation.py
@@ -7,44 +7,22 @@ These invariants must hold for any payment on any loan:
 """
 
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from money_warp import (
-    InterestRate,
-    InvertedPriceScheduler,
-    Loan,
-    Money,
-    PriceScheduler,
-    Settlement,
-    Warp,
+from money_warp import Settlement, Warp
+
+from strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    make_payment_amount,
+    num_installments_st,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
 )
-
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
-num_installments_st = st.integers(min_value=2, max_value=12)
-payment_fraction_st = st.floats(min_value=0.05, max_value=1.0)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
-
-
-def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int, scheduler: type) -> Loan:
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
-
-
-def _make_payment_amount(balance: Money, fraction: float) -> Money:
-    raw = (balance.raw_amount * Decimal(str(fraction))).quantize(Decimal("0.01"))
-    return Money(str(raw))
 
 
 def _assert_components_nonneg(settlement: Settlement) -> None:
@@ -75,7 +53,7 @@ def test_single_payment_components_nonneg_and_sum(
     principal, annual_rate, num_installments, scheduler, payment_fraction, days_offset
 ):
     """Single payment: all components nonneg and sum to payment amount."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -87,7 +65,7 @@ def test_single_payment_components_nonneg_and_sum(
         return
 
     with Warp(loan, pay_dt) as warped:
-        amount = _make_payment_amount(warped.current_balance, payment_fraction)
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         if amount.is_zero() or amount.is_negative():
             return
         settlement = warped.pay_installment(amount)
@@ -118,7 +96,7 @@ def test_multiple_payments_all_components_nonneg_and_sum(
     principal, annual_rate, num_installments, scheduler, payment_days, fractions
 ):
     """Multiple payments: every settlement has nonneg components that sum correctly."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
 
     all_settlements = []
     for i, day_offset in enumerate(payment_days):
@@ -128,7 +106,7 @@ def test_multiple_payments_all_components_nonneg_and_sum(
             balance = warped.current_balance
             if balance.is_zero() or balance.is_negative():
                 break
-            amount = _make_payment_amount(balance, fractions[i])
+            amount = make_payment_amount(balance, fractions[i])
             if amount.is_zero() or amount.is_negative():
                 continue
             all_settlements.append(warped.pay_installment(amount))

--- a/tests/invariants/test_allocation.py
+++ b/tests/invariants/test_allocation.py
@@ -10,7 +10,10 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
+
+from money_warp import Settlement, Warp
+
+from .strategies import (
     DISBURSEMENT,
     annual_rate_st,
     build_loan,
@@ -20,8 +23,6 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
-
-from money_warp import Settlement, Warp
 
 
 def _assert_components_nonneg(settlement: Settlement) -> None:

--- a/tests/invariants/test_allocation.py
+++ b/tests/invariants/test_allocation.py
@@ -10,9 +10,6 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
-from money_warp import Settlement, Warp
-
 from strategies import (
     DISBURSEMENT,
     annual_rate_st,
@@ -23,6 +20,8 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
+
+from money_warp import Settlement, Warp
 
 
 def _assert_components_nonneg(settlement: Settlement) -> None:

--- a/tests/invariants/test_allocation_completeness.py
+++ b/tests/invariants/test_allocation_completeness.py
@@ -9,6 +9,7 @@ from strategies import (
     DISBURSEMENT,
     annual_rate_st,
     build_loan,
+    make_payment_amount,
     payment_fraction_st,
     principal_st,
     scheduler_st,
@@ -64,9 +65,7 @@ def test_on_time_payment_fully_allocated(principal, annual_rate, num_installment
     )
 
     with Warp(loan, due_date_dt) as warped:
-        amount = Money(
-            str((warped.current_balance.raw_amount * Decimal(str(payment_fraction))).quantize(Decimal("0.01")))
-        )
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         if amount.is_zero() or amount.is_negative():
             return
         settlement = warped.pay_installment(amount)
@@ -99,10 +98,7 @@ def test_early_payment_fully_allocated(
         return
 
     with Warp(loan, early_dt) as warped:
-        amount = Money(
-            str((warped.current_balance.raw_amount * Decimal(str(payment_fraction))).quantize(Decimal("0.01")))
-        )
-
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         settlement = warped.pay_installment(amount)
 
     _assert_fully_allocated(settlement)
@@ -131,10 +127,7 @@ def test_late_payment_with_fines_fully_allocated(
     late_dt = due_date_dt + timedelta(days=days_late)
 
     with Warp(loan, late_dt) as warped:
-        amount = Money(
-            str((warped.current_balance.raw_amount * Decimal(str(payment_fraction))).quantize(Decimal("0.01")))
-        )
-
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         settlement = warped.pay_installment(amount)
 
     _assert_fully_allocated(settlement)
@@ -168,10 +161,7 @@ def test_multiple_sequential_payments_all_fully_allocated(
         )
 
         with Warp(loan, due_date_dt) as warped:
-            amount = Money(
-                str((warped.current_balance.raw_amount * Decimal(str(fractions[i]))).quantize(Decimal("0.01")))
-            )
-
+            amount = make_payment_amount(warped.current_balance, fractions[i])
             warped.pay_installment(amount)
 
     for settlement in loan.settlements:

--- a/tests/invariants/test_allocation_completeness.py
+++ b/tests/invariants/test_allocation_completeness.py
@@ -5,9 +5,6 @@ from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
-from money_warp import Money, Settlement, Warp
-
 from strategies import (
     DISBURSEMENT,
     annual_rate_st,
@@ -16,6 +13,8 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
+
+from money_warp import Money, Settlement, Warp
 
 num_installments_st = st.integers(min_value=1, max_value=12)
 

--- a/tests/invariants/test_allocation_completeness.py
+++ b/tests/invariants/test_allocation_completeness.py
@@ -5,7 +5,10 @@ from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
+
+from money_warp import Money, Settlement, Warp
+
+from .strategies import (
     DISBURSEMENT,
     annual_rate_st,
     build_loan,
@@ -14,8 +17,6 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
-
-from money_warp import Money, Settlement, Warp
 
 num_installments_st = st.integers(min_value=1, max_value=12)
 

--- a/tests/invariants/test_allocation_completeness.py
+++ b/tests/invariants/test_allocation_completeness.py
@@ -6,37 +6,21 @@ from decimal import Decimal
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from money_warp import (
-    InterestRate,
-    InvertedPriceScheduler,
-    Loan,
-    Money,
-    PriceScheduler,
-    Settlement,
-    Warp,
+from money_warp import Money, Settlement, Warp
+
+from strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
 )
 
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
 num_installments_st = st.integers(min_value=1, max_value=12)
-payment_fraction_st = st.floats(min_value=0.10, max_value=1.0)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
 
 
-def _build_loan(principal, annual_rate, num_installments, scheduler):
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
-
-
-def assert_fully_allocated(settlement: Settlement) -> None:
+def _assert_fully_allocated(settlement: Settlement) -> None:
     """Assert the three allocation invariants on a settlement."""
     assert (
         settlement.total_paid == settlement.payment_amount
@@ -72,7 +56,7 @@ def assert_fully_allocated(settlement: Settlement) -> None:
 @settings(max_examples=50)
 def test_on_time_payment_fully_allocated(principal, annual_rate, num_installments, scheduler, payment_fraction):
     """Paying on the due date: all money is accounted for."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -88,7 +72,7 @@ def test_on_time_payment_fully_allocated(principal, annual_rate, num_installment
             return
         settlement = warped.pay_installment(amount)
 
-    assert_fully_allocated(settlement)
+    _assert_fully_allocated(settlement)
 
 
 @given(
@@ -104,7 +88,7 @@ def test_early_payment_fully_allocated(
     principal, annual_rate, num_installments, scheduler, payment_fraction, days_early
 ):
     """Paying before the due date: all money is accounted for."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -122,7 +106,7 @@ def test_early_payment_fully_allocated(
 
         settlement = warped.pay_installment(amount)
 
-    assert_fully_allocated(settlement)
+    _assert_fully_allocated(settlement)
 
 
 @given(
@@ -138,7 +122,7 @@ def test_late_payment_with_fines_fully_allocated(
     principal, annual_rate, num_installments, scheduler, payment_fraction, days_late
 ):
     """Paying after the due date (fines + mora active): all money is accounted for."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -154,7 +138,7 @@ def test_late_payment_with_fines_fully_allocated(
 
         settlement = warped.pay_installment(amount)
 
-    assert_fully_allocated(settlement)
+    _assert_fully_allocated(settlement)
 
 
 @given(
@@ -173,7 +157,7 @@ def test_multiple_sequential_payments_all_fully_allocated(
     principal, annual_rate, num_installments, scheduler, fractions
 ):
     """Multiple payments across due dates: every settlement is fully allocated."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     payments_to_make = min(len(fractions), num_installments)
 
     for i in range(payments_to_make):
@@ -192,4 +176,4 @@ def test_multiple_sequential_payments_all_fully_allocated(
             warped.pay_installment(amount)
 
     for settlement in loan.settlements:
-        assert_fully_allocated(settlement)
+        _assert_fully_allocated(settlement)

--- a/tests/invariants/test_balance.py
+++ b/tests/invariants/test_balance.py
@@ -10,7 +10,10 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
+
+from money_warp import Warp
+
+from .strategies import (
     DISBURSEMENT,
     annual_rate_st,
     build_loan,
@@ -20,8 +23,6 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
-
-from money_warp import Warp
 
 
 @given(

--- a/tests/invariants/test_balance.py
+++ b/tests/invariants/test_balance.py
@@ -7,43 +7,22 @@ These invariants must hold for any loan, any payment amounts, and any timing:
 """
 
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from money_warp import (
-    InterestRate,
-    InvertedPriceScheduler,
-    Loan,
-    Money,
-    PriceScheduler,
-    Warp,
+from money_warp import Warp
+
+from strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    make_payment_amount,
+    num_installments_st,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
 )
-
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
-num_installments_st = st.integers(min_value=2, max_value=12)
-payment_fraction_st = st.floats(min_value=0.05, max_value=1.0)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
-
-
-def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int, scheduler: type) -> Loan:
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
-
-
-def _make_payment_amount(balance: Money, fraction: float) -> Money:
-    raw = (balance.raw_amount * Decimal(str(fraction))).quantize(Decimal("0.01"))
-    return Money(str(raw))
 
 
 @given(
@@ -66,7 +45,7 @@ def _make_payment_amount(balance: Money, fraction: float) -> Money:
 @settings(max_examples=200)
 def test_principal_balance_never_negative(principal, annual_rate, num_installments, scheduler, payment_days, fractions):
     """After any sequence of payments, principal balance is never negative."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
 
     for i, day_offset in enumerate(payment_days):
         pay_dt = DISBURSEMENT + timedelta(days=day_offset)
@@ -75,7 +54,7 @@ def test_principal_balance_never_negative(principal, annual_rate, num_installmen
             balance = warped.current_balance
             if balance.is_zero() or balance.is_negative():
                 break
-            amount = _make_payment_amount(balance, fractions[i])
+            amount = make_payment_amount(balance, fractions[i])
             if amount.is_zero() or amount.is_negative():
                 continue
             warped.pay_installment(amount)
@@ -100,7 +79,7 @@ def test_installment_balance_nonneg_and_consistency(
     principal, annual_rate, num_installments, scheduler, payment_fraction, days_offset
 ):
     """Every installment balance is nonneg; is_fully_paid implies balance == 0."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -112,7 +91,7 @@ def test_installment_balance_nonneg_and_consistency(
         return
 
     with Warp(loan, pay_dt) as warped:
-        amount = _make_payment_amount(warped.current_balance, payment_fraction)
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         if amount.is_zero() or amount.is_negative():
             return
         warped.pay_installment(amount)

--- a/tests/invariants/test_balance.py
+++ b/tests/invariants/test_balance.py
@@ -10,9 +10,6 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
-from money_warp import Warp
-
 from strategies import (
     DISBURSEMENT,
     annual_rate_st,
@@ -23,6 +20,8 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
+
+from money_warp import Warp
 
 
 @given(
@@ -99,6 +98,6 @@ def test_installment_balance_nonneg_and_consistency(
         for inst in warped.installments:
             assert not inst.balance.is_negative(), f"Installment #{inst.number} has negative balance: {inst.balance}"
             if inst.is_fully_paid:
-                assert inst.balance.is_zero(), (
-                    f"Installment #{inst.number} is_fully_paid=True " f"but balance={inst.balance}"
-                )
+                assert (
+                    inst.balance.is_zero()
+                ), f"Installment #{inst.number} is_fully_paid=True but balance={inst.balance}"

--- a/tests/invariants/test_interest.py
+++ b/tests/invariants/test_interest.py
@@ -9,9 +9,6 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
-from money_warp import InterestRate, Money, Warp
-
 from strategies import (
     DISBURSEMENT,
     annual_rate_st,
@@ -22,6 +19,8 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
+
+from money_warp import InterestRate, Money, Warp
 
 
 # ── Invariant 6: Interest monotonicity ──────────────────────────────
@@ -59,9 +58,9 @@ def test_interest_is_nonnegative(principal, annual_rate, days):
     p = Money(str(principal))
 
     interest = rate.accrue(p, days)
-    assert not interest.is_negative(), (
-        f"Interest should be nonneg but got {interest} " f"for principal={principal}, rate={annual_rate}%, days={days}"
-    )
+    assert (
+        not interest.is_negative()
+    ), f"Interest should be nonneg but got {interest} for principal={principal}, rate={annual_rate}%, days={days}"
 
 
 # ── Invariant 7: Covered due date count monotone ────────────────────
@@ -105,10 +104,9 @@ def test_covered_due_date_count_never_decreases(
             warped.pay_installment(amount)
             covered = warped._covered_due_date_count()
 
-            assert covered >= prev_covered, (
-                f"Covered count decreased from {prev_covered} to {covered} "
-                f"after payment of {amount} on day {day_offset}"
-            )
+            assert (
+                covered >= prev_covered
+            ), f"Covered count decreased from {prev_covered} to {covered} after payment of {amount} on day {day_offset}"
             prev_covered = covered
         loan = warped
 
@@ -147,7 +145,7 @@ def test_mora_is_zero_when_paying_on_or_before_due_date(
         settlement = warped.pay_installment(amount)
 
     assert settlement.mora_paid.is_zero(), (
-        f"Mora should be zero for payment on/before due date "
+        "Mora should be zero for payment on/before due date "
         f"but got {settlement.mora_paid} "
         f"(paid {days_early} days early)"
     )

--- a/tests/invariants/test_interest.py
+++ b/tests/invariants/test_interest.py
@@ -9,7 +9,10 @@ from datetime import datetime, timedelta, timezone
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
+
+from money_warp import InterestRate, Money, Warp
+
+from .strategies import (
     DISBURSEMENT,
     annual_rate_st,
     build_loan,
@@ -19,8 +22,6 @@ from strategies import (
     principal_st,
     scheduler_st,
 )
-
-from money_warp import InterestRate, Money, Warp
 
 
 # ── Invariant 6: Interest monotonicity ──────────────────────────────

--- a/tests/invariants/test_interest.py
+++ b/tests/invariants/test_interest.py
@@ -6,43 +6,22 @@
 """
 
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from money_warp import (
-    InterestRate,
-    InvertedPriceScheduler,
-    Loan,
-    Money,
-    PriceScheduler,
-    Warp,
+from money_warp import InterestRate, Money, Warp
+
+from strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    make_payment_amount,
+    num_installments_st,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
 )
-
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
-num_installments_st = st.integers(min_value=2, max_value=12)
-payment_fraction_st = st.floats(min_value=0.05, max_value=1.0)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
-
-
-def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int, scheduler: type) -> Loan:
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
-
-
-def _make_payment_amount(balance: Money, fraction: float) -> Money:
-    raw = (balance.raw_amount * Decimal(str(fraction))).quantize(Decimal("0.01"))
-    return Money(str(raw))
 
 
 # ── Invariant 6: Interest monotonicity ──────────────────────────────
@@ -110,7 +89,7 @@ def test_covered_due_date_count_never_decreases(
     principal, annual_rate, num_installments, scheduler, payment_days, fractions
 ):
     """As payments are made, the count of covered due dates never goes down."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     prev_covered = 0
 
     for i, day_offset in enumerate(payment_days):
@@ -120,7 +99,7 @@ def test_covered_due_date_count_never_decreases(
             balance = warped.current_balance
             if balance.is_zero() or balance.is_negative():
                 break
-            amount = _make_payment_amount(balance, fractions[i])
+            amount = make_payment_amount(balance, fractions[i])
             if amount.is_zero() or amount.is_negative():
                 continue
             warped.pay_installment(amount)
@@ -150,7 +129,7 @@ def test_mora_is_zero_when_paying_on_or_before_due_date(
     principal, annual_rate, num_installments, scheduler, payment_fraction, days_early
 ):
     """Paying on or before the due date produces zero mora."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -162,7 +141,7 @@ def test_mora_is_zero_when_paying_on_or_before_due_date(
         return
 
     with Warp(loan, pay_dt) as warped:
-        amount = _make_payment_amount(warped.current_balance, payment_fraction)
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         if amount.is_zero() or amount.is_negative():
             return
         settlement = warped.pay_installment(amount)

--- a/tests/invariants/test_schedule.py
+++ b/tests/invariants/test_schedule.py
@@ -11,15 +11,14 @@ installments, and scheduler type:
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-
-from money_warp.engines.constants import BALANCE_TOLERANCE
-
 from strategies import (
     annual_rate_st,
     build_loan,
     principal_st,
     scheduler_st,
 )
+
+from money_warp.engines.constants import BALANCE_TOLERANCE
 
 num_installments_st = st.integers(min_value=1, max_value=12)
 

--- a/tests/invariants/test_schedule.py
+++ b/tests/invariants/test_schedule.py
@@ -9,38 +9,19 @@ installments, and scheduler type:
    and payment = principal + interest for every row.
 """
 
-from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from money_warp import (
-    InterestRate,
-    InvertedPriceScheduler,
-    Loan,
-    Money,
-    PriceScheduler,
-)
 from money_warp.engines.constants import BALANCE_TOLERANCE
 
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
+from strategies import (
+    annual_rate_st,
+    build_loan,
+    principal_st,
+    scheduler_st,
+)
 
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
 num_installments_st = st.integers(min_value=1, max_value=12)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
-
-
-def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int, scheduler: type) -> Loan:
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
 
 
 @given(
@@ -52,7 +33,7 @@ def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int,
 @settings(max_examples=200)
 def test_schedule_principal_sums_to_loan_principal(principal, annual_rate, num_installments, scheduler):
     """Sum of all principal payments equals the original loan principal."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     schedule = loan.get_original_schedule()
 
     assert schedule.total_principal + BALANCE_TOLERANCE >= loan.principal
@@ -68,7 +49,7 @@ def test_schedule_principal_sums_to_loan_principal(principal, annual_rate, num_i
 @settings(max_examples=200)
 def test_schedule_last_entry_ends_at_zero(principal, annual_rate, num_installments, scheduler):
     """The last schedule entry has an ending balance at or near zero."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     schedule = loan.get_original_schedule()
     last = schedule.entries[-1]
 
@@ -86,7 +67,7 @@ def test_schedule_last_entry_ends_at_zero(principal, annual_rate, num_installmen
 @settings(max_examples=200)
 def test_per_row_balance_identity(principal, annual_rate, num_installments, scheduler):
     """For every row: beginning_balance - principal_payment == ending_balance."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     schedule = loan.get_original_schedule()
 
     for entry in schedule:
@@ -108,7 +89,7 @@ def test_per_row_balance_identity(principal, annual_rate, num_installments, sche
 @settings(max_examples=200)
 def test_per_row_payment_equals_principal_plus_interest(principal, annual_rate, num_installments, scheduler):
     """For every row: payment_amount == principal_payment + interest_payment."""
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     schedule = loan.get_original_schedule()
 
     for entry in schedule:

--- a/tests/invariants/test_schedule.py
+++ b/tests/invariants/test_schedule.py
@@ -11,14 +11,15 @@ installments, and scheduler type:
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
+
+from money_warp.engines.constants import BALANCE_TOLERANCE
+
+from .strategies import (
     annual_rate_st,
     build_loan,
     principal_st,
     scheduler_st,
 )
-
-from money_warp.engines.constants import BALANCE_TOLERANCE
 
 num_installments_st = st.integers(min_value=1, max_value=12)
 

--- a/tests/invariants/test_sequential_coverage.py
+++ b/tests/invariants/test_sequential_coverage.py
@@ -9,7 +9,6 @@ for arbitrary loan parameters, payment amounts, and timing.
 """
 
 from datetime import date, datetime, timedelta, timezone
-from decimal import Decimal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -19,8 +18,6 @@ from money_warp import (
     BillingCycleLoan,
     BrazilianWorkingDayCalendar,
     InterestRate,
-    InvertedPriceScheduler,
-    Loan,
     Money,
     MonthlyBillingCycle,
     PriceScheduler,
@@ -28,26 +25,19 @@ from money_warp import (
     Warp,
 )
 
+from strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    days_offset_st,
+    make_payment_amount,
+    num_installments_st,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
+)
+
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")
-DISBURSEMENT = datetime(2025, 1, 1, tzinfo=timezone.utc)
-
-principal_st = st.decimals(min_value=1000, max_value=500_000, places=2)
-annual_rate_st = st.decimals(min_value=1, max_value=50, places=1)
-num_installments_st = st.integers(min_value=2, max_value=12)
-payment_fraction_st = st.floats(min_value=0.05, max_value=1.0)
-scheduler_st = st.sampled_from([PriceScheduler, InvertedPriceScheduler])
-days_offset_st = st.integers(min_value=-25, max_value=90)
-
-
-def _build_loan(principal: Decimal, annual_rate: Decimal, num_installments: int, scheduler: type) -> Loan:
-    due_dates = [(DISBURSEMENT + timedelta(days=30 * (i + 1))).date() for i in range(num_installments)]
-    return Loan(
-        Money(str(principal)),
-        InterestRate(f"{annual_rate}% a"),
-        due_dates,
-        disbursement_date=DISBURSEMENT,
-        scheduler=scheduler,
-    )
 
 
 def _resolve_high_mora_rate(reference_date: date, base_mora_rate: InterestRate) -> InterestRate:
@@ -80,11 +70,6 @@ def _assert_sequential_coverage(settlement: Settlement) -> None:
         if not alloc.is_fully_covered:
             seen_uncovered = True
             uncovered_number = alloc.installment_number
-
-
-def _make_payment_amount(balance: Money, fraction: float) -> Money:
-    raw = (balance.raw_amount * Decimal(str(fraction))).quantize(Decimal("0.01"))
-    return Money(str(raw))
 
 
 # ── Deterministic reproduction ──────────────────────────────────────
@@ -154,7 +139,7 @@ def test_single_payment_coverage_always_sequential(
     """A single payment — early, on-time, or late — must never produce
     out-of-order coverage flags.
     """
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
     due_date_dt = datetime(
         loan.due_dates[0].year,
         loan.due_dates[0].month,
@@ -166,7 +151,7 @@ def test_single_payment_coverage_always_sequential(
         return
 
     with Warp(loan, pay_dt) as warped:
-        amount = _make_payment_amount(warped.current_balance, payment_fraction)
+        amount = make_payment_amount(warped.current_balance, payment_fraction)
         if amount.is_zero() or amount.is_negative():
             return
         settlement = warped.pay_installment(amount)
@@ -202,7 +187,7 @@ def test_multiple_payments_coverage_always_sequential(
     flags must be sequential in every settlement regardless of how many
     payments are made or when they land.
     """
-    loan = _build_loan(principal, annual_rate, num_installments, scheduler)
+    loan = build_loan(principal, annual_rate, num_installments, scheduler)
 
     all_settlements = []
     for i, day_offset in enumerate(payment_days):
@@ -212,7 +197,7 @@ def test_multiple_payments_coverage_always_sequential(
             balance = warped.current_balance
             if balance.is_zero() or balance.is_negative():
                 break
-            amount = _make_payment_amount(balance, fractions[i])
+            amount = make_payment_amount(balance, fractions[i])
             if amount.is_zero() or amount.is_negative():
                 continue
             all_settlements.append(warped.pay_installment(amount))

--- a/tests/invariants/test_sequential_coverage.py
+++ b/tests/invariants/test_sequential_coverage.py
@@ -9,22 +9,10 @@ for arbitrary loan parameters, payment amounts, and timing.
 """
 
 from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from zoneinfo import ZoneInfo
-
-from money_warp import (
-    BillingCycleLoan,
-    BrazilianWorkingDayCalendar,
-    InterestRate,
-    Money,
-    MonthlyBillingCycle,
-    PriceScheduler,
-    Settlement,
-    Warp,
-)
-
 from strategies import (
     DISBURSEMENT,
     annual_rate_st,
@@ -35,6 +23,17 @@ from strategies import (
     payment_fraction_st,
     principal_st,
     scheduler_st,
+)
+
+from money_warp import (
+    BillingCycleLoan,
+    BrazilianWorkingDayCalendar,
+    InterestRate,
+    Money,
+    MonthlyBillingCycle,
+    PriceScheduler,
+    Settlement,
+    Warp,
 )
 
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")
@@ -65,7 +64,7 @@ def _assert_sequential_coverage(settlement: Settlement) -> None:
             assert alloc.total_allocated.is_zero(), (
                 f"Installment #{alloc.installment_number} received "
                 f"{alloc.total_allocated} but installment #{uncovered_number} "
-                f"is not fully covered — money must not leak to newer installments"
+                "is not fully covered — money must not leak to newer installments"
             )
         if not alloc.is_fully_covered:
             seen_uncovered = True

--- a/tests/invariants/test_sequential_coverage.py
+++ b/tests/invariants/test_sequential_coverage.py
@@ -13,17 +13,6 @@ from zoneinfo import ZoneInfo
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from strategies import (
-    DISBURSEMENT,
-    annual_rate_st,
-    build_loan,
-    days_offset_st,
-    make_payment_amount,
-    num_installments_st,
-    payment_fraction_st,
-    principal_st,
-    scheduler_st,
-)
 
 from money_warp import (
     BillingCycleLoan,
@@ -34,6 +23,18 @@ from money_warp import (
     PriceScheduler,
     Settlement,
     Warp,
+)
+
+from .strategies import (
+    DISBURSEMENT,
+    annual_rate_st,
+    build_loan,
+    days_offset_st,
+    make_payment_amount,
+    num_installments_st,
+    payment_fraction_st,
+    principal_st,
+    scheduler_st,
 )
 
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")


### PR DESCRIPTION
## Summary

- Renames `tests/engines/` to `tests/invariants/` — the old name implied unit tests for `money_warp/engines/`, but these are cross-cutting property-based invariant tests exercising the full stack
- Consolidates duplicated Hypothesis strategies and helper functions (`_build_loan`, `_make_payment_amount`, `DISBURSEMENT`, etc.) from 6 files into a single shared `strategies.py` module
- Moves `tests/loan/settlements/test_allocation_completeness.py` into `tests/invariants/` alongside its sibling invariant tests
- Drops the redundant `_invariants` suffix from filenames (the directory name already conveys this)

Closes #64

## Test plan

- [x] All 19 invariant tests pass (`poetry run pytest tests/invariants/ -v`)
- [x] Full test suite passes (5473 passed, 0 failed)
- [x] Git correctly tracks file renames (71-82% similarity)