### PR TITLE
fix: grace_period_days eliminates both fines and mora

### DIFF
--- a/knowledge/billing_cycle_loan.md
+++ b/knowledge/billing_cycle_loan.md
@@ -37,7 +37,7 @@ The `BillingCycleLoan` models a personal loan where principal is amortized on a 
 | `disbursement_date` | `Optional[datetime]` | `now()` | Must be before first due date |
 | `scheduler` | `Optional[Type[BaseScheduler]]` | `PriceScheduler` | Amortization strategy |
 | `fine_rate` | `Optional[InterestRate]` | `InterestRate("2% annual")` | Fine rate on missed payments |
-| `grace_period_days` | `int` | `0` | Days after due date before fines |
+| `grace_period_days` | `int` | `0` | Days after due date before fines and mora (threshold, not shift) |
 | `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Base mora rate |
 | `mora_rate_resolver` | `Optional[MoraRateResolver]` | `None` | Per-cycle mora adjustment |
 | `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora compounds |

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -45,7 +45,7 @@ The forward pass merges payment events with fine observation dates into a sorted
 | `disbursement_date` | `Optional[datetime]` | now | When funds are released; must be strictly before first due date |
 | `scheduler` | `Optional[Type[BaseScheduler]]` | `PriceScheduler` | Amortization strategy |
 | `fine_rate` | `Optional[InterestRate]` | `InterestRate("2% annual")` | Fine rate applied to expected payment |
-| `grace_period_days` | `int` | `0` | Days after due date before fines apply |
+| `grace_period_days` | `int` | `0` | Days after due date before fines and mora apply (threshold, not shift — see Grace Period below) |
 | `mora_interest_rate` | `Optional[InterestRate]` | `interest_rate` | Rate used for mora (late) interest; defaults to the base rate |
 | `mora_strategy` | `MoraStrategy` | `COMPOUND` | How mora interest is computed (see Mora Strategy below) |
 | `payment_tolerance` | `Optional[Money]` | `Money("0.01")` | Per-installment rounding error tolerance (see Payment Tolerance below) |
@@ -188,6 +188,15 @@ Fixed total payment per period. The PMT is computed as `principal / sum(1 / (1 +
 Fixed principal payment per period (`principal / number_of_payments`). Interest is computed on the outstanding balance.
 
 ## Late Payments
+
+### Grace Period
+
+The `grace_period_days` parameter acts as a **forgiveness threshold** for both fines and mora. It is all-or-nothing:
+
+- **Within grace period** (payment date ≤ due date + grace days): no fine, no mora. Any interest accrued beyond the due date is reclassified as regular interest.
+- **After grace period** (payment date > due date + grace days): full fine + full mora. Mora is computed from the (working-day-adjusted) due date, not from the grace period end.
+
+The gate is implemented via `is_payment_late` checks in the forward pass (`compute_state`) and the installment snapshot builder (`_build_installments_snapshot`).
 
 ### Fines
 
@@ -400,3 +409,13 @@ This aligns the coverage flag with the tolerance-adjustment mechanism: a residua
 **Fix:** Added `BALANCE_TOLERANCE` to the per-installment coverage check: `is_covered = total + BALANCE_TOLERANCE >= inst.balance`. This is consistent with how `_apply_coverage_fixup` already uses the same constant for principal-level checks.
 
 **Lesson:** Tolerance must be applied at the point where the decision is made, not only in a downstream fixup that may not run. A fixup gated on loan-level state cannot correct per-installment flags when only one installment is affected.
+
+### Grace period only eliminated fines, not mora (fixed 2026-05-04)
+
+**Symptom:** A payment within the grace period was charged mora interest. Only fines were deferred by `grace_period_days`; mora started accruing from the due date regardless.
+
+**Root cause:** In `compute_state`, the mora boundary (`penalty_next_due`) was set to the working-day-adjusted due date without adding `grace_period_days`. The `is_payment_late` check (which does add `grace_period_days`) was only used for the fine computation in `compute_fines_at`, not for the mora split.
+
+**Fix:** After computing `regular` and `mora` interest in the forward pass, added an `is_payment_late` gate: if the payment is within the grace period, mora is reclassified as regular interest (`regular += mora; mora = 0`). Same gate applied in `_build_installments_snapshot` for the display estimate. The mora computation itself stays anchored to the due date — when the grace period is exceeded, full mora accrues from the due date (not from the grace period end).
+
+**Lesson:** When two penalty types (fine and mora) share the same grace period concept, the gate must be applied to both. Implementing it in only one path creates an inconsistency that is hard to spot because the two computations live in different functions.

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -3,7 +3,6 @@
 import warnings
 from datetime import date, datetime, tzinfo
 from typing import Dict, List, Optional, Type, Union
-
 from zoneinfo import ZoneInfo
 
 from ..billing_cycle import BaseBillingCycle

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -411,6 +411,7 @@ class BillingCycleLoan:
             state.last_accrual_end,
             tz=self._time_ctx.tz,
             calendar=self.working_day_calendar,
+            grace_period_days=self.grace_period_days,
         )
 
     @property

--- a/money_warp/cash_flow/entry.py
+++ b/money_warp/cash_flow/entry.py
@@ -58,7 +58,8 @@ class CashFlowEntry(ABC):
 
     @property
     @abstractmethod
-    def kind(self) -> CashFlowType: ...
+    def kind(self) -> CashFlowType:
+        ...
 
     def is_inflow(self) -> bool:
         return self.amount.is_positive()

--- a/money_warp/engines/forward_pass.py
+++ b/money_warp/engines/forward_pass.py
@@ -20,7 +20,7 @@ from ..tz import to_date, to_datetime
 from ..working_day import EveryDayCalendar, WorkingDayCalendar, effective_penalty_due_date
 from .allocation import allocate_payment_into_installments
 from .constants import BALANCE_TOLERANCE
-from .fines import compute_fines_at
+from .fines import compute_fines_at, is_payment_late
 from .interest import InterestCalculator, MoraRateCallback
 
 _DEFAULT_CALENDAR = EveryDayCalendar()
@@ -101,6 +101,7 @@ def _build_installments_snapshot(
     tz: tzinfo,
     last_payment_date: Optional[datetime] = None,
     calendar: WorkingDayCalendar = _DEFAULT_CALENDAR,
+    grace_period_days: int = 0,
 ) -> List[Installment]:
     """Build Installment objects from pre-computed allocation data."""
     covered = covered_due_date_count(principal_balance, schedule)
@@ -116,8 +117,11 @@ def _build_installments_snapshot(
         if i < covered:
             expected_mora = prior_mora
         elif i == covered and entry.due_date < to_date(as_of_date, tz):
-            penalty_due = effective_penalty_due_date(entry.due_date, calendar)
-            if last_payment_date is not None:
+            within_grace = not is_payment_late(entry.due_date, grace_period_days, as_of_date, tz, calendar)
+            if within_grace:
+                accrued_mora = Money.zero()
+            elif last_payment_date is not None:
+                penalty_due = effective_penalty_due_date(entry.due_date, calendar)
                 total_days = (to_date(as_of_date, tz) - to_date(last_payment_date, tz)).days
                 _, accrued_mora = interest_calc.compute_accrued_interest(
                     total_days,
@@ -127,6 +131,7 @@ def _build_installments_snapshot(
                     last_payment_date,
                 )
             else:
+                penalty_due = effective_penalty_due_date(entry.due_date, calendar)
                 days_overdue = max(0, (to_date(as_of_date, tz) - penalty_due).days)
                 _, accrued_mora = interest_calc.compute_accrued_interest(
                     days_overdue,
@@ -255,6 +260,10 @@ def compute_state(
             mora_rate_override=mora_override,
         )
 
+        if next_due and not is_payment_late(next_due, grace_period_days, payment.datetime, tz, calendar):
+            regular = regular + mora
+            mora = Money.zero()
+
         installments = _build_installments_snapshot(
             allocs_by_number,
             running_principal,
@@ -265,6 +274,7 @@ def compute_state(
             tz,
             last_payment_date=last_accrual_end,
             calendar=calendar,
+            grace_period_days=grace_period_days,
         )
 
         skipped = _skipped_contractual_interest(installments, next_due, to_date(interest_date, tz))
@@ -353,6 +363,7 @@ def build_installments(
     last_accrual_end: datetime,
     tz: tzinfo,
     calendar: WorkingDayCalendar = _DEFAULT_CALENDAR,
+    grace_period_days: int = 0,
 ) -> List[Installment]:
     """Build the installment view from settlements + schedule."""
     allocs_by_number: Dict[int, List[Allocation]] = {}
@@ -370,6 +381,7 @@ def build_installments(
         tz,
         last_payment_date=last_accrual_end,
         calendar=calendar,
+        grace_period_days=grace_period_days,
     )
 
 

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -3,7 +3,6 @@
 import warnings
 from datetime import date, datetime, tzinfo
 from typing import Dict, List, Optional, Type, Union
-
 from zoneinfo import ZoneInfo
 
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -415,6 +415,7 @@ class Loan:
             state.last_accrual_end,
             tz=self._time_ctx.tz,
             calendar=self.working_day_calendar,
+            grace_period_days=self.grace_period_days,
         )
 
     # ------------------------------------------------------------------

--- a/tests/billing_cycle_loan/test_working_day_penalty.py
+++ b/tests/billing_cycle_loan/test_working_day_penalty.py
@@ -144,11 +144,11 @@ def test_fine_observation_respects_calendar(weekend_calendar: WeekendCalendar) -
     assert fines > Money.zero()
 
 
-def test_grace_period_defers_fine_not_mora(weekend_calendar: WeekendCalendar) -> None:
-    """Grace period defers fine but mora still accrues from effective due date."""
+def test_grace_period_eliminates_fine_and_mora(weekend_calendar: WeekendCalendar) -> None:
+    """Payment within grace period incurs neither fine nor mora."""
     # Feb 1, 2025 is Saturday -> effective Monday Feb 3
-    # With 1 day grace: fine deadline is Feb 4
+    # With 1 day grace: deadline is Feb 4
     loan = _make_bcl([date(2025, 2, 1)], calendar=weekend_calendar, grace_period_days=1)
     s = loan.record_payment(Money("3000"), datetime(2025, 2, 4, tzinfo=timezone.utc))
     assert s.fine_paid == Money.zero()
-    assert s.mora_paid > Money.zero()
+    assert s.mora_paid == Money.zero()

--- a/tests/loan/test_fines.py
+++ b/tests/loan/test_fines.py
@@ -542,3 +542,66 @@ def test_late_overpayment_projected_entry_closes_loan():
         projected = schedule[-1]
 
     assert projected.ending_balance == Money.zero()
+
+
+def test_grace_period_eliminates_mora_within_grace():
+    """Payment within grace period should incur neither fine nor mora."""
+    principal = Money("10000.00")
+    rate = InterestRate("6% a")
+    due_date = date(2025, 2, 1)
+    disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    loan = Loan(
+        principal,
+        rate,
+        [due_date],
+        disbursement_date=disbursement,
+        fine_rate=InterestRate("2% annual"),
+        grace_period_days=5,
+    )
+
+    with Warp(loan, datetime(2025, 2, 4, tzinfo=timezone.utc)) as warped:
+        warped.pay_installment(Money("11000.00"))
+        settlement = warped.settlements[-1]
+
+    assert settlement.fine_paid == Money.zero()
+    assert settlement.mora_paid == Money.zero()
+
+
+def test_grace_period_full_mora_after_grace():
+    """Payment after grace period should charge full mora from the due date."""
+    principal = Money("10000.00")
+    rate = InterestRate("6% a")
+    due_date = date(2025, 2, 1)
+    disbursement = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    loan_with_grace = Loan(
+        principal,
+        rate,
+        [due_date],
+        disbursement_date=disbursement,
+        fine_rate=InterestRate("2% annual"),
+        grace_period_days=5,
+    )
+
+    loan_no_grace = Loan(
+        principal,
+        rate,
+        [due_date],
+        disbursement_date=disbursement,
+        fine_rate=InterestRate("2% annual"),
+        grace_period_days=0,
+    )
+
+    payment_date = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    with Warp(loan_with_grace, payment_date) as warped:
+        warped.pay_installment(Money("11000.00"))
+        settlement_grace = warped.settlements[-1]
+
+    with Warp(loan_no_grace, payment_date) as warped:
+        warped.pay_installment(Money("11000.00"))
+        settlement_no_grace = warped.settlements[-1]
+
+    assert settlement_grace.mora_paid > Money.zero()
+    assert settlement_grace.mora_paid == settlement_no_grace.mora_paid

--- a/tests/loan/test_working_day_penalty.py
+++ b/tests/loan/test_working_day_penalty.py
@@ -124,27 +124,27 @@ def test_is_payment_late_with_calendar(weekend_calendar: WeekendCalendar) -> Non
 
 
 def test_grace_period_with_calendar(weekend_calendar: WeekendCalendar) -> None:
-    """Grace period is applied after the effective due date for fines.
+    """Payment within grace period incurs neither fine nor mora.
 
-    Mora still accrues from the effective due date (Mon Feb 3) because
-    grace period only defers the fine, not the interest boundary.
+    Feb 1, 2025 is Saturday -> effective Monday Feb 3.
+    With 1-day grace the deadline is Feb 4 (Tuesday).
+    Paying on Feb 4 is within the grace window: no fine, no mora.
     """
-    # Feb 1, 2025 is Saturday -> effective Monday Feb 3
-    # With 1 day grace: fine deadline is Feb 4 (Tuesday)
     loan = _make_loan([date(2025, 2, 1)], calendar=weekend_calendar, grace_period_days=1)
     s = loan.record_payment(Money("3000"), datetime(2025, 2, 4, tzinfo=timezone.utc))
     assert s.fine_paid == Money.zero()
-    assert s.mora_paid > Money.zero()
+    assert s.mora_paid == Money.zero()
 
 
 def test_grace_period_exceeded_with_calendar(weekend_calendar: WeekendCalendar) -> None:
-    """Payment after grace period on the effective due date incurs penalty."""
+    """Payment after grace period incurs both fine and full mora."""
     # Feb 1, 2025 is Saturday -> effective Monday Feb 3
     # With 1 day grace: deadline is Feb 4 (Tuesday)
-    # Pay on Wednesday Feb 5 -> late
+    # Pay on Wednesday Feb 5 -> late, full mora from effective due date
     loan = _make_loan([date(2025, 2, 1)], calendar=weekend_calendar, grace_period_days=1)
     s = loan.record_payment(Money("3000"), datetime(2025, 2, 5, tzinfo=timezone.utc))
     assert s.fine_paid > Money.zero()
+    assert s.mora_paid > Money.zero()
 
 
 def test_fine_observation_respects_calendar(weekend_calendar: WeekendCalendar) -> None:


### PR DESCRIPTION
## Summary

- Grace period now acts as a forgiveness threshold for **both** fines and mora (previously only fines were deferred)
- Within grace period: no fine, no mora — interest beyond the due date is reclassified as regular interest
- After grace period: full fine + full mora accrued from the due date (not the grace period end)

Closes #68

## Test plan

- [x] New test: payment within grace period has zero mora and zero fine
- [x] New test: payment after grace period has identical mora to a loan with no grace period
- [x] Updated existing tests that asserted mora > 0 within grace period (Loan + BillingCycleLoan)
- [x] Full test suite passes (5502 tests)