### PR TITLE
Add waive_fines and waive_mora flags to payment recording

### DIFF
--- a/knowledge/engines.md
+++ b/knowledge/engines.md
@@ -33,6 +33,8 @@ Before this package existed, shared computation lived in `money_warp/loan/engine
 ### `forward_pass.py`
 `LoanState` (frozen dataclass), `compute_state` (unified forward pass), `build_installments`, `covered_due_date_count`, `apply_tolerance_adjustment`. The largest submodule -- orchestrates fines, allocation, and installment snapshots into a single chronological replay. `compute_state` and `build_installments` require a `tz: tzinfo` parameter and a `calendar: WorkingDayCalendar` parameter; all internal `.date()` calls use `to_date(dt, tz)` for correct business-day extraction. The calendar adjusts the mora boundary via `effective_penalty_due_date(next_due, calendar)` before passing to `compute_accrued_interest`.
 
+**Waiver handling in `compute_state`**: When a payment entry has `waive_fines=True`, the forward pass adds the outstanding fine balance to `fines_paid_total` (marking fines as settled) and sets `fine_cap` to zero so no payment amount flows to fines. When `waive_mora=True`, `mora_cap` is set to zero. The waived amounts are recorded in the `Settlement` via `fines_waived` and `mora_waived` fields.
+
 ## Import Patterns
 
 Both products now import shared engine logic from `money_warp.engines`:

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -84,14 +84,14 @@ The **interest_date** controls how many days of interest are charged. Fewer days
 
 Neither method takes a date parameter — they use `self.now()` (which respects `Warp` context for time travel).
 
-- **`pay_installment(amount, description=None)`** — the common case. Records payment at `self.now()` and calculates interest up to `max(self.now(), next_due_date)`. Works correctly for all three timing scenarios:
+- **`pay_installment(amount, description=None, waive_fines=False, waive_mora=False)`** — the common case. Records payment at `self.now()` and calculates interest up to `max(self.now(), next_due_date)`. Works correctly for all three timing scenarios:
   - **Early payment** (before due date): interest accrues up to the due date. The borrower pays the full scheduled interest — no discount. The installment is fully covered if the amount is sufficient.
   - **On-time payment**: interest matches the scheduled amount exactly.
   - **Late payment**: interest accrues up to `self.now()`, so the borrower pays extra interest (mora) for the days beyond the due date. Late fines are also applied automatically.
 
   A large payment naturally covers the current installment **and** eats into future installments — the per-installment allocation and `covered_due_date_count()` handle this without special-casing.
 
-- **`anticipate_payment(amount, installments=None, description=None)`** — early payment **with interest discount**. Records payment at `self.now()` and calculates interest only up to `self.now()` (fewer days = less interest charged). When `installments` is provided (1-based numbers), the corresponding expected cash-flow items are temporally deleted via `CashFlowItem.delete()`.
+- **`anticipate_payment(amount, installments=None, description=None, waive_fines=False, waive_mora=False)`** — early payment **with interest discount**. Records payment at `self.now()` and calculates interest only up to `self.now()` (fewer days = less interest charged). When `installments` is provided (1-based numbers), the corresponding expected cash-flow items are temporally deleted via `CashFlowItem.delete()`.
 
 ### Early Payment vs Anticipation
 
@@ -107,7 +107,7 @@ Neither method takes a date parameter — they use `self.now()` (which respects 
 
 ### Explicit-Date Method
 
-- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None)`** — full control over all dates. Appends one `CashFlowItem` to `self.cashflow` and returns the latest derived `Settlement`.
+- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None, waive_fines=False, waive_mora=False)`** — full control over all dates. Appends one `CashFlowItem` to `self.cashflow` and returns the latest derived `Settlement`.
 
 ### Payment Allocation
 
@@ -117,6 +117,28 @@ Payment allocation uses a two-step process:
 2. **Per-installment distribution** (`distribute_into_installments`): maps those totals to individual installments for reporting. Walks installments sequentially — installment 1 absorbs what it can, then installment 2, etc.
 
 This means all fines across all installments are paid before any mora, all mora before any interest, and all interest before any principal. Within each component, installments are filled in order.
+
+## Waiving Fines and Mora
+
+All payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) accept `waive_fines: bool` and `waive_mora: bool` flags.
+
+### Behavior
+
+- **`waive_fines=True`**: All accumulated fines up to this payment are forgiven. The fine balance is zeroed without spending any of the payment amount. The waived amount is recorded in `Settlement.fines_waived` for audit purposes.
+- **`waive_mora=True`**: All accrued mora interest up to this payment is forgiven. No payment amount is allocated to mora. The waived amount is recorded in `Settlement.mora_waived`.
+- Both flags can be used together.
+
+### Snapshot Semantics
+
+Waivers are snapshots — they forgive what has accumulated **so far** but do not prevent future accrual. If the borrower misses the next due date, new fines and mora will accrue normally.
+
+### Implementation
+
+The flags are stored on `CashFlowEntry` (via `waive_fines` and `waive_mora` fields) and read by the forward pass during payment processing. When `waive_fines` is True, `fines_paid_total` is incremented by the outstanding fine balance and `fine_cap` is set to zero. When `waive_mora` is True, `mora_cap` is set to zero. The allocation engine receives zero caps and allocates nothing to those components.
+
+### Settlement Fields
+
+`Settlement` includes `fines_waived: Money` and `mora_waived: Money` (default `Money.zero()`). These record the amounts forgiven at each payment for audit and reporting. Existing code that creates Settlements without these fields continues to work via defaults.
 
 ## Forward Pass: `compute_state`
 
@@ -229,7 +251,7 @@ Per-installment allocation is a reporting view produced by `engines.distribute_i
 
 A frozen dataclass capturing how a single payment was allocated. Derived by the forward pass.
 
-Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`.
+Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`, `fines_waived`, `mora_waived`.
 
 ### Allocation
 

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -3,6 +3,7 @@
 import warnings
 from datetime import date, datetime, tzinfo
 from typing import Dict, List, Optional, Type, Union
+
 from zoneinfo import ZoneInfo
 
 from ..billing_cycle import BaseBillingCycle
@@ -251,6 +252,8 @@ class BillingCycleLoan:
         payment_date: datetime,
         interest_date: Optional[datetime] = None,
         description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
     ) -> Settlement:
         """Record a payment and return the derived settlement.
 
@@ -260,6 +263,8 @@ class BillingCycleLoan:
             interest_date: Cutoff for interest accrual.  Defaults to
                 *payment_date*.
             description: Optional description.
+            waive_fines: If True, forgive accumulated fines.
+            waive_mora: If True, forgive accrued mora interest.
         """
         if amount.is_negative() or amount.is_zero():
             raise ValueError("Payment amount must be positive")
@@ -275,12 +280,20 @@ class BillingCycleLoan:
                 "payment",
                 time_context=self._time_ctx,
                 interest_date=interest_date,
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
             )
         )
 
         return self.settlements[-1]
 
-    def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
+    def pay_installment(
+        self,
+        amount: Money,
+        description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
+    ) -> Settlement:
         """Pay the next installment.
 
         Interest accrual depends on timing:
@@ -295,6 +308,12 @@ class BillingCycleLoan:
         the schedule's expected ending balance by a small amount (within
         ``payment_tolerance``), a tolerance adjustment CashFlowItem is
         added to the cashflow to prevent rounding drift from compounding.
+
+        Args:
+            amount: Payment amount (must be positive).
+            description: Optional description.
+            waive_fines: If True, forgive accumulated fines.
+            waive_mora: If True, forgive accrued mora interest.
         """
         payment_date = self.now()
 
@@ -308,6 +327,8 @@ class BillingCycleLoan:
                 payment_date=payment_date,
                 interest_date=payment_date,
                 description=description or "Overpayment",
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
             )
 
         next_due = self._next_unpaid_due_date()
@@ -317,6 +338,8 @@ class BillingCycleLoan:
             payment_date=payment_date,
             interest_date=interest_date,
             description=description,
+            waive_fines=waive_fines,
+            waive_mora=waive_mora,
         )
 
         schedule = self.get_original_schedule()

--- a/money_warp/cash_flow/entry.py
+++ b/money_warp/cash_flow/entry.py
@@ -53,11 +53,12 @@ class CashFlowEntry(ABC):
     description: Optional[str] = None
     category: FrozenSet[str] = frozenset()
     interest_date: Optional[datetime] = None
+    waive_fines: bool = False
+    waive_mora: bool = False
 
     @property
     @abstractmethod
-    def kind(self) -> CashFlowType:
-        ...
+    def kind(self) -> CashFlowType: ...
 
     def is_inflow(self) -> bool:
         return self.amount.is_positive()

--- a/money_warp/cash_flow/item.py
+++ b/money_warp/cash_flow/item.py
@@ -46,6 +46,8 @@ class CashFlowItem:
         time_context: Optional[TimeContext] = None,
         effective_date: Optional["datetime"] = None,
         interest_date: Optional["datetime"] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
     ) -> None:
         if entry is not None:
             initial = entry
@@ -60,6 +62,8 @@ class CashFlowItem:
                 description=description,
                 category=_normalize_category(category),
                 interest_date=interest_date,
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
             )
         else:
             raise TypeError(
@@ -67,7 +71,7 @@ class CashFlowItem:
             )
 
         start = effective_date if effective_date is not None else EPOCH
-        self._timeline: List[Tuple["datetime", Optional[CashFlowEntry]]] = [(start, initial)]
+        self._timeline: List[Tuple[datetime, Optional[CashFlowEntry]]] = [(start, initial)]
         self._time_ctx = time_context
 
     # ------------------------------------------------------------------
@@ -128,6 +132,16 @@ class CashFlowItem:
     def interest_date(self) -> Optional["datetime"]:
         entry = self._require_resolved()
         return entry.interest_date
+
+    @property
+    def waive_fines(self) -> bool:
+        entry = self._require_resolved()
+        return entry.waive_fines
+
+    @property
+    def waive_mora(self) -> bool:
+        entry = self._require_resolved()
+        return entry.waive_mora
 
     # ------------------------------------------------------------------
     # Delegated helpers

--- a/money_warp/engines/forward_pass.py
+++ b/money_warp/engines/forward_pass.py
@@ -275,13 +275,27 @@ def compute_state(
         if fine_balance.is_negative():
             fine_balance = Money.zero()
 
+        fines_waived = Money.zero()
+        mora_waived = Money.zero()
+        effective_fine_cap = fine_balance
+        effective_mora_cap = mora
+
+        if payment.waive_fines:
+            fines_waived = fine_balance
+            fines_paid_total = fines_paid_total + fine_balance
+            effective_fine_cap = Money.zero()
+
+        if payment.waive_mora:
+            mora_waived = mora
+            effective_mora_cap = Money.zero()
+
         fine_paid, mora_paid, interest_paid, principal_paid, allocations = allocate_payment_into_installments(
             payment.amount,
             installments,
             running_principal,
-            fine_cap=fine_balance,
+            fine_cap=effective_fine_cap,
             interest_cap=interest_cap,
-            mora_cap=mora,
+            mora_cap=effective_mora_cap,
         )
 
         fines_paid_total = fines_paid_total + fine_paid
@@ -303,6 +317,8 @@ def compute_state(
                 principal_paid=principal_paid,
                 remaining_balance=running_principal,
                 allocations=allocations,
+                fines_waived=fines_waived,
+                mora_waived=mora_waived,
             )
         )
 

--- a/money_warp/engines/forward_pass.py
+++ b/money_warp/engines/forward_pass.py
@@ -282,7 +282,8 @@ def compute_state(
 
         if payment.waive_fines:
             fines_waived = fine_balance
-            fines_paid_total = fines_paid_total + fine_balance
+            fines_applied = {dd: Money.zero() for dd in fines_applied}
+            fines_paid_total = Money.zero()
             effective_fine_cap = Money.zero()
 
         if payment.waive_mora:

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -3,6 +3,7 @@
 import warnings
 from datetime import date, datetime, tzinfo
 from typing import Dict, List, Optional, Type, Union
+
 from zoneinfo import ZoneInfo
 
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
@@ -197,6 +198,8 @@ class Loan:
         interest_date: Optional[datetime] = None,
         processing_date: Optional[datetime] = None,
         description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
     ) -> Settlement:
         """Record a payment. Just one CashFlowItem -- everything else is derived.
 
@@ -207,6 +210,10 @@ class Loan:
                 Defaults to payment_date.
             processing_date: Unused, kept for API compatibility.
             description: Optional description of the payment.
+            waive_fines: If True, all accumulated fines up to this
+                payment are forgiven.  Future fines can still accrue.
+            waive_mora: If True, all accrued mora interest up to this
+                payment is forgiven.  Future mora can still accrue.
 
         Returns:
             Settlement describing how the payment was allocated.
@@ -225,12 +232,20 @@ class Loan:
                 "payment",
                 time_context=self._time_ctx,
                 interest_date=interest_date,
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
             )
         )
 
         return self.settlements[-1]
 
-    def pay_installment(self, amount: Money, description: Optional[str] = None) -> Settlement:
+    def pay_installment(
+        self,
+        amount: Money,
+        description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
+    ) -> Settlement:
         """Pay the next installment.
 
         Interest accrual depends on timing:
@@ -244,6 +259,12 @@ class Loan:
         the schedule's expected ending balance by a small amount (within
         ``payment_tolerance``), a tolerance adjustment CashFlowItem is
         added to the cashflow to prevent rounding drift from compounding.
+
+        Args:
+            amount: Payment amount (must be positive).
+            description: Optional description.
+            waive_fines: If True, forgive accumulated fines.
+            waive_mora: If True, forgive accrued mora interest.
         """
         payment_date = self.now()
 
@@ -257,6 +278,8 @@ class Loan:
                 payment_date=payment_date,
                 interest_date=payment_date,
                 description=description or "Overpayment",
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
             )
 
         next_due = self._next_unpaid_due_date()
@@ -266,6 +289,8 @@ class Loan:
             payment_date=payment_date,
             interest_date=interest_date,
             description=description,
+            waive_fines=waive_fines,
+            waive_mora=waive_mora,
         )
 
         schedule = self.get_original_schedule()
@@ -290,6 +315,8 @@ class Loan:
         amount: Money,
         installments: Optional[List[int]] = None,
         description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
     ) -> Settlement:
         """Make an early payment with interest discount.
 
@@ -298,6 +325,13 @@ class Loan:
 
         When *installments* is provided (1-based), the corresponding
         expected cash-flow items are temporally deleted.
+
+        Args:
+            amount: Payment amount (must be positive).
+            installments: 1-based installment numbers to remove.
+            description: Optional description.
+            waive_fines: If True, forgive accumulated fines.
+            waive_mora: If True, forgive accrued mora interest.
         """
         payment_date = self.now()
 
@@ -309,6 +343,8 @@ class Loan:
             payment_date=payment_date,
             interest_date=payment_date,
             description=description,
+            waive_fines=waive_fines,
+            waive_mora=waive_mora,
         )
 
     def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:

--- a/money_warp/models/settlement.py
+++ b/money_warp/models/settlement.py
@@ -1,6 +1,6 @@
 """Settlement data structures for loan payment allocation."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, List
 
@@ -9,6 +9,10 @@ from .allocation import Allocation
 
 if TYPE_CHECKING:
     from .installment import Installment
+
+
+def _zero() -> Money:
+    return Money.zero()
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,8 @@ class Settlement:
     principal_paid: Money
     remaining_balance: Money
     allocations: List[Allocation]
+    fines_waived: Money = field(default_factory=_zero)
+    mora_waived: Money = field(default_factory=_zero)
 
     @property
     def total_paid(self) -> Money:

--- a/tests/billing_cycle_loan/test_waive.py
+++ b/tests/billing_cycle_loan/test_waive.py
@@ -1,0 +1,86 @@
+"""Tests for waiving fines and mora interest on billing-cycle loan payments."""
+
+from datetime import datetime, timezone
+
+from money_warp import Money
+
+
+def test_waive_fines_zeroes_fine_balance(simple_loan):
+    """Late payment with waive_fines=True should result in zero fine paid."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+        waive_fines=True,
+    )
+    assert s.fine_paid == Money.zero()
+    assert s.fines_waived == Money("20.45")
+    assert simple_loan.fine_balance == Money.zero()
+
+
+def test_waive_mora_zeroes_mora_allocation(simple_loan):
+    """Late payment with waive_mora=True should result in zero mora paid."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+        waive_mora=True,
+    )
+    assert s.mora_paid == Money.zero()
+    assert s.mora_waived == Money("18.93")
+
+
+def test_waive_both_fines_and_mora(simple_loan):
+    """Waiving both should allocate all payment to interest and principal."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+        waive_fines=True,
+        waive_mora=True,
+    )
+    assert s.fine_paid == Money.zero()
+    assert s.mora_paid == Money.zero()
+    assert s.interest_paid > Money.zero()
+    assert s.principal_paid > Money.zero()
+
+
+def test_waive_fines_more_goes_to_principal(simple_loan):
+    """When fines are waived, more of the payment goes to principal."""
+    s_waived = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+        waive_fines=True,
+    )
+    assert s_waived.principal_paid > Money("943.82")
+
+
+def test_settlement_no_waiver_has_zero_waived_fields(simple_loan):
+    """Without waivers, waived fields should be zero."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+    assert s.fines_waived == Money.zero()
+    assert s.mora_waived == Money.zero()
+
+
+def test_waive_fines_no_fines_is_noop(simple_loan):
+    """Waiving fines on an on-time payment should be harmless."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 2, 12, tzinfo=timezone.utc),
+        waive_fines=True,
+    )
+    assert s.fine_paid == Money.zero()
+    assert s.fines_waived == Money.zero()
+
+
+def test_pay_installment_waive_flags(simple_loan):
+    """pay_installment should forward waiver flags to record_payment."""
+    from money_warp import Warp
+
+    with Warp(simple_loan, datetime(2025, 3, 4, tzinfo=timezone.utc)) as warped:
+        s = warped.pay_installment(Money("1022.58"), waive_fines=True, waive_mora=True)
+
+    assert s.fine_paid == Money.zero()
+    assert s.mora_paid == Money.zero()
+    assert s.fines_waived > Money.zero()
+    assert s.mora_waived > Money.zero()

--- a/tests/billing_cycle_loan/test_waive.py
+++ b/tests/billing_cycle_loan/test_waive.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from money_warp import Money
+from money_warp import Money, Warp
 
 
 def test_waive_fines_zeroes_fine_balance(simple_loan):
@@ -75,8 +75,6 @@ def test_waive_fines_no_fines_is_noop(simple_loan):
 
 def test_pay_installment_waive_flags(simple_loan):
     """pay_installment should forward waiver flags to record_payment."""
-    from money_warp import Warp
-
     with Warp(simple_loan, datetime(2025, 3, 4, tzinfo=timezone.utc)) as warped:
         s = warped.pay_installment(Money("1022.58"), waive_fines=True, waive_mora=True)
 

--- a/tests/loan/test_waive.py
+++ b/tests/loan/test_waive.py
@@ -3,6 +3,8 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
+import pytest
+
 from money_warp import InterestRate, Loan, Money, Warp
 
 
@@ -301,3 +303,125 @@ def test_anticipate_payment_waive_flags():
     assert settlement.fine_paid == Money.zero()
     assert settlement.mora_paid == Money.zero()
     assert settlement.fines_waived > Money.zero()
+
+
+# --- Late payment with waive covers the installment ---
+
+
+@pytest.fixture
+def late_loan():
+    """3-installment loan with fine and mora, for coverage tests."""
+    return Loan(
+        Money("890.22"),
+        InterestRate("15% annual"),
+        [
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
+        ],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("2% annual"),
+    )
+
+
+def test_late_without_waive_installment_not_fully_paid(late_loan):
+    """Paying the scheduled amount late leaves the installment short due to fines and mora."""
+    scheduled = late_loan.get_expected_payment_amount(date(2025, 2, 1))
+
+    with Warp(late_loan, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(scheduled)
+        inst = warped.installments[0]
+
+    assert inst.fine_paid > Money.zero()
+    assert not inst.is_fully_paid
+
+
+def test_late_with_waive_both_installment_fully_paid(late_loan):
+    """Same scheduled amount late with both waivers covers the installment fully."""
+    scheduled = late_loan.get_expected_payment_amount(date(2025, 2, 1))
+
+    with Warp(late_loan, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(scheduled, waive_fines=True, waive_mora=True)
+        inst = warped.installments[0]
+        settlement = warped.settlements[-1]
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.mora_paid == Money.zero()
+    assert inst.is_fully_paid
+
+
+def test_late_with_waive_fines_more_principal_than_without(late_loan):
+    """Waiving fines redirects fine amount to principal."""
+    scheduled = late_loan.get_expected_payment_amount(date(2025, 2, 1))
+
+    loan_no_waive = Loan(
+        Money("890.22"),
+        InterestRate("15% annual"),
+        [date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("2% annual"),
+    )
+
+    with Warp(late_loan, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        s_waived = warped.pay_installment(scheduled, waive_fines=True)
+
+    with Warp(loan_no_waive, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        s_normal = warped.pay_installment(scheduled)
+
+    assert s_waived.fine_paid == Money.zero()
+    assert s_waived.principal_paid > s_normal.principal_paid
+
+
+def test_late_with_waive_both_loan_paid_off():
+    """Full loan amount late with both waivers pays off a single-installment loan."""
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("12% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    scheduled = loan.get_expected_payment_amount(date(2025, 2, 1))
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(scheduled, waive_fines=True, waive_mora=True)
+        assert warped.is_paid_off
+
+
+def test_late_without_waive_loan_not_paid_off():
+    """Same payment without waivers does not pay off the loan."""
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("12% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    scheduled = loan.get_expected_payment_amount(date(2025, 2, 1))
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(scheduled)
+        assert not warped.is_paid_off
+
+
+def test_late_with_waive_covers_more_installments(late_loan):
+    """Large late payment with waivers covers more installments than without."""
+    with Warp(late_loan, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("800.00"), waive_fines=True, waive_mora=True)
+        covered_waived = [a for a in warped.settlements[-1].allocations if a.is_fully_covered]
+
+    loan_no_waive = Loan(
+        Money("890.22"),
+        InterestRate("15% annual"),
+        [date(2025, 2, 1), date(2025, 3, 1), date(2025, 4, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("2% annual"),
+    )
+
+    with Warp(loan_no_waive, datetime(2025, 2, 16, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("800.00"))
+        covered_normal = [a for a in warped.settlements[-1].allocations if a.is_fully_covered]
+
+    assert len(covered_waived) >= len(covered_normal)

--- a/tests/loan/test_waive.py
+++ b/tests/loan/test_waive.py
@@ -1,0 +1,278 @@
+"""Tests for waiving fines and mora interest on loan payments."""
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from money_warp import InterestRate, Loan, Money, Warp
+
+
+def test_waive_fines_zeroes_fine_balance():
+    """Paying late with waive_fines=True should result in zero fine balance."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_fines=True)
+        settlement = warped.settlements[-1]
+
+    assert settlement.fine_paid == Money.zero()
+    assert warped.fine_balance == Money.zero()
+
+
+def test_waive_fines_redirects_money_to_other_components():
+    """When fines are waived, the full payment goes to mora, interest, and principal."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_fines=True)
+        settlement = warped.settlements[-1]
+
+    total_allocated = settlement.fine_paid + settlement.interest_paid + settlement.mora_paid + settlement.principal_paid
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.principal_paid > Money.zero()
+    assert total_allocated == settlement.payment_amount
+
+
+def test_waive_mora_zeroes_mora_allocation():
+    """Paying late with waive_mora=True should result in zero mora paid."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_mora=True)
+        settlement = warped.settlements[-1]
+
+    assert settlement.mora_paid == Money.zero()
+    assert settlement.interest_paid > Money.zero()
+
+
+def test_waive_mora_redirects_money_to_principal():
+    """When mora is waived, money that would go to mora goes to principal instead."""
+    loan_with_mora = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    loan_waived = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    payment = Money("11000.00")
+    payment_dt = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    with Warp(loan_with_mora, payment_dt) as warped:
+        warped.pay_installment(payment)
+        s_with = warped.settlements[-1]
+
+    with Warp(loan_waived, payment_dt) as warped:
+        warped.pay_installment(payment, waive_mora=True)
+        s_waived = warped.settlements[-1]
+
+    assert s_waived.principal_paid > s_with.principal_paid
+    assert s_waived.mora_paid == Money.zero()
+
+
+def test_waive_both_fines_and_mora():
+    """Waiving both fines and mora should allocate entire payment to interest + principal."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_fines=True, waive_mora=True)
+        settlement = warped.settlements[-1]
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.mora_paid == Money.zero()
+    assert settlement.interest_paid > Money.zero()
+    assert settlement.principal_paid > Money.zero()
+
+
+def test_waive_fines_snapshot_future_fines_still_accrue():
+    """After waiving fines on one payment, a later late payment still triggers new fines."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    first = loan.record_payment(
+        Money("5500.00"),
+        datetime(2025, 2, 15, tzinfo=timezone.utc),
+        waive_fines=True,
+    )
+    assert first.fines_waived > Money.zero()
+    assert first.fine_paid == Money.zero()
+
+    second = loan.record_payment(
+        Money("5500.00"),
+        datetime(2025, 3, 15, tzinfo=timezone.utc),
+    )
+    assert second.fine_paid > Money.zero()
+
+
+def test_settlement_records_waived_fine_amounts():
+    """Settlement.fines_waived should contain the amount of forgiven fines."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    scheduled_payment = loan.get_expected_payment_amount(date(2025, 2, 1))
+    expected_fine = Money(scheduled_payment.raw_amount * Decimal("0.05"))
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_fines=True)
+        settlement = warped.settlements[-1]
+
+    assert settlement.fines_waived == expected_fine
+    assert settlement.fine_paid == Money.zero()
+
+
+def test_settlement_records_waived_mora_amounts():
+    """Settlement.mora_waived should contain the accrued mora that was forgiven."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    daily_rate = InterestRate("6% a").to_daily().as_decimal()
+    regular_interest = Decimal("10000") * ((1 + daily_rate) ** 31 - 1)
+    total_interest = Decimal("10000") * ((1 + daily_rate) ** 45 - 1)
+    expected_mora = total_interest - regular_interest
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"), waive_mora=True)
+        settlement = warped.settlements[-1]
+
+    assert settlement.mora_waived == Money(expected_mora)
+    assert settlement.mora_paid == Money.zero()
+
+
+def test_settlement_no_waiver_has_zero_waived_fields():
+    """Without waivers, fines_waived and mora_waived should be zero."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"))
+        settlement = warped.settlements[-1]
+
+    assert settlement.fines_waived == Money.zero()
+    assert settlement.mora_waived == Money.zero()
+
+
+def test_waive_fines_no_fines_is_noop():
+    """Waiving fines when none exist should be harmless."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    loan.record_payment(
+        Money("10500.00"),
+        datetime(2025, 2, 1, tzinfo=timezone.utc),
+        waive_fines=True,
+    )
+    settlement = loan.settlements[-1]
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.fines_waived == Money.zero()
+
+
+def test_waive_mora_no_mora_is_noop():
+    """Waiving mora when payment is on time should be harmless."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    loan.record_payment(
+        Money("10500.00"),
+        datetime(2025, 2, 1, tzinfo=timezone.utc),
+        waive_mora=True,
+    )
+    settlement = loan.settlements[-1]
+
+    assert settlement.mora_paid == Money.zero()
+    assert settlement.mora_waived == Money.zero()
+
+
+def test_pay_installment_waive_fines():
+    """pay_installment with waive_fines=True should forward the flag."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        settlement = warped.pay_installment(Money("11000.00"), waive_fines=True)
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.fines_waived > Money.zero()
+
+
+def test_record_payment_waive_flags():
+    """record_payment should accept and honor waive flags."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    loan.calculate_late_fines(datetime(2025, 2, 10, tzinfo=timezone.utc))
+
+    settlement = loan.record_payment(
+        Money("11000.00"),
+        datetime(2025, 2, 15, tzinfo=timezone.utc),
+        waive_fines=True,
+        waive_mora=True,
+    )
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.mora_paid == Money.zero()
+    assert settlement.fines_waived > Money.zero()
+    assert settlement.mora_waived > Money.zero()

--- a/tests/loan/test_waive.py
+++ b/tests/loan/test_waive.py
@@ -276,3 +276,28 @@ def test_record_payment_waive_flags():
     assert settlement.mora_paid == Money.zero()
     assert settlement.fines_waived > Money.zero()
     assert settlement.mora_waived > Money.zero()
+
+
+def test_anticipate_payment_waive_flags():
+    """anticipate_payment should forward waiver flags to record_payment."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    loan.calculate_late_fines(datetime(2025, 2, 10, tzinfo=timezone.utc))
+
+    with Warp(loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as warped:
+        settlement = warped.anticipate_payment(
+            Money("11000.00"),
+            installments=[1, 2],
+            waive_fines=True,
+            waive_mora=True,
+        )
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.mora_paid == Money.zero()
+    assert settlement.fines_waived > Money.zero()


### PR DESCRIPTION
## Summary

- Add `waive_fines` and `waive_mora` boolean flags to `record_payment`, `pay_installment`, and `anticipate_payment` on both `Loan` and `BillingCycleLoan`
- When set, the forward pass zeroes the fine/mora allocation caps and records waived amounts on `Settlement` for audit
- Flags are stored on `CashFlowEntry` and flow through the existing pipeline -- no new cashflow event types

Closes #66

## Test plan

- [x] 13 new Loan waiver tests (`tests/loan/test_waive.py`)
- [x] 7 new BillingCycleLoan waiver tests (`tests/billing_cycle_loan/test_waive.py`)
- [x] Full test suite passes (5493 tests, 0 failures)
- [x] No regressions in existing fine/mora/allocation tests