### PR TITLE
Add flat-amount discount parameter to payment methods

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -83,14 +83,14 @@ The **interest_date** controls how many days of interest are charged. Fewer days
 
 Neither method takes a date parameter — they use `self.now()` (which respects `Warp` context for time travel).
 
-- **`pay_installment(amount, description=None, waive_fines=False, waive_mora=False)`** — the common case. Records payment at `self.now()` and calculates interest up to `max(self.now(), next_due_date)`. Works correctly for all three timing scenarios:
+- **`pay_installment(amount, description=None, waive_fines=False, waive_mora=False, discount=None)`** — the common case. Records payment at `self.now()` and calculates interest up to `max(self.now(), next_due_date)`. Works correctly for all three timing scenarios:
   - **Early payment** (before due date): interest accrues up to the due date. The borrower pays the full scheduled interest — no discount. The installment is fully covered if the amount is sufficient.
   - **On-time payment**: interest matches the scheduled amount exactly.
   - **Late payment**: interest accrues up to `self.now()`, so the borrower pays extra interest (mora) for the days beyond the due date. Late fines are also applied automatically.
 
   A large payment naturally covers the current installment **and** eats into future installments — the per-installment allocation and `covered_due_date_count()` handle this without special-casing.
 
-- **`anticipate_payment(amount, installments=None, description=None, waive_fines=False, waive_mora=False)`** — early payment **with interest discount**. Records payment at `self.now()` and calculates interest only up to `self.now()` (fewer days = less interest charged). When `installments` is provided (1-based numbers), the corresponding expected cash-flow items are temporally deleted via `CashFlowItem.delete()`.
+- **`anticipate_payment(amount, installments=None, description=None, waive_fines=False, waive_mora=False, discount=None)`** — early payment **with interest discount**. Records payment at `self.now()` and calculates interest only up to `self.now()` (fewer days = less interest charged). When `installments` is provided (1-based numbers), the corresponding expected cash-flow items are temporally deleted via `CashFlowItem.delete()`.
 
 ### Early Payment vs Anticipation
 
@@ -106,7 +106,7 @@ Neither method takes a date parameter — they use `self.now()` (which respects 
 
 ### Explicit-Date Method
 
-- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None, waive_fines=False, waive_mora=False)`** — full control over all dates. Appends one `CashFlowItem` to `self.cashflow` and returns the latest derived `Settlement`.
+- **`record_payment(amount, payment_date, interest_date=None, processing_date=None, description=None, waive_fines=False, waive_mora=False, discount=None)`** — full control over all dates. Appends one `CashFlowItem` to `self.cashflow` and returns the latest derived `Settlement`.
 
 ### Payment Allocation
 
@@ -138,6 +138,31 @@ The flags are stored on `CashFlowEntry` (via `waive_fines` and `waive_mora` fiel
 ### Settlement Fields
 
 `Settlement` includes `fines_waived: Money` and `mora_waived: Money` (default `Money.zero()`). These record the amounts forgiven at each payment for audit and reporting. Existing code that creates Settlements without these fields continues to work via defaults.
+
+## Discount
+
+All payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) accept an optional `discount: Money` parameter. The discount reduces the borrower's obligation by a flat amount before the payment is allocated.
+
+### Behavior
+
+The discount follows the same allocation priority as payments: fines first, then mora, then interest, then principal. For example, with a R$100 discount on a late payment owing R$50 fines, R$30 mora, R$100 interest, and R$500 principal:
+
+1. R$50 absorbed from fines (fines owed drops to R$0)
+2. R$30 absorbed from mora (mora owed drops to R$0)
+3. R$20 absorbed from interest (interest owed drops to R$80)
+4. The payment is then allocated against the reduced obligations
+
+### Interaction with Waivers
+
+Waivers are applied first. When `waive_fines=True` and a discount is also provided, fines are zeroed by the waiver (free), and the discount starts from mora. This avoids double-counting: the waiver handles its components, then the discount acts on whatever remains.
+
+### Implementation
+
+The discount amount is stored on `CashFlowEntry` (via the `discount: Money` field, default `Money.zero()`) and read by the forward pass during payment processing. After computing effective caps and applying waivers, the forward pass reduces each cap in priority order by the discount amount. Fines absorbed by the discount are added to `fines_paid_total` so `fine_balance` correctly reaches zero. Principal absorbed by the discount reduces `running_principal` directly.
+
+### Settlement Fields
+
+`Settlement` includes `discount_applied: Money` (default `Money.zero()`). This records the total discount amount given for the payment. The per-component breakdown (how much was absorbed from fines, mora, interest, principal) stays internal to the forward pass.
 
 ## Forward Pass: `compute_state`
 
@@ -259,7 +284,7 @@ Per-installment allocation is a reporting view produced by `engines.distribute_i
 
 A frozen dataclass capturing how a single payment was allocated. Derived by the forward pass.
 
-Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`, `fines_waived`, `mora_waived`.
+Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_paid`, `principal_paid`, `remaining_balance`, `allocations`, `fines_waived`, `mora_waived`, `discount_applied`.
 
 ### Allocation
 

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -253,6 +253,7 @@ class BillingCycleLoan:
         description: Optional[str] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
         """Record a payment and return the derived settlement.
 
@@ -264,6 +265,8 @@ class BillingCycleLoan:
             description: Optional description.
             waive_fines: If True, forgive accumulated fines.
             waive_mora: If True, forgive accrued mora interest.
+            discount: Flat amount to forgive from obligations before
+                allocating the payment.
         """
         if amount.is_negative() or amount.is_zero():
             raise ValueError("Payment amount must be positive")
@@ -281,6 +284,7 @@ class BillingCycleLoan:
                 interest_date=interest_date,
                 waive_fines=waive_fines,
                 waive_mora=waive_mora,
+                discount=discount,
             )
         )
 
@@ -292,6 +296,7 @@ class BillingCycleLoan:
         description: Optional[str] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
         """Pay the next installment.
 
@@ -313,6 +318,7 @@ class BillingCycleLoan:
             description: Optional description.
             waive_fines: If True, forgive accumulated fines.
             waive_mora: If True, forgive accrued mora interest.
+            discount: Flat amount to forgive from obligations.
         """
         payment_date = self.now()
 
@@ -328,6 +334,7 @@ class BillingCycleLoan:
                 description=description or "Overpayment",
                 waive_fines=waive_fines,
                 waive_mora=waive_mora,
+                discount=discount,
             )
 
         next_due = self._next_unpaid_due_date()
@@ -339,6 +346,7 @@ class BillingCycleLoan:
             description=description,
             waive_fines=waive_fines,
             waive_mora=waive_mora,
+            discount=discount,
         )
 
         schedule = self.get_original_schedule()

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -270,6 +270,8 @@ class BillingCycleLoan:
         """
         if amount.is_negative() or amount.is_zero():
             raise ValueError("Payment amount must be positive")
+        if discount is not None and discount.is_negative():
+            raise ValueError("Discount amount must not be negative")
 
         if interest_date is None:
             interest_date = payment_date

--- a/money_warp/cash_flow/entry.py
+++ b/money_warp/cash_flow/entry.py
@@ -1,7 +1,7 @@
 """CashFlowEntry hierarchy — abstract base and concrete Expected / Happened types."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import FrozenSet, Optional, Set, Union
@@ -55,6 +55,7 @@ class CashFlowEntry(ABC):
     interest_date: Optional[datetime] = None
     waive_fines: bool = False
     waive_mora: bool = False
+    discount: Money = field(default_factory=Money.zero)
 
     @property
     @abstractmethod

--- a/money_warp/cash_flow/item.py
+++ b/money_warp/cash_flow/item.py
@@ -48,6 +48,7 @@ class CashFlowItem:
         interest_date: Optional["datetime"] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> None:
         if entry is not None:
             initial = entry
@@ -64,6 +65,7 @@ class CashFlowItem:
                 interest_date=interest_date,
                 waive_fines=waive_fines,
                 waive_mora=waive_mora,
+                discount=discount if discount is not None else Money.zero(),
             )
         else:
             raise TypeError(
@@ -142,6 +144,11 @@ class CashFlowItem:
     def waive_mora(self) -> bool:
         entry = self._require_resolved()
         return entry.waive_mora
+
+    @property
+    def discount(self) -> Money:
+        entry = self._require_resolved()
+        return entry.discount
 
     # ------------------------------------------------------------------
     # Delegated helpers

--- a/money_warp/engines/forward_pass.py
+++ b/money_warp/engines/forward_pass.py
@@ -300,6 +300,21 @@ def compute_state(
             mora_waived = mora
             effective_mora_cap = Money.zero()
 
+        discount_remaining = payment.discount
+        fine_discounted = Money(min(effective_fine_cap.raw_amount, discount_remaining.raw_amount))
+        discount_remaining = discount_remaining - fine_discounted
+        effective_fine_cap = effective_fine_cap - fine_discounted
+
+        mora_discounted = Money(min(effective_mora_cap.raw_amount, discount_remaining.raw_amount))
+        discount_remaining = discount_remaining - mora_discounted
+        effective_mora_cap = effective_mora_cap - mora_discounted
+
+        interest_discounted = Money(min(interest_cap.raw_amount, discount_remaining.raw_amount))
+        discount_remaining = discount_remaining - interest_discounted
+        interest_cap = interest_cap - interest_discounted
+
+        principal_discounted = discount_remaining
+
         fine_paid, mora_paid, interest_paid, principal_paid, allocations = allocate_payment_into_installments(
             payment.amount,
             installments,
@@ -309,8 +324,8 @@ def compute_state(
             mora_cap=effective_mora_cap,
         )
 
-        fines_paid_total = fines_paid_total + fine_paid
-        running_principal = running_principal - principal_paid
+        fines_paid_total = fines_paid_total + fine_paid + fine_discounted
+        running_principal = running_principal - principal_paid - principal_discounted
         if running_principal.is_negative():
             overpaid = overpaid + Money(-running_principal.raw_amount)
             running_principal = Money.zero()
@@ -330,6 +345,7 @@ def compute_state(
                 allocations=allocations,
                 fines_waived=fines_waived,
                 mora_waived=mora_waived,
+                discount_applied=payment.discount,
             )
         )
 

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -12,7 +12,6 @@ from sqlalchemy import Float, String, case, cast, column, func, literal, select
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
 from money_warp.engines import MoraStrategy
-from money_warp.money import Money
 from money_warp.ext.sa.compat import (
     mw_greatest,
     mw_instr,
@@ -23,6 +22,7 @@ from money_warp.ext.sa.compat import (
 )
 from money_warp.ext.sa.types import _FREQUENCY_TOKEN
 from money_warp.loan import Loan
+from money_warp.money import Money
 from money_warp.rate import _ABBREV_MAP, CompoundingFrequency
 from money_warp.tz import ensure_aware, get_tz, now, to_date
 from money_warp.warp import Warp, WarpedTime

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -12,6 +12,7 @@ from sqlalchemy import Float, String, case, cast, column, func, literal, select
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
 from money_warp.engines import MoraStrategy
+from money_warp.money import Money
 from money_warp.ext.sa.compat import (
     mw_greatest,
     mw_instr,
@@ -175,7 +176,6 @@ def _resolve_discount(item, s_meta, raw_intention):
 
     json_discount = raw_intention.get("discount")
     if json_discount is not None:
-        from money_warp.money import Money
         return Money(json_discount)
 
     return None

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -43,6 +43,7 @@ def settlement_bridge(
     interest_date: str = "interest_date",
     processing_date: str = "processing_date",
     intention: str = "intention",
+    discount: Optional[str] = None,
 ):
     """Mark a settlement model with column metadata for :func:`loan_bridge`.
 
@@ -76,6 +77,9 @@ def settlement_bridge(
         interest_date: Attribute name for the interest accrual cutoff date.
         processing_date: Attribute name for the audit-trail processing date.
         intention: Attribute name for the payment intention JSON object.
+        discount: Attribute name for the discount amount column.
+            When ``None``, discount is read from the intention JSON
+            (``{"discount": "100.00"}``).
     """
 
     def decorator(cls):
@@ -86,6 +90,7 @@ def settlement_bridge(
             "interest_date": interest_date,
             "processing_date": processing_date,
             "intention": intention,
+            "discount": discount,
         }
         return cls
 
@@ -155,6 +160,27 @@ def _collect_optional_loan_kwargs(instance, meta):
 _DEFAULT_INTENTION = {"method": "record_payment"}
 
 
+def _resolve_discount(item, s_meta, raw_intention):
+    """Extract the discount amount from the settlement item or intention JSON.
+
+    Checks the dedicated ``discount`` column first (via bridge metadata),
+    then falls back to the ``discount`` key in the intention JSON.
+    Returns ``None`` when no discount is present.
+    """
+    discount_attr = s_meta.get("discount")
+    if discount_attr is not None:
+        val = getattr(item, discount_attr, None)
+        if val is not None:
+            return val
+
+    json_discount = raw_intention.get("discount")
+    if json_discount is not None:
+        from money_warp.money import Money
+        return Money(json_discount)
+
+    return None
+
+
 def _replay_settlements(loan, items):
     """Replay recorded settlements onto *loan*, warping time per payment.
 
@@ -169,6 +195,9 @@ def _replay_settlements(loan, items):
 
     When the ``intention`` attribute is absent on the model, falls back
     to ``record_payment`` for backward compatibility.
+
+    The ``discount`` is read from a dedicated column (if configured via
+    ``settlement_bridge(discount=...)``) or from the intention JSON.
     """
     if not items:
         return
@@ -181,12 +210,13 @@ def _replay_settlements(loan, items):
         amount = getattr(item, s_meta["amount"])
         raw_intention = getattr(item, s_meta["intention"], _DEFAULT_INTENTION)
         method = raw_intention.get("method", "record_payment")
+        discount = _resolve_discount(item, s_meta, raw_intention)
 
         if method == "pay_installment":
-            loan.pay_installment(amount)
+            loan.pay_installment(amount, discount=discount)
         elif method == "anticipate_payment":
             installments = raw_intention.get("installments")
-            loan.anticipate_payment(amount, installments=installments)
+            loan.anticipate_payment(amount, installments=installments, discount=discount)
         else:
             rp_kwargs: dict = {}
             idate = getattr(item, s_meta["interest_date"], None)
@@ -196,7 +226,7 @@ def _replay_settlements(loan, items):
             if proc_date is not None:
                 rp_kwargs["processing_date"] = proc_date
 
-            loan.record_payment(amount, pdate, **rp_kwargs)
+            loan.record_payment(amount, pdate, discount=discount, **rp_kwargs)
 
 
 def _load_money_warp_loan_impl(self):

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -199,6 +199,7 @@ class Loan:
         description: Optional[str] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
         """Record a payment. Just one CashFlowItem -- everything else is derived.
 
@@ -213,6 +214,9 @@ class Loan:
                 payment are forgiven.  Future fines can still accrue.
             waive_mora: If True, all accrued mora interest up to this
                 payment is forgiven.  Future mora can still accrue.
+            discount: Flat amount to forgive from obligations before
+                allocating the payment.  Follows the same priority as
+                payment allocation (fines -> mora -> interest -> principal).
 
         Returns:
             Settlement describing how the payment was allocated.
@@ -233,6 +237,7 @@ class Loan:
                 interest_date=interest_date,
                 waive_fines=waive_fines,
                 waive_mora=waive_mora,
+                discount=discount,
             )
         )
 
@@ -244,6 +249,7 @@ class Loan:
         description: Optional[str] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
         """Pay the next installment.
 
@@ -264,6 +270,7 @@ class Loan:
             description: Optional description.
             waive_fines: If True, forgive accumulated fines.
             waive_mora: If True, forgive accrued mora interest.
+            discount: Flat amount to forgive from obligations.
         """
         payment_date = self.now()
 
@@ -279,6 +286,7 @@ class Loan:
                 description=description or "Overpayment",
                 waive_fines=waive_fines,
                 waive_mora=waive_mora,
+                discount=discount,
             )
 
         next_due = self._next_unpaid_due_date()
@@ -290,6 +298,7 @@ class Loan:
             description=description,
             waive_fines=waive_fines,
             waive_mora=waive_mora,
+            discount=discount,
         )
 
         schedule = self.get_original_schedule()
@@ -316,6 +325,7 @@ class Loan:
         description: Optional[str] = None,
         waive_fines: bool = False,
         waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
         """Make an early payment with interest discount.
 
@@ -331,6 +341,7 @@ class Loan:
             description: Optional description.
             waive_fines: If True, forgive accumulated fines.
             waive_mora: If True, forgive accrued mora interest.
+            discount: Flat amount to forgive from obligations.
         """
         payment_date = self.now()
 
@@ -344,6 +355,7 @@ class Loan:
             description=description,
             waive_fines=waive_fines,
             waive_mora=waive_mora,
+            discount=discount,
         )
 
     def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -223,6 +223,8 @@ class Loan:
         """
         if amount.is_negative() or amount.is_zero():
             raise ValueError("Payment amount must be positive")
+        if discount is not None and discount.is_negative():
+            raise ValueError("Discount amount must not be negative")
 
         if interest_date is None:
             interest_date = payment_date

--- a/money_warp/models/settlement.py
+++ b/money_warp/models/settlement.py
@@ -34,6 +34,7 @@ class Settlement:
     allocations: List[Allocation]
     fines_waived: Money = field(default_factory=_zero)
     mora_waived: Money = field(default_factory=_zero)
+    discount_applied: Money = field(default_factory=_zero)
 
     @property
     def total_paid(self) -> Money:

--- a/tests/billing_cycle_loan/test_discount.py
+++ b/tests/billing_cycle_loan/test_discount.py
@@ -25,42 +25,36 @@ def test_discount_applied_on_record_payment(simple_loan):
         discount=Money("30.00"),
     )
     assert s.discount_applied == Money("30.00")
+    assert s.interest_paid == Money("9.38")
+    assert s.principal_paid == Money("1013.20")
 
 
 def test_discount_reduces_interest_on_time(simple_loan):
-    """On-time discount absorbs interest, redirecting payment to principal."""
-    s_plain = simple_loan.record_payment(
-        Money("1022.58"),
-        datetime(2025, 2, 12, tzinfo=timezone.utc),
-    )
-
+    """On-time R$10 discount reduces interest from R$39.38 to R$29.38."""
     loan_disc = _make_simple_bcl()
-    s_disc = loan_disc.record_payment(
+    s = loan_disc.record_payment(
         Money("1022.58"),
         datetime(2025, 2, 12, tzinfo=timezone.utc),
         discount=Money("10.00"),
     )
 
-    assert s_disc.interest_paid < s_plain.interest_paid
-    assert s_disc.principal_paid > s_plain.principal_paid
+    assert s.interest_paid == Money("29.38")
+    assert s.principal_paid == Money("993.20")
 
 
 def test_discount_absorbs_fines_late_payment(simple_loan):
-    """Late payment discount absorbs fines first."""
-    s_plain = simple_loan.record_payment(
-        Money("1022.58"),
-        datetime(2025, 3, 4, tzinfo=timezone.utc),
-    )
-
+    """Late payment discount of R$20.45 absorbs all fines."""
     loan_disc = _make_simple_bcl()
-    s_disc = loan_disc.record_payment(
+    s = loan_disc.record_payment(
         Money("1022.58"),
         datetime(2025, 3, 4, tzinfo=timezone.utc),
-        discount=s_plain.fine_paid,
+        discount=Money("20.45"),
     )
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_disc.principal_paid > s_plain.principal_paid
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("18.93")
+    assert s.interest_paid == Money("39.38")
+    assert s.principal_paid == Money("964.27")
 
 
 def test_pay_installment_forwards_discount(simple_loan):
@@ -69,12 +63,16 @@ def test_pay_installment_forwards_discount(simple_loan):
         s = w.pay_installment(Money("1022.58"), discount=Money("20.00"))
 
     assert s.discount_applied == Money("20.00")
+    assert s.interest_paid == Money("19.38")
+    assert s.principal_paid == Money("1003.20")
 
 
 def test_no_discount_has_zero_field(simple_loan):
-    """Without discount, discount_applied is zero."""
+    """Without discount, discount_applied is zero and normal allocation applies."""
     s = simple_loan.record_payment(
         Money("1022.58"),
         datetime(2025, 2, 12, tzinfo=timezone.utc),
     )
     assert s.discount_applied == Money.zero()
+    assert s.interest_paid == Money("39.38")
+    assert s.principal_paid == Money("983.20")

--- a/tests/billing_cycle_loan/test_discount.py
+++ b/tests/billing_cycle_loan/test_discount.py
@@ -1,0 +1,80 @@
+"""Tests for flat-amount discount on billing-cycle loan payments."""
+
+from datetime import datetime, timezone
+
+from money_warp import BillingCycleLoan, InterestRate, Money, Warp
+from money_warp.billing_cycle import MonthlyBillingCycle
+
+
+def _make_simple_bcl() -> BillingCycleLoan:
+    return BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=MonthlyBillingCycle(closing_day=28, payment_due_days=15),
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_discount_applied_on_record_payment(simple_loan):
+    """record_payment with discount records the amount on the settlement."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 2, 12, tzinfo=timezone.utc),
+        discount=Money("30.00"),
+    )
+    assert s.discount_applied == Money("30.00")
+
+
+def test_discount_reduces_interest_on_time(simple_loan):
+    """On-time discount absorbs interest, redirecting payment to principal."""
+    s_plain = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+
+    loan_disc = _make_simple_bcl()
+    s_disc = loan_disc.record_payment(
+        Money("1022.58"),
+        datetime(2025, 2, 12, tzinfo=timezone.utc),
+        discount=Money("10.00"),
+    )
+
+    assert s_disc.interest_paid < s_plain.interest_paid
+    assert s_disc.principal_paid > s_plain.principal_paid
+
+
+def test_discount_absorbs_fines_late_payment(simple_loan):
+    """Late payment discount absorbs fines first."""
+    s_plain = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+    )
+
+    loan_disc = _make_simple_bcl()
+    s_disc = loan_disc.record_payment(
+        Money("1022.58"),
+        datetime(2025, 3, 4, tzinfo=timezone.utc),
+        discount=s_plain.fine_paid,
+    )
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_disc.principal_paid > s_plain.principal_paid
+
+
+def test_pay_installment_forwards_discount(simple_loan):
+    """pay_installment passes discount through to record_payment."""
+    with Warp(simple_loan, datetime(2025, 2, 12, tzinfo=timezone.utc)) as w:
+        s = w.pay_installment(Money("1022.58"), discount=Money("20.00"))
+
+    assert s.discount_applied == Money("20.00")
+
+
+def test_no_discount_has_zero_field(simple_loan):
+    """Without discount, discount_applied is zero."""
+    s = simple_loan.record_payment(
+        Money("1022.58"),
+        datetime(2025, 2, 12, tzinfo=timezone.utc),
+    )
+    assert s.discount_applied == Money.zero()

--- a/tests/ext/sa/test_sa_bridge.py
+++ b/tests/ext/sa/test_sa_bridge.py
@@ -35,6 +35,7 @@ def test_settlement_bridge_defaults():
         "interest_date": "interest_date",
         "processing_date": "processing_date",
         "intention": "intention",
+        "discount": None,
     }
 
 
@@ -58,6 +59,7 @@ def test_settlement_bridge_custom_names():
         "interest_date": "int_dt",
         "processing_date": "proc_dt",
         "intention": "intent",
+        "discount": None,
     }
 
 

--- a/tests/loan/test_discount.py
+++ b/tests/loan/test_discount.py
@@ -5,6 +5,8 @@ from datetime import date, datetime, timezone
 import pytest
 
 from money_warp import InterestRate, Loan, Money, Warp
+from money_warp.billing_cycle_loan import BillingCycleLoan
+from money_warp.billing_cycle import MonthlyBillingCycle
 
 
 @pytest.fixture
@@ -365,3 +367,58 @@ def test_discount_redirects_to_principal_like_waive(late_loan):
     assert s_disc.fine_paid == Money.zero()
     assert s_waive.fine_paid == Money.zero()
     assert s_disc.principal_paid == s_waive.principal_paid
+
+
+# --- Edge cases ---
+
+
+def test_discount_exceeding_total_obligation():
+    """Discount larger than all obligations doesn't crash and zeroes the balance."""
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("12% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        s = w.pay_installment(Money("500.00"), discount=Money("5000.00"))
+
+    assert s.remaining_balance == Money.zero()
+    assert s.discount_applied == Money("5000.00")
+
+
+def test_negative_discount_raises_value_error():
+    """Negative discount is rejected."""
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("12% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="Discount amount must not be negative"):
+        loan.record_payment(
+            Money("500.00"),
+            datetime(2025, 2, 1, tzinfo=timezone.utc),
+            discount=Money("-10.00"),
+        )
+
+
+def test_negative_discount_rejected_on_bcl():
+    """BillingCycleLoan also rejects negative discount."""
+    loan = BillingCycleLoan(
+        principal=Money("3000.00"),
+        interest_rate=InterestRate("12% a"),
+        billing_cycle=MonthlyBillingCycle(closing_day=28, payment_due_days=15),
+        start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        num_installments=3,
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="Discount amount must not be negative"):
+        loan.record_payment(
+            Money("500.00"),
+            datetime(2025, 2, 12, tzinfo=timezone.utc),
+            discount=Money("-5.00"),
+        )

--- a/tests/loan/test_discount.py
+++ b/tests/loan/test_discount.py
@@ -1,0 +1,367 @@
+"""Tests for flat-amount discount on loan payments."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, Warp
+
+
+@pytest.fixture
+def on_time_loan():
+    """Single-installment loan for on-time discount tests."""
+    return Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def late_loan():
+    """Single-installment loan with fine for late discount tests."""
+    return Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+
+@pytest.fixture
+def multi_installment_loan():
+    """3-installment loan for multi-payment discount tests."""
+    return Loan(
+        Money("890.22"),
+        InterestRate("15% annual"),
+        [
+            date(2025, 2, 1),
+            date(2025, 3, 1),
+            date(2025, 4, 1),
+        ],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("2% annual"),
+    )
+
+
+# --- Discount on on-time payments ---
+
+
+def test_discount_reduces_interest_on_time(on_time_loan):
+    """On-time payment with discount absorbs interest, more goes to principal."""
+    no_discount = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    payment = Money("10500.00")
+    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    with Warp(on_time_loan, payment_dt) as w:
+        s_disc = w.pay_installment(payment, discount=Money("50.00"))
+
+    with Warp(no_discount, payment_dt) as w:
+        s_plain = w.pay_installment(payment)
+
+    assert s_disc.principal_paid > s_plain.principal_paid
+    assert s_disc.interest_paid < s_plain.interest_paid
+
+
+def test_discount_applied_field_records_amount(on_time_loan):
+    """Settlement.discount_applied equals the requested discount."""
+    with Warp(on_time_loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("10500.00"), discount=Money("100.00"))
+
+    assert settlement.discount_applied == Money("100.00")
+
+
+def test_no_discount_has_zero_discount_applied(on_time_loan):
+    """Without discount, discount_applied is zero."""
+    with Warp(on_time_loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("10500.00"))
+
+    assert settlement.discount_applied == Money.zero()
+
+
+# --- Discount on late payments (fines + mora) ---
+
+
+def test_discount_absorbs_fines_first(late_loan):
+    """Discount reduces fines before touching mora or interest."""
+    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_plain = w.pay_installment(Money("11000.00"))
+
+    late_loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_disc = w.pay_installment(Money("11000.00"), discount=s_plain.fine_paid)
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_disc.principal_paid > s_plain.principal_paid
+
+
+def test_discount_absorbs_fines_then_mora(late_loan):
+    """Discount larger than fines spills into mora."""
+    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_plain = w.pay_installment(Money("11000.00"))
+
+    fine_plus_mora = s_plain.fine_paid + s_plain.mora_paid
+
+    late_loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_disc = w.pay_installment(Money("11000.00"), discount=fine_plus_mora)
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_disc.mora_paid == Money.zero()
+    assert s_disc.interest_paid > Money.zero()
+
+
+def test_discount_zeroes_fine_balance(late_loan):
+    """After discount absorbs all fines, fine_balance is zero."""
+    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_plain = w.pay_installment(Money("11000.00"))
+
+    late_loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        w.pay_installment(Money("11000.00"), discount=s_plain.fine_paid)
+        assert w.fine_balance == Money.zero()
+
+
+# --- Discount combined with waivers ---
+
+
+def test_discount_with_waive_fines(late_loan):
+    """When fines are waived, discount starts from mora."""
+    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_plain = w.pay_installment(Money("11000.00"))
+
+    late_loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_disc = w.pay_installment(
+            Money("11000.00"),
+            waive_fines=True,
+            discount=s_plain.mora_paid,
+        )
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_disc.mora_paid == Money.zero()
+    assert s_disc.fines_waived > Money.zero()
+
+
+def test_discount_with_waive_both(late_loan):
+    """With both waivers, discount starts from interest."""
+    late_loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_disc = w.pay_installment(
+            Money("11000.00"),
+            waive_fines=True,
+            waive_mora=True,
+            discount=Money("50.00"),
+        )
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_disc.mora_paid == Money.zero()
+    assert s_disc.discount_applied == Money("50.00")
+
+
+# --- Discount reduces principal ---
+
+
+def test_discount_larger_than_non_principal_reduces_principal():
+    """Discount exceeding interest spills into principal reduction."""
+    loan_plain = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    payment = Money("5100.00")
+    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    with Warp(loan_plain, payment_dt) as w:
+        s_plain = w.pay_installment(payment)
+
+    large_discount = s_plain.interest_paid + Money("100.00")
+
+    with Warp(loan_disc, payment_dt) as w:
+        s_disc = w.pay_installment(payment, discount=large_discount)
+
+    assert s_disc.interest_paid == Money.zero()
+    assert s_disc.remaining_balance < s_plain.remaining_balance
+
+
+def test_discount_pays_off_loan_with_smaller_payment():
+    """Discount + payment together can pay off the loan with less cash."""
+    loan = Loan(
+        Money("1000.00"),
+        InterestRate("12% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    scheduled = loan.get_expected_payment_amount(date(2025, 2, 1))
+    discount = Money("200.00")
+    reduced_payment = scheduled - discount
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        w.pay_installment(reduced_payment, discount=discount)
+        assert w.is_paid_off
+
+
+# --- Zero discount ---
+
+
+def test_zero_discount_is_noop(on_time_loan):
+    """Explicit zero discount behaves identically to no discount."""
+    no_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    payment = Money("10500.00")
+    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    with Warp(on_time_loan, payment_dt) as w:
+        s_zero = w.pay_installment(payment, discount=Money.zero())
+
+    with Warp(no_disc, payment_dt) as w:
+        s_none = w.pay_installment(payment)
+
+    assert s_zero.interest_paid == s_none.interest_paid
+    assert s_zero.principal_paid == s_none.principal_paid
+    assert s_zero.discount_applied == Money.zero()
+
+
+# --- Payment methods forward discount ---
+
+
+def test_record_payment_accepts_discount(on_time_loan):
+    """record_payment passes discount to the settlement engine."""
+    settlement = on_time_loan.record_payment(
+        Money("10500.00"),
+        datetime(2025, 2, 1, tzinfo=timezone.utc),
+        discount=Money("50.00"),
+    )
+
+    assert settlement.discount_applied == Money("50.00")
+
+
+def test_anticipate_payment_accepts_discount():
+    """anticipate_payment forwards discount to record_payment."""
+    loan = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1), date(2025, 3, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with Warp(loan, datetime(2025, 1, 20, tzinfo=timezone.utc)) as w:
+        settlement = w.anticipate_payment(
+            Money("10500.00"),
+            installments=[1, 2],
+            discount=Money("75.00"),
+        )
+
+    assert settlement.discount_applied == Money("75.00")
+
+
+# --- Multiple payments with discount ---
+
+
+def test_multiple_payments_with_discount(multi_installment_loan):
+    """Discounts on sequential payments accumulate correctly."""
+    scheduled = multi_installment_loan.get_original_schedule()
+    pmt_1 = scheduled[0].payment_amount
+    pmt_2 = scheduled[1].payment_amount
+
+    with Warp(multi_installment_loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        s1 = w.pay_installment(pmt_1, discount=Money("5.00"))
+
+    with Warp(multi_installment_loan, datetime(2025, 3, 1, tzinfo=timezone.utc)) as w:
+        s2 = w.pay_installment(pmt_2, discount=Money("3.00"))
+
+    assert s1.discount_applied == Money("5.00")
+    assert s2.discount_applied == Money("3.00")
+
+
+# --- Discount redirects payment money to principal ---
+
+
+def test_discount_redirects_to_principal_like_waive(late_loan):
+    """Discount on fines has the same principal-boosting effect as waive_fines."""
+    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_plain = w.pay_installment(Money("11000.00"))
+
+    fine_amount = s_plain.fine_paid
+
+    loan_disc = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+    loan_waive = Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+    with Warp(loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_disc = w.pay_installment(Money("11000.00"), discount=fine_amount)
+
+    with Warp(loan_waive, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
+        s_waive = w.pay_installment(Money("11000.00"), waive_fines=True)
+
+    assert s_disc.fine_paid == Money.zero()
+    assert s_waive.fine_paid == Money.zero()
+    assert s_disc.principal_paid == s_waive.principal_paid

--- a/tests/loan/test_discount.py
+++ b/tests/loan/test_discount.py
@@ -5,8 +5,8 @@ from datetime import date, datetime, timezone
 import pytest
 
 from money_warp import InterestRate, Loan, Money, Warp
-from money_warp.billing_cycle_loan import BillingCycleLoan
 from money_warp.billing_cycle import MonthlyBillingCycle
+from money_warp.billing_cycle_loan import BillingCycleLoan
 
 
 @pytest.fixture

--- a/tests/loan/test_discount.py
+++ b/tests/loan/test_discount.py
@@ -52,25 +52,13 @@ def multi_installment_loan():
 
 
 def test_discount_reduces_interest_on_time(on_time_loan):
-    """On-time payment with discount absorbs interest, more goes to principal."""
-    no_discount = Loan(
-        Money("10000.00"),
-        InterestRate("6% a"),
-        [date(2025, 2, 1)],
-        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
-    )
+    """On-time R$50 discount absorbs all R$49.61 interest, rest to principal."""
+    with Warp(on_time_loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        s = w.pay_installment(Money("10500.00"), discount=Money("50.00"))
 
-    payment = Money("10500.00")
-    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
-
-    with Warp(on_time_loan, payment_dt) as w:
-        s_disc = w.pay_installment(payment, discount=Money("50.00"))
-
-    with Warp(no_discount, payment_dt) as w:
-        s_plain = w.pay_installment(payment)
-
-    assert s_disc.principal_paid > s_plain.principal_paid
-    assert s_disc.interest_paid < s_plain.interest_paid
+    assert s.interest_paid == Money("0.00")
+    assert s.principal_paid == Money("10500.00")
+    assert s.discount_applied == Money("50.00")
 
 
 def test_discount_applied_field_records_amount(on_time_loan):
@@ -93,10 +81,7 @@ def test_no_discount_has_zero_discount_applied(on_time_loan):
 
 
 def test_discount_absorbs_fines_first(late_loan):
-    """Discount reduces fines before touching mora or interest."""
-    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_plain = w.pay_installment(Money("11000.00"))
-
+    """Discount equal to fine amount zeroes fines, redirects to principal."""
     late_loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -106,19 +91,16 @@ def test_discount_absorbs_fines_first(late_loan):
     )
 
     with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_disc = w.pay_installment(Money("11000.00"), discount=s_plain.fine_paid)
+        s = w.pay_installment(Money("11000.00"), discount=Money("502.48"))
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_disc.principal_paid > s_plain.principal_paid
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("22.49")
+    assert s.interest_paid == Money("49.61")
+    assert s.principal_paid == Money("10927.90")
 
 
 def test_discount_absorbs_fines_then_mora(late_loan):
-    """Discount larger than fines spills into mora."""
-    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_plain = w.pay_installment(Money("11000.00"))
-
-    fine_plus_mora = s_plain.fine_paid + s_plain.mora_paid
-
+    """Discount equal to fines + mora zeroes both components."""
     late_loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -128,18 +110,16 @@ def test_discount_absorbs_fines_then_mora(late_loan):
     )
 
     with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_disc = w.pay_installment(Money("11000.00"), discount=fine_plus_mora)
+        s = w.pay_installment(Money("11000.00"), discount=Money("524.97"))
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_disc.mora_paid == Money.zero()
-    assert s_disc.interest_paid > Money.zero()
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("0.00")
+    assert s.interest_paid == Money("49.61")
+    assert s.principal_paid == Money("10950.39")
 
 
 def test_discount_zeroes_fine_balance(late_loan):
     """After discount absorbs all fines, fine_balance is zero."""
-    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_plain = w.pay_installment(Money("11000.00"))
-
     late_loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -149,7 +129,7 @@ def test_discount_zeroes_fine_balance(late_loan):
     )
 
     with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        w.pay_installment(Money("11000.00"), discount=s_plain.fine_paid)
+        w.pay_installment(Money("11000.00"), discount=Money("502.48"))
         assert w.fine_balance == Money.zero()
 
 
@@ -157,10 +137,7 @@ def test_discount_zeroes_fine_balance(late_loan):
 
 
 def test_discount_with_waive_fines(late_loan):
-    """When fines are waived, discount starts from mora."""
-    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_plain = w.pay_installment(Money("11000.00"))
-
+    """Fines waived, discount absorbs mora. All goes to interest + principal."""
     late_loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -170,19 +147,21 @@ def test_discount_with_waive_fines(late_loan):
     )
 
     with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_disc = w.pay_installment(
+        s = w.pay_installment(
             Money("11000.00"),
             waive_fines=True,
-            discount=s_plain.mora_paid,
+            discount=Money("22.49"),
         )
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_disc.mora_paid == Money.zero()
-    assert s_disc.fines_waived > Money.zero()
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("0.00")
+    assert s.interest_paid == Money("49.61")
+    assert s.principal_paid == Money("10950.39")
+    assert s.fines_waived == Money("502.48")
 
 
 def test_discount_with_waive_both(late_loan):
-    """With both waivers, discount starts from interest."""
+    """Both waivers active, R$50 discount absorbs interest."""
     late_loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -192,16 +171,18 @@ def test_discount_with_waive_both(late_loan):
     )
 
     with Warp(late_loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_disc = w.pay_installment(
+        s = w.pay_installment(
             Money("11000.00"),
             waive_fines=True,
             waive_mora=True,
             discount=Money("50.00"),
         )
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_disc.mora_paid == Money.zero()
-    assert s_disc.discount_applied == Money("50.00")
+    assert s.fine_paid == Money("0.00")
+    assert s.mora_paid == Money("0.00")
+    assert s.interest_paid == Money("0.00")
+    assert s.principal_paid == Money("11000.00")
+    assert s.discount_applied == Money("50.00")
 
 
 # --- Discount reduces principal ---
@@ -209,12 +190,6 @@ def test_discount_with_waive_both(late_loan):
 
 def test_discount_larger_than_non_principal_reduces_principal():
     """Discount exceeding interest spills into principal reduction."""
-    loan_plain = Loan(
-        Money("10000.00"),
-        InterestRate("6% a"),
-        [date(2025, 2, 1), date(2025, 3, 1)],
-        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
-    )
     loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -222,23 +197,16 @@ def test_discount_larger_than_non_principal_reduces_principal():
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
-    payment = Money("5100.00")
-    payment_dt = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    with Warp(loan_disc, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        s = w.pay_installment(Money("5100.00"), discount=Money("149.61"))
 
-    with Warp(loan_plain, payment_dt) as w:
-        s_plain = w.pay_installment(payment)
-
-    large_discount = s_plain.interest_paid + Money("100.00")
-
-    with Warp(loan_disc, payment_dt) as w:
-        s_disc = w.pay_installment(payment, discount=large_discount)
-
-    assert s_disc.interest_paid == Money.zero()
-    assert s_disc.remaining_balance < s_plain.remaining_balance
+    assert s.interest_paid == Money("0.00")
+    assert s.principal_paid == Money("5100.00")
+    assert s.remaining_balance == Money("4800.00")
 
 
 def test_discount_pays_off_loan_with_smaller_payment():
-    """Discount + payment together can pay off the loan with less cash."""
+    """R$200 discount + R$809.67 payment covers R$1009.67 scheduled amount."""
     loan = Loan(
         Money("1000.00"),
         InterestRate("12% annual"),
@@ -246,12 +214,8 @@ def test_discount_pays_off_loan_with_smaller_payment():
         disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
-    scheduled = loan.get_expected_payment_amount(date(2025, 2, 1))
-    discount = Money("200.00")
-    reduced_payment = scheduled - discount
-
     with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
-        w.pay_installment(reduced_payment, discount=discount)
+        w.pay_installment(Money("809.67"), discount=Money("200.00"))
         assert w.is_paid_off
 
 
@@ -259,7 +223,7 @@ def test_discount_pays_off_loan_with_smaller_payment():
 
 
 def test_zero_discount_is_noop(on_time_loan):
-    """Explicit zero discount behaves identically to no discount."""
+    """Explicit zero discount produces same result as no discount."""
     no_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -276,8 +240,10 @@ def test_zero_discount_is_noop(on_time_loan):
     with Warp(no_disc, payment_dt) as w:
         s_none = w.pay_installment(payment)
 
-    assert s_zero.interest_paid == s_none.interest_paid
-    assert s_zero.principal_paid == s_none.principal_paid
+    assert s_zero.interest_paid == Money("49.61")
+    assert s_none.interest_paid == Money("49.61")
+    assert s_zero.principal_paid == Money("10450.39")
+    assert s_none.principal_paid == Money("10450.39")
     assert s_zero.discount_applied == Money.zero()
 
 
@@ -293,6 +259,8 @@ def test_record_payment_accepts_discount(on_time_loan):
     )
 
     assert settlement.discount_applied == Money("50.00")
+    assert settlement.interest_paid == Money("0.00")
+    assert settlement.principal_paid == Money("10500.00")
 
 
 def test_anticipate_payment_accepts_discount():
@@ -318,31 +286,27 @@ def test_anticipate_payment_accepts_discount():
 
 
 def test_multiple_payments_with_discount(multi_installment_loan):
-    """Discounts on sequential payments accumulate correctly."""
-    scheduled = multi_installment_loan.get_original_schedule()
-    pmt_1 = scheduled[0].payment_amount
-    pmt_2 = scheduled[1].payment_amount
-
+    """Discounts on sequential payments produce correct allocations."""
     with Warp(multi_installment_loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
-        s1 = w.pay_installment(pmt_1, discount=Money("5.00"))
-
-    with Warp(multi_installment_loan, datetime(2025, 3, 1, tzinfo=timezone.utc)) as w:
-        s2 = w.pay_installment(pmt_2, discount=Money("3.00"))
+        s1 = w.pay_installment(Money("303.62"), discount=Money("5.00"))
 
     assert s1.discount_applied == Money("5.00")
+    assert s1.interest_paid == Money("5.63")
+    assert s1.principal_paid == Money("297.99")
+
+    with Warp(multi_installment_loan, datetime(2025, 3, 1, tzinfo=timezone.utc)) as w:
+        s2 = w.pay_installment(Money("303.62"), discount=Money("3.00"))
+
     assert s2.discount_applied == Money("3.00")
+    assert s2.interest_paid == Money("17.07")
+    assert s2.principal_paid == Money("273.77")
 
 
 # --- Discount redirects payment money to principal ---
 
 
 def test_discount_redirects_to_principal_like_waive(late_loan):
-    """Discount on fines has the same principal-boosting effect as waive_fines."""
-    with Warp(late_loan, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_plain = w.pay_installment(Money("11000.00"))
-
-    fine_amount = s_plain.fine_paid
-
+    """Discount on fines produces identical allocation as waive_fines."""
     loan_disc = Loan(
         Money("10000.00"),
         InterestRate("6% a"),
@@ -359,21 +323,22 @@ def test_discount_redirects_to_principal_like_waive(late_loan):
     )
 
     with Warp(loan_disc, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
-        s_disc = w.pay_installment(Money("11000.00"), discount=fine_amount)
+        s_disc = w.pay_installment(Money("11000.00"), discount=Money("502.48"))
 
     with Warp(loan_waive, datetime(2025, 2, 15, tzinfo=timezone.utc)) as w:
         s_waive = w.pay_installment(Money("11000.00"), waive_fines=True)
 
-    assert s_disc.fine_paid == Money.zero()
-    assert s_waive.fine_paid == Money.zero()
-    assert s_disc.principal_paid == s_waive.principal_paid
+    assert s_disc.fine_paid == Money("0.00")
+    assert s_waive.fine_paid == Money("0.00")
+    assert s_disc.principal_paid == Money("10927.90")
+    assert s_waive.principal_paid == Money("10927.90")
 
 
 # --- Edge cases ---
 
 
 def test_discount_exceeding_total_obligation():
-    """Discount larger than all obligations doesn't crash and zeroes the balance."""
+    """Discount larger than all obligations zeroes the balance."""
     loan = Loan(
         Money("1000.00"),
         InterestRate("12% annual"),
@@ -384,7 +349,9 @@ def test_discount_exceeding_total_obligation():
     with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
         s = w.pay_installment(Money("500.00"), discount=Money("5000.00"))
 
-    assert s.remaining_balance == Money.zero()
+    assert s.remaining_balance == Money("0.00")
+    assert s.interest_paid == Money("0.00")
+    assert s.principal_paid == Money("500.00")
     assert s.discount_applied == Money("5000.00")
 
 


### PR DESCRIPTION
## Summary

- Add `discount: Money` parameter to all payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) on both `Loan` and `BillingCycleLoan`
- Discount reduces borrower obligations following the same allocation priority as payments (fines -> mora -> interest -> principal) before the payment is allocated
- Track total discount on `Settlement.discount_applied`; per-component breakdown stays internal to the forward pass

## Changes

- **CashFlowEntry**: new `discount: Money` field (default zero)
- **CashFlowItem**: passes `discount` through constructor, adds convenience property
- **Settlement**: new `discount_applied: Money` field (default zero)
- **Forward pass**: applies discount to caps after waivers, before allocation
- **Loan / BillingCycleLoan**: all payment methods accept `discount`
- **SA bridge**: `settlement_bridge` supports optional discount column; `_replay_settlements` reads discount from column or intention JSON
- **Knowledge**: documented in `knowledge/loan.md`

Closes #72

## Test plan

- [x] 15 tests for Loan discount scenarios (on-time, late with fines/mora, waivers + discount, principal reduction, zero discount, all payment methods, multiple payments)
- [x] 5 tests for BillingCycleLoan discount scenarios
- [x] SA bridge metadata tests updated
- [x] Full suite: 5524 passed, 0 failed