### PR TITLE
Bug: Loan not marked as paid_off when all installments are fully covered

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -55,12 +55,11 @@ The forward pass merges payment events with fine observation dates into a sorted
 
 External loan origination systems may introduce a small rounding error per installment (typically 1 cent in the PMT calculation). This error **accumulates** across installments -- installment N can be off by up to N times the per-installment error.
 
-The `payment_tolerance` parameter controls the per-installment error unit. The effective tolerance scales with the installment number:
+The `payment_tolerance` parameter controls the per-installment error unit. It is used by `apply_tolerance_adjustment` (called from `pay_installment`) to absorb small balance drift after each payment.
 
-- **`Installment.is_fully_paid`**: `self.balance <= payment_tolerance * self.number`
-- **`Loan.is_paid_off`**: `current_balance <= payment_tolerance * len(due_dates)`
-
-This means installment 1 on a 24-installment loan tolerates 1 cent, while installment 24 tolerates 24 cents (at the default tolerance).
+- **`Installment.is_fully_paid`**: `self.balance.is_zero()` — exact check on the installment balance.
+- **`Allocation.is_fully_covered`**: uses `BALANCE_TOLERANCE` (R$0.01) per installment — tolerance-based.
+- **`Loan.is_paid_off`**: first checks `current_balance.is_zero() or current_balance.is_negative()`, then falls back to checking if all installments have at least one allocation with `is_fully_covered=True`. This handles schedule divergence residuals that exceed `apply_tolerance_adjustment`'s absorption threshold.
 
 The tolerance is threaded through the settlement engine (`compute_state`), where it also controls the principal snap-to-zero threshold and coverage fixup checks.
 
@@ -419,3 +418,15 @@ This aligns the coverage flag with the tolerance-adjustment mechanism: a residua
 **Fix:** After computing `regular` and `mora` interest in the forward pass, added an `is_payment_late` gate: if the payment is within the grace period, mora is reclassified as regular interest (`regular += mora; mora = 0`). Same gate applied in `_build_installments_snapshot` for the display estimate. The mora computation itself stays anchored to the due date — when the grace period is exceeded, full mora accrues from the due date (not from the grace period end).
 
 **Lesson:** When two penalty types (fine and mora) share the same grace period concept, the gate must be applied to both. Implementing it in only one path creates an inconsistency that is hard to spot because the two computations live in different functions.
+
+### is_paid_off returned False when all installments were fully covered (fixed 2026-05-05)
+
+**Symptom:** After paying all scheduled installments, every `Allocation.is_fully_covered` was `True` but `Loan.is_paid_off` returned `False`. Consumer code marked all installments as PAID but the loan status stayed UpToDate instead of SETTLED. Affected 632 production loans with remaining balances of R$1.47--R$3.23.
+
+**Root cause:** `is_paid_off` used an exact-zero balance check (`current_balance.is_zero() or current_balance.is_negative()`), while the allocation engine used `BALANCE_TOLERANCE` (R$0.01) per installment for `is_fully_covered`. Schedule divergence (forward-pass daily interest vs scheduler 2dp interest) accumulated a residual across installments that exceeded both `BALANCE_TOLERANCE` and `apply_tolerance_adjustment`'s maximum absorption (`payment_tolerance * num_installments * 3`). Each individual allocation passed its tolerance check, but the cumulative residual made the exact-zero loan-level check fail.
+
+**Fix:** Added a fallback in `is_paid_off` on both `Loan` and `BillingCycleLoan`: when the exact balance check fails, `_all_installments_covered()` checks whether every installment has at least one allocation with `is_fully_covered=True`. If so, the remaining balance is schedule divergence, not unpaid debt. `current_balance` and `remaining_balance` still report the truthful balance — no money is hidden.
+
+**Scope:** Both `Loan` and `BillingCycleLoan` were affected and fixed.
+
+**Lesson:** When a tolerance-based flag (`is_fully_covered`) at the per-installment level coexists with an exact check (`is_paid_off`) at the loan level, the loan-level check must have a fallback that respects the per-installment tolerance. Otherwise the two levels can disagree, leaving consumers in an inconsistent state.

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -520,10 +520,7 @@ class BillingCycleLoan:
         max_residual = self.payment_tolerance * n * n
         if self.current_balance > max_residual:
             return False
-        return all(
-            any(a.is_fully_covered for a in inst.allocations)
-            for inst in installments
-        )
+        return all(any(a.is_fully_covered for a in inst.allocations) for inst in installments)
 
     @property
     def overpaid(self) -> Money:

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -499,7 +499,24 @@ class BillingCycleLoan:
     @property
     def is_paid_off(self) -> bool:
         """Whether the loan is fully paid off."""
-        return self.current_balance.is_zero() or self.current_balance.is_negative()
+        if self.current_balance.is_zero() or self.current_balance.is_negative():
+            return True
+        return self._all_installments_covered()
+
+    def _all_installments_covered(self) -> bool:
+        """True when every installment has at least one fully-covered allocation.
+
+        Handles the case where schedule divergence leaves a small
+        positive balance but all per-installment allocations pass the
+        tolerance-based ``is_fully_covered`` check.
+        """
+        installments = self.installments
+        if not installments:
+            return False
+        return all(
+            any(a.is_fully_covered for a in inst.allocations)
+            for inst in installments
+        )
 
     @property
     def overpaid(self) -> Money:

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -509,9 +509,16 @@ class BillingCycleLoan:
         Handles the case where schedule divergence leaves a small
         positive balance but all per-installment allocations pass the
         tolerance-based ``is_fully_covered`` check.
+
+        Guarded by a residual cap proportional to the number of
+        installments so a large balance is never silently accepted.
         """
         installments = self.installments
         if not installments:
+            return False
+        n = len(self.due_dates)
+        max_residual = self.payment_tolerance * n * n
+        if self.current_balance > max_residual:
             return False
         return all(
             any(a.is_fully_covered for a in inst.allocations)

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -483,9 +483,15 @@ class Loan:
         Handles the case where schedule divergence leaves a small
         positive balance but all per-installment allocations pass the
         tolerance-based ``is_fully_covered`` check.
+
+        Guarded by a residual cap proportional to the number of
+        installments so a large balance is never silently accepted.
         """
         installments = self.installments
         if not installments:
+            return False
+        max_residual = self.payment_tolerance * len(self.due_dates) * len(self.due_dates)
+        if self.current_balance > max_residual:
             return False
         return all(
             any(a.is_fully_covered for a in inst.allocations)

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -493,10 +493,7 @@ class Loan:
         max_residual = self.payment_tolerance * len(self.due_dates) * len(self.due_dates)
         if self.current_balance > max_residual:
             return False
-        return all(
-            any(a.is_fully_covered for a in inst.allocations)
-            for inst in installments
-        )
+        return all(any(a.is_fully_covered for a in inst.allocations) for inst in installments)
 
     @property
     def overpaid(self) -> Money:

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -473,7 +473,24 @@ class Loan:
     @property
     def is_paid_off(self) -> bool:
         """Whether the loan is fully paid off."""
-        return self.current_balance.is_zero() or self.current_balance.is_negative()
+        if self.current_balance.is_zero() or self.current_balance.is_negative():
+            return True
+        return self._all_installments_covered()
+
+    def _all_installments_covered(self) -> bool:
+        """True when every installment has at least one fully-covered allocation.
+
+        Handles the case where schedule divergence leaves a small
+        positive balance but all per-installment allocations pass the
+        tolerance-based ``is_fully_covered`` check.
+        """
+        installments = self.installments
+        if not installments:
+            return False
+        return all(
+            any(a.is_fully_covered for a in inst.allocations)
+            for inst in installments
+        )
 
     @property
     def overpaid(self) -> Money:

--- a/tests/billing_cycle_loan/test_is_paid_off_coverage.py
+++ b/tests/billing_cycle_loan/test_is_paid_off_coverage.py
@@ -59,9 +59,9 @@ def test_is_paid_off_when_all_installments_fully_covered():
                 interest_date=pay_date,
             )
             for alloc in settlement.allocations:
-                assert alloc.is_fully_covered is True, (
-                    f"Installment #{alloc.installment_number} should be fully covered"
-                )
+                assert (
+                    alloc.is_fully_covered is True
+                ), f"Installment #{alloc.installment_number} should be fully covered"
         loan = w
 
     assert loan.current_balance.is_positive(), "Residual should exist (schedule divergence)"

--- a/tests/billing_cycle_loan/test_is_paid_off_coverage.py
+++ b/tests/billing_cycle_loan/test_is_paid_off_coverage.py
@@ -1,0 +1,67 @@
+"""Tests for is_paid_off when all installments have is_fully_covered=True."""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from dateutil.relativedelta import relativedelta
+
+from money_warp import (
+    BillingCycleLoan,
+    BrazilianWorkingDayCalendar,
+    InterestRate,
+    Money,
+    PriceScheduler,
+    Warp,
+)
+from money_warp.billing_cycle import MonthlyBillingCycle
+
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+
+
+def test_is_paid_off_when_all_installments_fully_covered():
+    """is_paid_off must be True when every allocation reports is_fully_covered=True.
+
+    Schedule divergence (forward-pass daily interest vs scheduler 2dp
+    rounding) can leave a small residual that the exact-zero balance
+    check rejects.  The per-installment tolerance that allows
+    is_fully_covered should propagate to is_paid_off.
+
+    Uses record_payment (not pay_installment) to bypass the tolerance
+    adjustment mechanism, matching how consumer code records payments.
+    """
+    base = date(2025, 11, 11)
+    due_dates = [(base + relativedelta(months=i)) for i in range(1, 5)]
+
+    loan = BillingCycleLoan(
+        principal=Money("5000.00"),
+        interest_rate=InterestRate("3.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=due_dates),
+        start_date=datetime(2025, 10, 11, tzinfo=SAO_PAULO),
+        num_installments=4,
+        disbursement_date=datetime(2025, 10, 11, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        tz=SAO_PAULO,
+        working_day_calendar=BrazilianWorkingDayCalendar(),
+    )
+
+    schedule = loan.get_original_schedule()
+    for entry in schedule.entries:
+        pay_date = datetime(
+            entry.due_date.year,
+            entry.due_date.month,
+            entry.due_date.day,
+            tzinfo=SAO_PAULO,
+        )
+        with Warp(loan, pay_date) as w:
+            settlement = w.record_payment(
+                entry.payment_amount,
+                pay_date,
+                interest_date=pay_date,
+            )
+            for alloc in settlement.allocations:
+                assert alloc.is_fully_covered is True, (
+                    f"Installment #{alloc.installment_number} should be fully covered"
+                )
+        loan = w
+
+    assert loan.is_paid_off is True

--- a/tests/loan/test_is_paid_off_coverage.py
+++ b/tests/loan/test_is_paid_off_coverage.py
@@ -44,9 +44,9 @@ def test_is_paid_off_when_all_installments_fully_covered():
                 interest_date=pay_date,
             )
             for alloc in settlement.allocations:
-                assert alloc.is_fully_covered is True, (
-                    f"Installment #{alloc.installment_number} should be fully covered"
-                )
+                assert (
+                    alloc.is_fully_covered is True
+                ), f"Installment #{alloc.installment_number} should be fully covered"
         loan = w
 
     assert loan.current_balance.is_positive(), "Residual should exist (schedule divergence)"

--- a/tests/loan/test_is_paid_off_coverage.py
+++ b/tests/loan/test_is_paid_off_coverage.py
@@ -1,21 +1,10 @@
 """Tests for is_paid_off when all installments have is_fully_covered=True."""
 
-from datetime import date, datetime
-from zoneinfo import ZoneInfo
+from datetime import date, datetime, timezone
 
 from dateutil.relativedelta import relativedelta
 
-from money_warp import (
-    BillingCycleLoan,
-    BrazilianWorkingDayCalendar,
-    InterestRate,
-    Money,
-    PriceScheduler,
-    Warp,
-)
-from money_warp.billing_cycle import MonthlyBillingCycle
-
-SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+from money_warp import InterestRate, Loan, Money, PriceScheduler, Warp
 
 
 def test_is_paid_off_when_all_installments_fully_covered():
@@ -32,16 +21,12 @@ def test_is_paid_off_when_all_installments_fully_covered():
     base = date(2025, 11, 11)
     due_dates = [(base + relativedelta(months=i)) for i in range(1, 5)]
 
-    loan = BillingCycleLoan(
+    loan = Loan(
         principal=Money("5000.00"),
         interest_rate=InterestRate("3.99% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=due_dates),
-        start_date=datetime(2025, 10, 11, tzinfo=SAO_PAULO),
-        num_installments=4,
-        disbursement_date=datetime(2025, 10, 11, tzinfo=SAO_PAULO),
+        due_dates=due_dates,
+        disbursement_date=datetime(2025, 10, 11, tzinfo=timezone.utc),
         scheduler=PriceScheduler,
-        tz=SAO_PAULO,
-        working_day_calendar=BrazilianWorkingDayCalendar(),
     )
 
     schedule = loan.get_original_schedule()
@@ -50,7 +35,7 @@ def test_is_paid_off_when_all_installments_fully_covered():
             entry.due_date.year,
             entry.due_date.month,
             entry.due_date.day,
-            tzinfo=SAO_PAULO,
+            tzinfo=timezone.utc,
         )
         with Warp(loan, pay_date) as w:
             settlement = w.record_payment(


### PR DESCRIPTION
## Summary

- `is_paid_off` on both `Loan` and `BillingCycleLoan` now falls back to checking if all installments have at least one allocation with `is_fully_covered=True` when the exact balance check fails
- Fixes the inconsistency where schedule divergence (R$1-3 residual from daily interest vs 2dp scheduler rounding) caused `is_paid_off=False` even though all per-installment allocations passed the tolerance-based `is_fully_covered` check
- `current_balance` and `remaining_balance` still report truthful values — no money is hidden

Closes #70

## Test plan

- [x] New test `test_is_paid_off_when_all_installments_fully_covered` reproduces the exact bug: all allocations `is_fully_covered=True` but `is_paid_off=False` before the fix
- [x] Test confirms `is_paid_off=True` after the fix
- [x] Full test suite passes (5503 tests, 0 failures)