### PR TITLE
Add settlement_balance property to Loan and BillingCycleLoan

### DIFF
--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -33,15 +33,16 @@ money_warp/
 ├── billing_cycle/
 │   ├── base.py            # BaseBillingCycle (abstract)
 │   └── monthly.py         # MonthlyBillingCycle (fixed calendar day)
+├── base_loan.py              # BaseLoan ABC (shared implementation for Loan + BCL)
 ├── billing_cycle_loan/
-│   ├── billing_cycle_loan.py  # BillingCycleLoan facade
+│   ├── billing_cycle_loan.py  # BillingCycleLoan facade (extends BaseLoan)
 │   ├── engines.py             # BCL-specific: mora rate resolution + statements
 │   └── mora_rate_resolver.py  # MoraRateResolver protocol
 ├── credit_card/
 │   ├── credit_card.py     # CreditCard state machine
 │   └── statement.py       # Statement (frozen derived view)
 ├── loan/
-│   ├── loan.py            # Loan facade
+│   ├── loan.py            # Loan facade (extends BaseLoan)
 │   ├── engines.py         # Backward-compatible re-exports from money_warp.engines
 │   └── tvm.py             # TVM standalone functions (PV, IRR, anticipation)
 ├── scheduler/

--- a/knowledge/billing_cycle_loan.md
+++ b/knowledge/billing_cycle_loan.md
@@ -4,11 +4,13 @@ The `BillingCycleLoan` models a personal loan where principal is amortized on a 
 
 ## Architecture
 
+`BillingCycleLoan` extends `BaseLoan` (ABC in `money_warp/base_loan.py`), inheriting all shared implementation (balance properties, `pay_installment`, schedule queries, fine tracking, Warp hooks). It provides the abstract hook implementations plus BCL-specific features (billing cycle date derivation, per-cycle mora rate resolution, statements).
+
 `BillingCycleLoan` follows the same CashFlow-emergence philosophy as `Loan`: a single `CashFlow` is the source of truth, and all financial state (settlements, installments, balances, fines, statements) is derived on demand by a forward pass.
 
 ### Components
 
-- **`BillingCycleLoan`** (facade) — wires billing cycle, scheduler, interest calculator, and mora rate resolver. Provides payment methods and property views.
+- **`BillingCycleLoan`** (facade) — wires billing cycle, scheduler, interest calculator, and mora rate resolver. Extends `BaseLoan` with billing-cycle-specific hooks.
 - **`BaseBillingCycle`** — existing factory that generates closing dates and due dates. Enhanced with optional explicit `due_dates` and a `due_dates_between()` method.
 - **`MoraRateResolver`** (protocol) — callable `(date, InterestRate) -> InterestRate` that adjusts the mora rate per cycle. The first argument is the cycle's closing date; the second is the base mora rate.
 - **`engines.py`** (root) — shared building blocks (`InterestCalculator`, `MoraStrategy`, `MoraRateCallback`) used by both `Loan` and `BillingCycleLoan`. No dependency on domain objects.

--- a/knowledge/billing_cycle_loan.md
+++ b/knowledge/billing_cycle_loan.md
@@ -82,6 +82,10 @@ Statements are a reporting view — they don't affect the financial computation.
 - **`record_payment(amount, payment_date, interest_date=None)`** — full control, same as `Loan`.
 - **`pay_installment(amount)`** — sugar method using `now()`. Interest accrual depends on timing (early/on-time/late), same semantics as `Loan.pay_installment`.
 
+## Balance Properties
+
+Same four-component `current_balance` as `Loan` (principal + interest + mora + fines), plus `settlement_balance` — the amount to cover the next installment via `pay_installment`. Uses the per-cycle mora rate from `resolve_mora_rate` when a resolver is configured. See `knowledge/loan.md` for the full `settlement_balance` vs `current_balance` discussion.
+
 ## Warp Integration
 
 `BillingCycleLoan` has `_time_ctx` and `_on_warp`, so `Warp` works out of the box. Warping materialises fines at the target date.

--- a/knowledge/ext.md
+++ b/knowledge/ext.md
@@ -193,6 +193,14 @@ Stores `_money_warp_bridge_meta` on the loan class with all field mappings.
 - **Python side:** delegates to `self.balance_at(now())`.
 - **SQL side:** delegates to `cls.balance_at(func.now())`.
 
+**`settlement_balance_at(date)`** (hybrid_method):
+- **Python side:** Calls `self._load_money_warp_loan()`, uses `Warp(loan, as_of)`, reads `warped.settlement_balance`. Returns the amount needed to cover the next installment via `pay_installment`.
+- **SQL side:** CTE-based expression using `max(as_of, next_due)` as the interest cutoff plus the estimated next installment's scheduled principal (PMT minus one period's interest). Falls back to `0` when interest rate is NULL.
+
+**`settlement_balance`** (hybrid_property):
+- **Python side:** delegates to `self.settlement_balance_at(now())`.
+- **SQL side:** delegates to `cls.settlement_balance_at(func.now())`.
+
 The settlement model must be decorated with `@settlement_bridge` — `@loan_bridge` reads `_money_warp_bridge_meta` from the relationship target at query time. Raises `TypeError` if missing.
 
 ### Dialect compatibility layer (`compat.py`)

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -248,8 +248,17 @@ All derived from `_compute_state()`:
 | `interest_balance` | `Money` | Regular accrued interest since last payment |
 | `mora_interest_balance` | `Money` | Mora accrued interest (days beyond due date) |
 | `fine_balance` | `Money` | Unpaid fines (total applied minus fines paid) |
-| `current_balance` | `Money` | Sum of all four components |
+| `current_balance` | `Money` | Sum of all four components (point-in-time snapshot, interest accrued to `now()`) |
+| `settlement_balance` | `Money` | Amount to cover the next installment via `pay_installment` |
 | `overpaid` | `Money` | Total amount paid beyond the loan's obligations |
+
+### `settlement_balance` vs `current_balance`
+
+`current_balance` is a point-in-time snapshot — interest accrues up to `now()`. `settlement_balance` matches what `pay_installment` charges — interest accrues up to `max(now(), next_due_date)`. The difference matters for early payments, where `pay_installment` charges the full period's interest.
+
+`settlement_balance` computes: `fine_balance + mora + interest_to_max(now, next_due) + next_installment_scheduled_principal`. For multi-installment loans with more than one remaining, `settlement_balance < current_balance` (one installment vs all remaining principal). For single/last installment, `settlement_balance >= current_balance`.
+
+**Invariant:** `pay_installment(settlement_balance)` fully covers the next installment.
 
 ## Overpayment
 

--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -4,6 +4,8 @@ The `Loan` class models a personal loan where **everything emerges from the Cash
 
 ## Architecture
 
+`Loan` extends `BaseLoan` (ABC in `money_warp/base_loan.py`), which holds all shared implementation: balance properties, `pay_installment`, schedule queries, fine tracking, Warp hooks, and settlement logic. `Loan` provides the abstract hook implementations (`_compute_state`, `_accrued_interest_components`, `_build_initial_cashflow`, `settlement_balance`, `record_payment`) plus Loan-specific features (taxes, TVM, anticipation).
+
 The Loan delegates computation to two focused components in `engines.py`:
 
 - **`InterestCalculator`** — stateless interest math (regular + mora split). Holds `interest_rate`, `mora_interest_rate`, `mora_strategy`.

--- a/money_warp/base_loan.py
+++ b/money_warp/base_loan.py
@@ -1,0 +1,420 @@
+"""BaseLoan ABC -- shared implementation for Loan and BillingCycleLoan.
+
+All balance properties, payment methods (except ``record_payment``),
+settlement logic, fine tracking, schedule queries, and Warp hooks live
+here.  Subclasses provide ``_compute_state``, ``_accrued_interest_components``,
+``_build_initial_cashflow``, ``settlement_balance``, and ``record_payment``.
+"""
+
+import warnings
+from abc import ABC, abstractmethod
+from datetime import date, datetime
+from typing import Dict, List, Optional, Tuple, Type
+
+from .cash_flow import CashFlow, CashFlowItem
+from .engines import (
+    InterestCalculator,
+    LoanState,
+    MoraStrategy,
+    apply_tolerance_adjustment,
+    build_installments,
+    covered_due_date_count,
+    is_payment_late,
+)
+from .models import Installment, Settlement
+from .scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
+from .time_context import TimeContext
+from .types.interest_rate import InterestRate
+from .types.money import Money
+from .tz import tz_aware
+from .working_day import WorkingDayCalendar
+
+
+class BaseLoan(ABC):
+    """Abstract base for loan products.
+
+    Subclasses must set the following attributes during ``__init__``:
+
+    - ``_time_ctx``: :class:`TimeContext`
+    - ``principal``: :class:`Money`
+    - ``interest_rate``: :class:`InterestRate`
+    - ``mora_interest_rate``: :class:`InterestRate`
+    - ``mora_strategy``: :class:`MoraStrategy`
+    - ``_interest``: :class:`InterestCalculator`
+    - ``due_dates``: ``List[date]``
+    - ``disbursement_date``: ``datetime``
+    - ``scheduler``: ``Type[BaseScheduler]``
+    - ``fine_rate``: :class:`InterestRate`
+    - ``grace_period_days``: ``int``
+    - ``payment_tolerance``: :class:`Money`
+    - ``working_day_calendar``: :class:`WorkingDayCalendar`
+    - ``_fine_observation_dates``: ``List[datetime]``
+    - ``cashflow``: :class:`CashFlow`
+    """
+
+    _time_ctx: TimeContext
+    principal: Money
+    interest_rate: InterestRate
+    mora_interest_rate: InterestRate
+    mora_strategy: MoraStrategy
+    _interest: InterestCalculator
+    due_dates: List[date]
+    disbursement_date: datetime
+    scheduler: Type[BaseScheduler]
+    fine_rate: InterestRate
+    grace_period_days: int
+    payment_tolerance: Money
+    working_day_calendar: WorkingDayCalendar
+    _fine_observation_dates: List[datetime]
+    cashflow: CashFlow
+
+    # ------------------------------------------------------------------
+    # Abstract hooks
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _compute_state(self) -> LoanState:
+        """Run the forward pass and return derived loan state."""
+
+    @abstractmethod
+    def _accrued_interest_components(self) -> Tuple[Money, Money]:
+        """Return ``(regular, mora)`` accrued interest since last payment."""
+
+    @abstractmethod
+    def _build_initial_cashflow(self) -> CashFlow:
+        """Build the initial CashFlow with expected items from the schedule."""
+
+    @property
+    @abstractmethod
+    def settlement_balance(self) -> Money:
+        """Amount needed to cover the next installment via ``pay_installment``."""
+
+    @abstractmethod
+    def record_payment(
+        self,
+        amount: Money,
+        payment_date: datetime,
+        interest_date: Optional[datetime] = None,
+        **kwargs: object,
+    ) -> Settlement:
+        """Record a payment and return the derived settlement."""
+
+    # ------------------------------------------------------------------
+    # Payment methods
+    # ------------------------------------------------------------------
+
+    def pay_installment(
+        self,
+        amount: Money,
+        description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
+        discount: Optional[Money] = None,
+    ) -> Settlement:
+        """Pay the next installment.
+
+        Interest accrual depends on timing:
+
+        - Early / on-time: accrues up to the due date.
+        - Late: accrues up to ``now()`` (mora kicks in).
+
+        When all installments are already paid the payment is recorded
+        as an overpayment.
+
+        After recording the payment, if the principal balance drifts from
+        the schedule's expected ending balance by a small amount (within
+        ``payment_tolerance``), a tolerance adjustment CashFlowItem is
+        added to the cashflow to prevent rounding drift from compounding.
+        """
+        payment_date = self.now()
+
+        if self._covered_due_date_count() >= len(self.due_dates):
+            warnings.warn(
+                f"All installments already paid. Recording {amount} as overpayment.",
+                stacklevel=2,
+            )
+            return self.record_payment(
+                amount,
+                payment_date=payment_date,
+                interest_date=payment_date,
+                description=description or "Overpayment",
+                waive_fines=waive_fines,
+                waive_mora=waive_mora,
+                discount=discount,
+            )
+
+        next_due = self._next_unpaid_due_date()
+        interest_date = max(payment_date, self._time_ctx.to_datetime(next_due))
+        settlement = self.record_payment(
+            amount,
+            payment_date=payment_date,
+            interest_date=interest_date,
+            description=description,
+            waive_fines=waive_fines,
+            waive_mora=waive_mora,
+            discount=discount,
+        )
+
+        schedule = self.get_original_schedule()
+        for entry in schedule:
+            if entry.due_date == next_due:
+                apply_tolerance_adjustment(
+                    self.cashflow,
+                    entry,
+                    settlement,
+                    payment_date,
+                    interest_date,
+                    self.payment_tolerance,
+                    len(self.due_dates),
+                    self._time_ctx,
+                )
+                break
+
+        return settlement
+
+    # ------------------------------------------------------------------
+    # Derived state helpers
+    # ------------------------------------------------------------------
+
+    def _payment_entries(self) -> list:
+        """Payment CashFlowEntry objects from the cashflow, sorted by datetime."""
+        entries = [e for e in self.cashflow.items() if "payment" in e.category]
+        return sorted(entries, key=lambda e: e.datetime)
+
+    # ------------------------------------------------------------------
+    # Settlements and installments
+    # ------------------------------------------------------------------
+
+    @property
+    def settlements(self) -> List[Settlement]:
+        """All settlements (derived from CashFlow)."""
+        return self._compute_state().settlements
+
+    @property
+    def installments(self) -> List[Installment]:
+        """The repayment plan as Installment objects (derived from CashFlow)."""
+        state = self._compute_state()
+        return build_installments(
+            self.get_original_schedule(),
+            state.settlements,
+            state.fines_applied,
+            state.principal_balance,
+            self.now(),
+            self._interest,
+            state.last_accrual_end,
+            tz=self._time_ctx.tz,
+            calendar=self.working_day_calendar,
+            grace_period_days=self.grace_period_days,
+        )
+
+    # ------------------------------------------------------------------
+    # Balance properties
+    # ------------------------------------------------------------------
+
+    @property
+    def principal_balance(self) -> Money:
+        """Outstanding principal (derived from CashFlow)."""
+        return self._compute_state().principal_balance
+
+    @property
+    def interest_balance(self) -> Money:
+        """Regular (non-mora) accrued interest since last payment."""
+        return self._accrued_interest_components()[0]
+
+    @property
+    def mora_interest_balance(self) -> Money:
+        """Mora accrued interest since last payment."""
+        return self._accrued_interest_components()[1]
+
+    @property
+    def fine_balance(self) -> Money:
+        """Unpaid fine amount (derived from CashFlow)."""
+        state = self._compute_state()
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
+        )
+        outstanding = total_fines - state.fines_paid_total
+        return outstanding if outstanding.is_positive() else Money.zero()
+
+    @property
+    def current_balance(self) -> Money:
+        """Total outstanding balance (principal + interest + mora + fines)."""
+        return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
+
+    @property
+    def is_paid_off(self) -> bool:
+        """Whether the loan is fully paid off."""
+        if self.current_balance.is_zero() or self.current_balance.is_negative():
+            return True
+        return self._all_installments_covered()
+
+    def _all_installments_covered(self) -> bool:
+        """True when every installment has at least one fully-covered allocation.
+
+        Handles the case where schedule divergence leaves a small
+        positive balance but all per-installment allocations pass the
+        tolerance-based ``is_fully_covered`` check.
+
+        Guarded by a residual cap proportional to the number of
+        installments so a large balance is never silently accepted.
+        """
+        installments = self.installments
+        if not installments:
+            return False
+        n = len(self.due_dates)
+        max_residual = self.payment_tolerance * n * n
+        if self.current_balance > max_residual:
+            return False
+        return all(any(a.is_fully_covered for a in inst.allocations) for inst in installments)
+
+    @property
+    def overpaid(self) -> Money:
+        """Total amount paid beyond the loan's obligations (derived from CashFlow)."""
+        return self._compute_state().overpaid
+
+    # ------------------------------------------------------------------
+    # Fine-related
+    # ------------------------------------------------------------------
+
+    @property
+    def fines_applied(self) -> Dict[date, Money]:
+        """Fine amounts applied per due date (derived from CashFlow)."""
+        return self._compute_state().fines_applied
+
+    @property
+    def total_fines(self) -> Money:
+        """Total amount of fines applied."""
+        fines = self.fines_applied
+        if not fines:
+            return Money.zero()
+        return Money(sum(f.raw_amount for f in fines.values()))
+
+    @tz_aware
+    def is_payment_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
+        """Check if a payment is late considering the grace period."""
+        check = as_of_date if as_of_date is not None else self.now()
+        return is_payment_late(due_date, self.grace_period_days, check, self._time_ctx.tz, self.working_day_calendar)
+
+    def _on_warp(self, target_date: datetime) -> None:
+        """Hook called by Warp after overriding TimeContext."""
+        self._fine_observation_dates.append(target_date)
+
+    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
+        """Compute and record fine observations as of a date.
+
+        Appends the observation date so that subsequent property queries
+        include fines for due dates overdue at that point.
+
+        Returns the amount of NEW fines applied (zero if already applied).
+        """
+        as_of = as_of_date if as_of_date is not None else self.now()
+        old_total = self.total_fines
+        self._fine_observation_dates.append(as_of)
+        new_total = self.total_fines
+        return new_total - old_total
+
+    # ------------------------------------------------------------------
+    # Payment info
+    # ------------------------------------------------------------------
+
+    @property
+    def last_payment_date(self) -> datetime:
+        """Date of the last payment, or disbursement date if none."""
+        return self._compute_state().last_payment_date
+
+    def now(self) -> datetime:
+        """Current datetime (Warp-aware via shared TimeContext)."""
+        return self._time_ctx.now()
+
+    def days_since_last_payment(self) -> int:
+        """Days since the last payment (Warp-aware)."""
+        return (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(self.last_payment_date)).days
+
+    def _covered_due_date_count(self) -> int:
+        """How many due dates have been covered by payments."""
+        return covered_due_date_count(self.principal_balance, self.get_original_schedule())
+
+    def _next_unpaid_due_date(self) -> date:
+        """Find the next due date that hasn't been fully paid.
+
+        Raises:
+            ValueError: If all due dates have been paid.
+        """
+        covered = self._covered_due_date_count()
+        if covered >= len(self.due_dates):
+            raise ValueError("All due dates have been paid")
+        return self.due_dates[covered]
+
+    # ------------------------------------------------------------------
+    # Schedule
+    # ------------------------------------------------------------------
+
+    def get_original_schedule(self) -> PaymentSchedule:
+        """The original amortization schedule (static, ignores payments)."""
+        return self.scheduler.generate_schedule(
+            self.principal,
+            self.interest_rate,
+            self.due_dates,
+            self.disbursement_date,
+            self._time_ctx.tz,
+        )
+
+    def get_amortization_schedule(self) -> PaymentSchedule:
+        """Current schedule: recorded past entries + projected future."""
+        state = self._compute_state()
+        if not state.settlements:
+            return self.get_original_schedule()
+
+        actual_entries: List[PaymentScheduleEntry] = []
+        prev_balance = self.principal
+        prev_date = self.disbursement_date
+
+        for i, s in enumerate(state.settlements):
+            days = (self._time_ctx.to_date(s.payment_date) - self._time_ctx.to_date(prev_date)).days
+            actual_entries.append(
+                PaymentScheduleEntry(
+                    payment_number=i + 1,
+                    due_date=self._time_ctx.to_date(s.payment_date),
+                    days_in_period=days,
+                    beginning_balance=prev_balance,
+                    payment_amount=s.interest_paid + s.mora_paid + s.principal_paid,
+                    principal_payment=s.principal_paid,
+                    interest_payment=s.interest_paid + s.mora_paid,
+                    ending_balance=s.remaining_balance,
+                )
+            )
+            prev_balance = s.remaining_balance
+            prev_date = s.payment_date
+
+        covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
+        remaining_due_dates = self.due_dates[covered:]
+        if not remaining_due_dates:
+            return PaymentSchedule(entries=actual_entries)
+
+        if state.principal_balance.is_zero() or state.principal_balance.is_negative():
+            return PaymentSchedule(entries=actual_entries)
+
+        projected_schedule = self.scheduler.generate_schedule(
+            state.principal_balance,
+            self.interest_rate,
+            remaining_due_dates,
+            state.last_payment_date,
+            self._time_ctx.tz,
+        )
+
+        projected_entries: List[PaymentScheduleEntry] = []
+        for entry in projected_schedule:
+            projected_entries.append(
+                PaymentScheduleEntry(
+                    payment_number=len(actual_entries) + entry.payment_number,
+                    due_date=entry.due_date,
+                    days_in_period=entry.days_in_period,
+                    beginning_balance=entry.beginning_balance,
+                    payment_amount=entry.payment_amount,
+                    principal_payment=entry.principal_payment,
+                    interest_payment=entry.interest_payment,
+                    ending_balance=entry.ending_balance,
+                )
+            )
+
+        return PaymentSchedule(entries=actual_entries + projected_entries)

--- a/money_warp/base_loan.py
+++ b/money_warp/base_loan.py
@@ -2,8 +2,9 @@
 
 All balance properties, payment methods (except ``record_payment``),
 settlement logic, fine tracking, schedule queries, and Warp hooks live
-here.  Subclasses provide ``_compute_state``, ``_accrued_interest_components``,
-``_build_initial_cashflow``, ``settlement_balance``, and ``record_payment``.
+here.  Subclasses provide ``_compute_state``, ``_build_initial_cashflow``,
+and ``record_payment``.  Per-cycle mora rate resolution is handled via the
+``_resolve_mora_rate_for_due`` hook.
 """
 
 import warnings
@@ -27,7 +28,7 @@ from .time_context import TimeContext
 from .types.interest_rate import InterestRate
 from .types.money import Money
 from .tz import tz_aware
-from .working_day import WorkingDayCalendar
+from .working_day import WorkingDayCalendar, effective_penalty_due_date
 
 
 class BaseLoan(ABC):
@@ -77,17 +78,8 @@ class BaseLoan(ABC):
         """Run the forward pass and return derived loan state."""
 
     @abstractmethod
-    def _accrued_interest_components(self) -> Tuple[Money, Money]:
-        """Return ``(regular, mora)`` accrued interest since last payment."""
-
-    @abstractmethod
     def _build_initial_cashflow(self) -> CashFlow:
         """Build the initial CashFlow with expected items from the schedule."""
-
-    @property
-    @abstractmethod
-    def settlement_balance(self) -> Money:
-        """Amount needed to cover the next installment via ``pay_installment``."""
 
     @abstractmethod
     def record_payment(
@@ -95,9 +87,29 @@ class BaseLoan(ABC):
         amount: Money,
         payment_date: datetime,
         interest_date: Optional[datetime] = None,
-        **kwargs: object,
+        description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
+        discount: Optional[Money] = None,
     ) -> Settlement:
-        """Record a payment and return the derived settlement."""
+        """Record a payment and return the derived settlement.
+
+        Subclasses may extend the signature (e.g. ``Loan`` adds
+        ``processing_date``).
+        """
+
+    # ------------------------------------------------------------------
+    # Mora rate hook (override in subclasses with per-cycle resolution)
+    # ------------------------------------------------------------------
+
+    def _resolve_mora_rate_for_due(self, next_due: Optional[date]) -> Optional[InterestRate]:
+        """Return the mora rate override for *next_due*, or ``None`` for the default.
+
+        ``Loan`` returns ``None`` (uses the calculator's fixed rate).
+        ``BillingCycleLoan`` overrides this to call ``resolve_mora_rate``
+        with the per-cycle resolver.
+        """
+        return None
 
     # ------------------------------------------------------------------
     # Payment methods
@@ -216,6 +228,32 @@ class BaseLoan(ABC):
         """Outstanding principal (derived from CashFlow)."""
         return self._compute_state().principal_balance
 
+    def _accrued_interest_components(self) -> Tuple[Money, Money]:
+        """Return ``(regular, mora)`` accrued interest since last payment.
+
+        Uses ``_resolve_mora_rate_for_due`` to obtain the per-cycle
+        mora rate override (``None`` for ``Loan``, resolved rate for
+        ``BillingCycleLoan``).
+        """
+        state = self._compute_state()
+        days = (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(state.last_accrual_end)).days
+
+        if state.principal_balance.is_positive() and days > 0:
+            covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
+            next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
+            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar) if next_due else None
+            mora_rate = self._resolve_mora_rate_for_due(next_due)
+            return self._interest.compute_accrued_interest(
+                days,
+                state.principal_balance,
+                self._time_ctx.tz,
+                penalty_next_due,
+                state.last_accrual_end,
+                mora_rate_override=mora_rate,
+            )
+
+        return Money.zero(), Money.zero()
+
     @property
     def interest_balance(self) -> Money:
         """Regular (non-mora) accrued interest since last payment."""
@@ -240,6 +278,57 @@ class BaseLoan(ABC):
     def current_balance(self) -> Money:
         """Total outstanding balance (principal + interest + mora + fines)."""
         return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
+
+    @property
+    def settlement_balance(self) -> Money:
+        """Amount needed to cover the next installment via ``pay_installment``.
+
+        Computes fines + mora + interest (accrued to ``max(now, next_due)``)
+        + the next installment's scheduled principal.  Matches the interest
+        cutoff that ``pay_installment`` uses internally.
+
+        For single-installment or last-installment loans this equals the
+        full payoff amount.  For multi-installment loans with more than one
+        installment remaining, this is less than ``current_balance``.
+        """
+        state = self._compute_state()
+        if not state.principal_balance.is_positive():
+            return Money.zero()
+
+        schedule = self.get_original_schedule()
+        covered = covered_due_date_count(state.principal_balance, schedule)
+        if covered >= len(self.due_dates):
+            return Money.zero()
+
+        next_due = self.due_dates[covered]
+        next_entry = schedule.entries[covered]
+
+        now_date = self._time_ctx.to_date(self.now())
+        interest_cutoff = max(now_date, next_due)
+        days = (interest_cutoff - self._time_ctx.to_date(state.last_accrual_end)).days
+
+        if days > 0:
+            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar)
+            mora_rate = self._resolve_mora_rate_for_due(next_due)
+            regular, mora = self._interest.compute_accrued_interest(
+                days,
+                state.principal_balance,
+                self._time_ctx.tz,
+                penalty_next_due,
+                state.last_accrual_end,
+                mora_rate_override=mora_rate,
+            )
+        else:
+            regular, mora = Money.zero(), Money.zero()
+
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
+        )
+        fine = total_fines - state.fines_paid_total
+        if fine.is_negative():
+            fine = Money.zero()
+
+        return fine + mora + regular + next_entry.principal_payment
 
     @property
     def is_paid_off(self) -> bool:

--- a/money_warp/base_loan.py
+++ b/money_warp/base_loan.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime
 from typing import Dict, List, Optional, Tuple, Type
 
-from .cash_flow import CashFlow, CashFlowItem
+from .cash_flow import CashFlow
 from .engines import (
     InterestCalculator,
     LoanState,
@@ -22,7 +22,7 @@ from .engines import (
     is_payment_late,
 )
 from .models import Installment, Settlement
-from .scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
+from .scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry
 from .time_context import TimeContext
 from .types.interest_rate import InterestRate
 from .types.money import Money

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -1,7 +1,7 @@
 """BillingCycleLoan -- fixed amortization with billing-cycle payment timing."""
 
 from datetime import date, datetime, tzinfo
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 from zoneinfo import ZoneInfo
 
 from ..base_loan import BaseLoan

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -1,23 +1,20 @@
 """BillingCycleLoan -- fixed amortization with billing-cycle payment timing."""
 
-import warnings
 from datetime import date, datetime, tzinfo
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 from zoneinfo import ZoneInfo
 
+from ..base_loan import BaseLoan
 from ..billing_cycle import BaseBillingCycle
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
 from ..engines import (
     InterestCalculator,
     LoanState,
     MoraStrategy,
-    apply_tolerance_adjustment,
-    build_installments,
     covered_due_date_count,
-    is_payment_late,
 )
-from ..models import BillingCycleLoanStatement, Installment, Settlement
-from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
+from ..models import BillingCycleLoanStatement, Settlement
+from ..scheduler import BaseScheduler, PriceScheduler
 from ..time_context import TimeContext
 from ..types.interest_rate import InterestRate
 from ..types.money import Money
@@ -27,7 +24,7 @@ from .engines import build_statements, compute_state, resolve_mora_rate
 from .mora_rate_resolver import MoraRateResolver
 
 
-class BillingCycleLoan:
+class BillingCycleLoan(BaseLoan):
     """Loan with fixed amortization and credit-card-like billing cycles.
 
     Combines a traditional amortization schedule (Price / SAC) with
@@ -125,7 +122,7 @@ class BillingCycleLoan:
         self.cashflow = self._build_initial_cashflow()
 
     # ------------------------------------------------------------------
-    # Date derivation
+    # Date derivation (BCL-specific)
     # ------------------------------------------------------------------
 
     def _derive_closing_dates(self) -> List[datetime]:
@@ -171,13 +168,7 @@ class BillingCycleLoan:
         return all_dates[: self.num_installments]
 
     def _derive_due_dates(self) -> List[date]:
-        """Derive payment due dates from the billing cycle.
-
-        When the billing cycle has explicit due dates, use a wide
-        enough end boundary so that due dates falling after the last
-        closing date (the normal case -- due = close + offset) are
-        not accidentally excluded.
-        """
+        """Derive payment due dates from the billing cycle."""
         from dateutil.relativedelta import relativedelta
 
         last_closing = self._closing_dates[-1] if self._closing_dates else self.start_date
@@ -194,7 +185,7 @@ class BillingCycleLoan:
         return list(self._closing_dates)
 
     # ------------------------------------------------------------------
-    # CashFlow construction
+    # Abstract hook implementations
     # ------------------------------------------------------------------
 
     def _build_initial_cashflow(self) -> CashFlow:
@@ -240,10 +231,6 @@ class BillingCycleLoan:
 
         return CashFlow(items)
 
-    # ------------------------------------------------------------------
-    # Payment recording
-    # ------------------------------------------------------------------
-
     @tz_aware
     def record_payment(
         self,
@@ -255,19 +242,7 @@ class BillingCycleLoan:
         waive_mora: bool = False,
         discount: Optional[Money] = None,
     ) -> Settlement:
-        """Record a payment and return the derived settlement.
-
-        Args:
-            amount: Payment amount (must be positive).
-            payment_date: When the money moved.
-            interest_date: Cutoff for interest accrual.  Defaults to
-                *payment_date*.
-            description: Optional description.
-            waive_fines: If True, forgive accumulated fines.
-            waive_mora: If True, forgive accrued mora interest.
-            discount: Flat amount to forgive from obligations before
-                allocating the payment.
-        """
+        """Record a payment and return the derived settlement."""
         if amount.is_negative() or amount.is_zero():
             raise ValueError("Payment amount must be positive")
         if discount is not None and discount.is_negative():
@@ -292,86 +267,6 @@ class BillingCycleLoan:
 
         return self.settlements[-1]
 
-    def pay_installment(
-        self,
-        amount: Money,
-        description: Optional[str] = None,
-        waive_fines: bool = False,
-        waive_mora: bool = False,
-        discount: Optional[Money] = None,
-    ) -> Settlement:
-        """Pay the next installment.
-
-        Interest accrual depends on timing:
-
-        - Early / on-time: accrues up to the due date.
-        - Late: accrues up to ``now()`` (mora kicks in).
-
-        When all installments are already paid the payment is recorded
-        as an overpayment.
-
-        After recording the payment, if the principal balance drifts from
-        the schedule's expected ending balance by a small amount (within
-        ``payment_tolerance``), a tolerance adjustment CashFlowItem is
-        added to the cashflow to prevent rounding drift from compounding.
-
-        Args:
-            amount: Payment amount (must be positive).
-            description: Optional description.
-            waive_fines: If True, forgive accumulated fines.
-            waive_mora: If True, forgive accrued mora interest.
-            discount: Flat amount to forgive from obligations.
-        """
-        payment_date = self.now()
-
-        if self._covered_due_date_count() >= len(self.due_dates):
-            warnings.warn(
-                f"All installments already paid. Recording {amount} as overpayment.",
-                stacklevel=2,
-            )
-            return self.record_payment(
-                amount,
-                payment_date=payment_date,
-                interest_date=payment_date,
-                description=description or "Overpayment",
-                waive_fines=waive_fines,
-                waive_mora=waive_mora,
-                discount=discount,
-            )
-
-        next_due = self._next_unpaid_due_date()
-        interest_date = max(payment_date, self._time_ctx.to_datetime(next_due))
-        settlement = self.record_payment(
-            amount,
-            payment_date=payment_date,
-            interest_date=interest_date,
-            description=description,
-            waive_fines=waive_fines,
-            waive_mora=waive_mora,
-            discount=discount,
-        )
-
-        schedule = self.get_original_schedule()
-        for entry in schedule:
-            if entry.due_date == next_due:
-                apply_tolerance_adjustment(
-                    self.cashflow,
-                    entry,
-                    settlement,
-                    payment_date,
-                    interest_date,
-                    self.payment_tolerance,
-                    len(self.due_dates),
-                    self._time_ctx,
-                )
-                break
-
-        return settlement
-
-    # ------------------------------------------------------------------
-    # Derived state
-    # ------------------------------------------------------------------
-
     def _compute_state(self) -> LoanState:
         """Run the forward pass with per-cycle mora rate resolution."""
         return compute_state(
@@ -392,64 +287,7 @@ class BillingCycleLoan:
             calendar=self.working_day_calendar,
         )
 
-    def _payment_entries(self) -> list:
-        """Payment CashFlowEntry objects, sorted by datetime."""
-        entries = [e for e in self.cashflow.items() if "payment" in e.category]
-        return sorted(entries, key=lambda e: e.datetime)
-
-    # ------------------------------------------------------------------
-    # Settlements and installments
-    # ------------------------------------------------------------------
-
-    @property
-    def settlements(self) -> List[Settlement]:
-        """All settlements (derived from CashFlow)."""
-        return self._compute_state().settlements
-
-    @property
-    def installments(self) -> List[Installment]:
-        """Installment view (derived from CashFlow)."""
-        state = self._compute_state()
-        return build_installments(
-            self.get_original_schedule(),
-            state.settlements,
-            state.fines_applied,
-            state.principal_balance,
-            self.now(),
-            self._interest,
-            state.last_accrual_end,
-            tz=self._time_ctx.tz,
-            calendar=self.working_day_calendar,
-            grace_period_days=self.grace_period_days,
-        )
-
-    @property
-    def statements(self) -> List[BillingCycleLoanStatement]:
-        """Billing-period statements (one per cycle)."""
-        state = self._compute_state()
-        return build_statements(
-            self.get_original_schedule(),
-            self.due_dates,
-            self._closing_dates,
-            self.billing_cycle,
-            state.settlements,
-            state.fines_applied,
-            self.principal,
-            self.mora_interest_rate,
-            tz=self._time_ctx.tz,
-            mora_rate_resolver=self.mora_rate_resolver,
-        )
-
-    # ------------------------------------------------------------------
-    # Balance properties
-    # ------------------------------------------------------------------
-
-    @property
-    def principal_balance(self) -> Money:
-        """Outstanding principal."""
-        return self._compute_state().principal_balance
-
-    def _accrued_interest_components(self) -> tuple:
+    def _accrued_interest_components(self) -> Tuple[Money, Money]:
         """Return (regular, mora) accrued since last payment."""
         state = self._compute_state()
         days = (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(state.last_accrual_end)).days
@@ -482,41 +320,12 @@ class BillingCycleLoan:
         return Money.zero(), Money.zero()
 
     @property
-    def interest_balance(self) -> Money:
-        """Regular accrued interest since last payment."""
-        return self._accrued_interest_components()[0]
-
-    @property
-    def mora_interest_balance(self) -> Money:
-        """Mora accrued interest since last payment."""
-        return self._accrued_interest_components()[1]
-
-    @property
-    def fine_balance(self) -> Money:
-        """Unpaid fines."""
-        state = self._compute_state()
-        total_fines = (
-            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
-        )
-        outstanding = total_fines - state.fines_paid_total
-        return outstanding if outstanding.is_positive() else Money.zero()
-
-    @property
-    def current_balance(self) -> Money:
-        """Total outstanding balance."""
-        return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
-
-    @property
     def settlement_balance(self) -> Money:
         """Amount needed to cover the next installment via ``pay_installment``.
 
         Computes fines + mora + interest (accrued to ``max(now, next_due)``)
         + the next installment's scheduled principal.  Uses the per-cycle
         mora rate when a resolver is configured.
-
-        For single-installment or last-installment loans this equals the
-        full payoff amount.  For multi-installment loans with more than one
-        installment remaining, this is less than ``current_balance``.
         """
         state = self._compute_state()
         if not state.principal_balance.is_positive():
@@ -564,174 +373,35 @@ class BillingCycleLoan:
 
         return fine + mora + regular + next_entry.principal_payment
 
-    @property
-    def is_paid_off(self) -> bool:
-        """Whether the loan is fully paid off."""
-        if self.current_balance.is_zero() or self.current_balance.is_negative():
-            return True
-        return self._all_installments_covered()
-
-    def _all_installments_covered(self) -> bool:
-        """True when every installment has at least one fully-covered allocation.
-
-        Handles the case where schedule divergence leaves a small
-        positive balance but all per-installment allocations pass the
-        tolerance-based ``is_fully_covered`` check.
-
-        Guarded by a residual cap proportional to the number of
-        installments so a large balance is never silently accepted.
-        """
-        installments = self.installments
-        if not installments:
-            return False
-        n = len(self.due_dates)
-        max_residual = self.payment_tolerance * n * n
-        if self.current_balance > max_residual:
-            return False
-        return all(any(a.is_fully_covered for a in inst.allocations) for inst in installments)
-
-    @property
-    def overpaid(self) -> Money:
-        """Total amount paid beyond obligations."""
-        return self._compute_state().overpaid
-
     # ------------------------------------------------------------------
-    # Fine-related
+    # BCL-specific: late-check alias
     # ------------------------------------------------------------------
-
-    @property
-    def fines_applied(self) -> Dict[date, Money]:
-        """Fine amounts applied per due date."""
-        return self._compute_state().fines_applied
-
-    @property
-    def total_fines(self) -> Money:
-        """Total fines applied."""
-        fines = self.fines_applied
-        if not fines:
-            return Money.zero()
-        return Money(sum(f.raw_amount for f in fines.values()))
 
     @tz_aware
     def is_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
         """Check if a payment is late considering the grace period."""
-        check = as_of_date if as_of_date is not None else self.now()
-        return is_payment_late(due_date, self.grace_period_days, check, self._time_ctx.tz, self.working_day_calendar)
-
-    def _on_warp(self, target_date: datetime) -> None:
-        """Hook called by Warp after overriding TimeContext."""
-        self._fine_observation_dates.append(target_date)
-
-    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
-        """Compute and record fine observations as of a date.
-
-        Returns the amount of NEW fines applied.
-        """
-        as_of = as_of_date if as_of_date is not None else self.now()
-        old_total = self.total_fines
-        self._fine_observation_dates.append(as_of)
-        new_total = self.total_fines
-        return new_total - old_total
+        return self.is_payment_late(due_date, as_of_date)
 
     # ------------------------------------------------------------------
-    # Payment info
+    # BCL-specific: Statements
     # ------------------------------------------------------------------
 
     @property
-    def last_payment_date(self) -> datetime:
-        """Date of the last payment, or disbursement date if none."""
-        return self._compute_state().last_payment_date
-
-    def now(self) -> datetime:
-        """Current datetime (Warp-aware)."""
-        return self._time_ctx.now()
-
-    def days_since_last_payment(self) -> int:
-        """Days since the last payment."""
-        return (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(self.last_payment_date)).days
-
-    def _covered_due_date_count(self) -> int:
-        return covered_due_date_count(self.principal_balance, self.get_original_schedule())
-
-    def _next_unpaid_due_date(self) -> date:
-        covered = self._covered_due_date_count()
-        if covered >= len(self.due_dates):
-            raise ValueError("All due dates have been paid")
-        return self.due_dates[covered]
-
-    # ------------------------------------------------------------------
-    # Schedule
-    # ------------------------------------------------------------------
-
-    def get_original_schedule(self) -> PaymentSchedule:
-        """The original amortization schedule (static, ignores payments)."""
-        return self.scheduler.generate_schedule(
-            self.principal,
-            self.interest_rate,
-            self.due_dates,
-            self.disbursement_date,
-            self._time_ctx.tz,
-        )
-
-    def get_amortization_schedule(self) -> PaymentSchedule:
-        """Current schedule: recorded past entries + projected future."""
+    def statements(self) -> List[BillingCycleLoanStatement]:
+        """Billing-period statements (one per cycle)."""
         state = self._compute_state()
-        if not state.settlements:
-            return self.get_original_schedule()
-
-        actual_entries: List[PaymentScheduleEntry] = []
-        prev_balance = self.principal
-        prev_date = self.disbursement_date
-
-        for i, s in enumerate(state.settlements):
-            days = (self._time_ctx.to_date(s.payment_date) - self._time_ctx.to_date(prev_date)).days
-            actual_entries.append(
-                PaymentScheduleEntry(
-                    payment_number=i + 1,
-                    due_date=self._time_ctx.to_date(s.payment_date),
-                    days_in_period=days,
-                    beginning_balance=prev_balance,
-                    payment_amount=s.interest_paid + s.mora_paid + s.principal_paid,
-                    principal_payment=s.principal_paid,
-                    interest_payment=s.interest_paid + s.mora_paid,
-                    ending_balance=s.remaining_balance,
-                )
-            )
-            prev_balance = s.remaining_balance
-            prev_date = s.payment_date
-
-        covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
-        remaining_due_dates = self.due_dates[covered:]
-        if not remaining_due_dates:
-            return PaymentSchedule(entries=actual_entries)
-
-        if state.principal_balance.is_zero() or state.principal_balance.is_negative():
-            return PaymentSchedule(entries=actual_entries)
-
-        projected_schedule = self.scheduler.generate_schedule(
-            state.principal_balance,
-            self.interest_rate,
-            remaining_due_dates,
-            state.last_payment_date,
-            self._time_ctx.tz,
+        return build_statements(
+            self.get_original_schedule(),
+            self.due_dates,
+            self._closing_dates,
+            self.billing_cycle,
+            state.settlements,
+            state.fines_applied,
+            self.principal,
+            self.mora_interest_rate,
+            tz=self._time_ctx.tz,
+            mora_rate_resolver=self.mora_rate_resolver,
         )
-
-        projected_entries: List[PaymentScheduleEntry] = []
-        for entry in projected_schedule:
-            projected_entries.append(
-                PaymentScheduleEntry(
-                    payment_number=len(actual_entries) + entry.payment_number,
-                    due_date=entry.due_date,
-                    days_in_period=entry.days_in_period,
-                    beginning_balance=entry.beginning_balance,
-                    payment_amount=entry.payment_amount,
-                    principal_payment=entry.principal_payment,
-                    interest_payment=entry.interest_payment,
-                    ending_balance=entry.ending_balance,
-                )
-            )
-
-        return PaymentSchedule(entries=actual_entries + projected_entries)
 
     # ------------------------------------------------------------------
     # Dunder

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -555,7 +555,14 @@ class BillingCycleLoan:
         else:
             regular, mora = Money.zero(), Money.zero()
 
-        return self.fine_balance + mora + regular + next_entry.principal_payment
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
+        )
+        fine = total_fines - state.fines_paid_total
+        if fine.is_negative():
+            fine = Money.zero()
+
+        return fine + mora + regular + next_entry.principal_payment
 
     @property
     def is_paid_off(self) -> bool:

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -507,6 +507,57 @@ class BillingCycleLoan:
         return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
 
     @property
+    def settlement_balance(self) -> Money:
+        """Amount needed to cover the next installment via ``pay_installment``.
+
+        Computes fines + mora + interest (accrued to ``max(now, next_due)``)
+        + the next installment's scheduled principal.  Uses the per-cycle
+        mora rate when a resolver is configured.
+
+        For single-installment or last-installment loans this equals the
+        full payoff amount.  For multi-installment loans with more than one
+        installment remaining, this is less than ``current_balance``.
+        """
+        state = self._compute_state()
+        if not state.principal_balance.is_positive():
+            return Money.zero()
+
+        schedule = self.get_original_schedule()
+        covered = covered_due_date_count(state.principal_balance, schedule)
+        if covered >= len(self.due_dates):
+            return Money.zero()
+
+        next_due = self.due_dates[covered]
+        next_entry = schedule.entries[covered]
+
+        now_date = self._time_ctx.to_date(self.now())
+        interest_cutoff = max(now_date, next_due)
+        days = (interest_cutoff - self._time_ctx.to_date(state.last_accrual_end)).days
+
+        if days > 0:
+            mora_rate = resolve_mora_rate(
+                self.due_dates,
+                self._closing_dates,
+                next_due,
+                self.mora_interest_rate,
+                self.mora_rate_resolver,
+                self._time_ctx.tz,
+            )
+            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar)
+            regular, mora = self._interest.compute_accrued_interest(
+                days,
+                state.principal_balance,
+                self._time_ctx.tz,
+                penalty_next_due,
+                state.last_accrual_end,
+                mora_rate_override=mora_rate,
+            )
+        else:
+            regular, mora = Money.zero(), Money.zero()
+
+        return self.fine_balance + mora + regular + next_entry.principal_payment
+
+    @property
     def is_paid_off(self) -> bool:
         """Whether the loan is fully paid off."""
         if self.current_balance.is_zero() or self.current_balance.is_negative():

--- a/money_warp/billing_cycle_loan/billing_cycle_loan.py
+++ b/money_warp/billing_cycle_loan/billing_cycle_loan.py
@@ -1,7 +1,7 @@
 """BillingCycleLoan -- fixed amortization with billing-cycle payment timing."""
 
 from datetime import date, datetime, tzinfo
-from typing import List, Optional, Tuple, Type, Union
+from typing import List, Optional, Type, Union
 from zoneinfo import ZoneInfo
 
 from ..base_loan import BaseLoan
@@ -11,7 +11,6 @@ from ..engines import (
     InterestCalculator,
     LoanState,
     MoraStrategy,
-    covered_due_date_count,
 )
 from ..models import BillingCycleLoanStatement, Settlement
 from ..scheduler import BaseScheduler, PriceScheduler
@@ -19,7 +18,7 @@ from ..time_context import TimeContext
 from ..types.interest_rate import InterestRate
 from ..types.money import Money
 from ..tz import ensure_aware, get_tz, tz_aware
-from ..working_day import EveryDayCalendar, WorkingDayCalendar, effective_penalty_due_date
+from ..working_day import EveryDayCalendar, WorkingDayCalendar
 from .engines import build_statements, compute_state, resolve_mora_rate
 from .mora_rate_resolver import MoraRateResolver
 
@@ -287,97 +286,21 @@ class BillingCycleLoan(BaseLoan):
             calendar=self.working_day_calendar,
         )
 
-    def _accrued_interest_components(self) -> Tuple[Money, Money]:
-        """Return (regular, mora) accrued since last payment."""
-        state = self._compute_state()
-        days = (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(state.last_accrual_end)).days
-
-        if state.principal_balance.is_positive() and days > 0:
-            covered = covered_due_date_count(
-                state.principal_balance,
-                self.get_original_schedule(),
-            )
-            next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
-
-            mora_rate = resolve_mora_rate(
-                self.due_dates,
-                self._closing_dates,
-                next_due,
-                self.mora_interest_rate,
-                self.mora_rate_resolver,
-                self._time_ctx.tz,
-            )
-            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar) if next_due else None
-            return self._interest.compute_accrued_interest(
-                days,
-                state.principal_balance,
-                self._time_ctx.tz,
-                penalty_next_due,
-                state.last_accrual_end,
-                mora_rate_override=mora_rate,
-            )
-
-        return Money.zero(), Money.zero()
-
-    @property
-    def settlement_balance(self) -> Money:
-        """Amount needed to cover the next installment via ``pay_installment``.
-
-        Computes fines + mora + interest (accrued to ``max(now, next_due)``)
-        + the next installment's scheduled principal.  Uses the per-cycle
-        mora rate when a resolver is configured.
-        """
-        state = self._compute_state()
-        if not state.principal_balance.is_positive():
-            return Money.zero()
-
-        schedule = self.get_original_schedule()
-        covered = covered_due_date_count(state.principal_balance, schedule)
-        if covered >= len(self.due_dates):
-            return Money.zero()
-
-        next_due = self.due_dates[covered]
-        next_entry = schedule.entries[covered]
-
-        now_date = self._time_ctx.to_date(self.now())
-        interest_cutoff = max(now_date, next_due)
-        days = (interest_cutoff - self._time_ctx.to_date(state.last_accrual_end)).days
-
-        if days > 0:
-            mora_rate = resolve_mora_rate(
-                self.due_dates,
-                self._closing_dates,
-                next_due,
-                self.mora_interest_rate,
-                self.mora_rate_resolver,
-                self._time_ctx.tz,
-            )
-            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar)
-            regular, mora = self._interest.compute_accrued_interest(
-                days,
-                state.principal_balance,
-                self._time_ctx.tz,
-                penalty_next_due,
-                state.last_accrual_end,
-                mora_rate_override=mora_rate,
-            )
-        else:
-            regular, mora = Money.zero(), Money.zero()
-
-        total_fines = (
-            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
+    def _resolve_mora_rate_for_due(self, next_due: Optional[date]) -> Optional[InterestRate]:
+        """Resolve per-cycle mora rate via the billing cycle's resolver."""
+        return resolve_mora_rate(
+            self.due_dates,
+            self._closing_dates,
+            next_due,
+            self.mora_interest_rate,
+            self.mora_rate_resolver,
+            self._time_ctx.tz,
         )
-        fine = total_fines - state.fines_paid_total
-        if fine.is_negative():
-            fine = Money.zero()
-
-        return fine + mora + regular + next_entry.principal_payment
 
     # ------------------------------------------------------------------
     # BCL-specific: late-check alias
     # ------------------------------------------------------------------
 
-    @tz_aware
     def is_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
         """Check if a payment is late considering the grace period."""
         return self.is_payment_late(due_date, as_of_date)

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -640,8 +640,13 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
     #
     # For a Price schedule the PMT is constant.  The next installment's
     # principal portion = PMT - interest_for_one_period.  Interest for one
-    # period is approximated as principal * periodic_rate.  This mirrors the
-    # same PMT estimation already used for fines.
+    # period is approximated as principal * periodic_rate (where periodic_rate
+    # uses avg_period -- the arithmetic mean of all periods).  This mirrors
+    # the same PMT estimation already used for fines.
+    #
+    # For schedules with irregular periods (e.g. first period of 45 days,
+    # rest 30), the SQL value may diverge slightly from the Python-side
+    # settlement_balance which uses the exact schedule entry.
     period_interest = loan_state.c.principal_balance * periodic_rate
     next_principal = case(
         (loan_state.c.principal_balance <= 0, literal(0.0)),

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -645,7 +645,10 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
     # period is approximated as principal * periodic_rate.  This mirrors the
     # same PMT estimation already used for fines.
     period_interest = loan_state.c.principal_balance * periodic_rate
-    next_principal = mw_greatest(0, pmt - period_interest)
+    next_principal = case(
+        (loan_state.c.principal_balance <= 0, literal(0.0)),
+        else_=mw_greatest(0, pmt - period_interest),
+    )
 
     settlement_pmt = (
         select(

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -592,9 +592,7 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
                 else_=sett_mora_simple,
             ).label("mora_interest"),
         )
-        .select_from(
-            loan_state.join(daily_rates, literal(True)).join(settlement_day_split, literal(True))
-        )
+        .select_from(loan_state.join(daily_rates, literal(True)).join(settlement_day_split, literal(True)))
         .correlate(cls)
         .cte("settlement_accrued", nesting=True)
     )
@@ -682,8 +680,7 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
     target_expr = _component_expr[component]
 
     settlement_tables = (
-        loan_state
-        .join(accrued, literal(True))
+        loan_state.join(accrued, literal(True))
         .join(late_fines, literal(True))
         .join(settlement_accrued, literal(True))
         .join(settlement_pmt, literal(True))
@@ -692,12 +689,7 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
 
     from_tables = settlement_tables if component == _COMPONENT_SETTLEMENT else standard_tables
 
-    full_sq = (
-        select(target_expr.label("result"))
-        .select_from(from_tables)
-        .correlate(cls)
-        .scalar_subquery()
-    )
+    full_sq = select(target_expr.label("result")).select_from(from_tables).correlate(cls).scalar_subquery()
 
     # -- Fallback when rate is NULL ----------------------------------------
     simple_fallback = (
@@ -832,7 +824,11 @@ def loan_bridge(
 
         # -- settlement balance (next installment payoff via pay_installment)
         _attach_balance_hybrid(
-            cls, _meta, "settlement_balance", "settlement_balance", _COMPONENT_SETTLEMENT,
+            cls,
+            _meta,
+            "settlement_balance",
+            "settlement_balance",
+            _COMPONENT_SETTLEMENT,
         )
 
         # -- component balances --------------------------------------------

--- a/money_warp/ext/sa/bridge.py
+++ b/money_warp/ext/sa/bridge.py
@@ -402,6 +402,7 @@ _COMPONENT_PRINCIPAL = "principal"
 _COMPONENT_INTEREST = "interest"
 _COMPONENT_MORA = "mora_interest"
 _COMPONENT_FINES = "fines"
+_COMPONENT_SETTLEMENT = "settlement"
 
 
 def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
@@ -418,7 +419,8 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         meta: Bridge metadata dict mapping logical names to column names.
         component: Which balance component to return.  One of
             ``_COMPONENT_ALL`` (sum, default), ``_COMPONENT_PRINCIPAL``,
-            ``_COMPONENT_INTEREST``, ``_COMPONENT_MORA``, ``_COMPONENT_FINES``.
+            ``_COMPONENT_INTEREST``, ``_COMPONENT_MORA``,
+            ``_COMPONENT_FINES``, ``_COMPONENT_SETTLEMENT``.
     """
     info = _resolve_settlement_info(cls, meta["settlements"])
     pr_col = getattr(cls, meta["principal"])
@@ -480,14 +482,21 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         .scalar_subquery()
     )
 
+    settlement_cutoff = mw_greatest(mw_julianday(as_of), func.coalesce(mw_julianday(next_due_sq), mw_julianday(as_of)))
+
     total_days_expr = mw_greatest(
         0,
         mw_julianday(as_of) - mw_julianday(loan_state.c.last_pay_date),
+    )
+    settlement_days_expr = mw_greatest(
+        0,
+        settlement_cutoff - mw_julianday(loan_state.c.last_pay_date),
     )
 
     time_split = (
         select(
             total_days_expr.label("total_days"),
+            settlement_days_expr.label("settlement_days"),
             next_due_sq.label("next_due"),
             loan_state.c.last_pay_date,
         )
@@ -517,6 +526,28 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         .cte("day_split", nesting=True)
     )
 
+    # -- CTE 4b: settlement_day_split (uses max(as_of, next_due) cutoff) ---
+    sett_regular_days_expr = case(
+        (time_split.c.next_due.is_(None), time_split.c.settlement_days),
+        (
+            mw_julianday(time_split.c.next_due) >= mw_julianday(as_of),
+            time_split.c.settlement_days,
+        ),
+        else_=mw_greatest(
+            0,
+            mw_julianday(time_split.c.next_due) - mw_julianday(time_split.c.last_pay_date),
+        ),
+    )
+
+    settlement_day_split = (
+        select(
+            sett_regular_days_expr.label("regular_days"),
+            mw_greatest(0, time_split.c.settlement_days - sett_regular_days_expr).label("mora_days"),
+        )
+        .correlate(cls)
+        .cte("settlement_day_split", nesting=True)
+    )
+
     # -- CTE 5: accrued ----------------------------------------------------
     reg_interest = loan_state.c.principal_balance * (
         func.pow(1.0 + daily_rates.c.daily_rate, day_split.c.regular_days) - 1.0
@@ -540,6 +571,32 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         .select_from(loan_state.join(daily_rates, literal(True)).join(day_split, literal(True)))
         .correlate(cls)
         .cte("accrued", nesting=True)
+    )
+
+    # -- CTE 5b: settlement_accrued (interest to max(as_of, next_due)) -----
+    sett_reg = loan_state.c.principal_balance * (
+        func.pow(1.0 + daily_rates.c.daily_rate, settlement_day_split.c.regular_days) - 1.0
+    )
+    sett_mora_compound = (loan_state.c.principal_balance + sett_reg) * (
+        func.pow(1.0 + daily_rates.c.mora_daily_rate, settlement_day_split.c.mora_days) - 1.0
+    )
+    sett_mora_simple = loan_state.c.principal_balance * (
+        func.pow(1.0 + daily_rates.c.mora_daily_rate, settlement_day_split.c.mora_days) - 1.0
+    )
+
+    settlement_accrued = (
+        select(
+            sett_reg.label("regular_interest"),
+            case(
+                (ms_col == "COMPOUND", sett_mora_compound),
+                else_=sett_mora_simple,
+            ).label("mora_interest"),
+        )
+        .select_from(
+            loan_state.join(daily_rates, literal(True)).join(settlement_day_split, literal(True))
+        )
+        .correlate(cls)
+        .cte("settlement_accrued", nesting=True)
     )
 
     # -- CTE 6: late_fines -------------------------------------------------
@@ -581,6 +638,24 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
         .cte("late_fines", nesting=True)
     )
 
+    # -- CTE 7: settlement_pmt (next installment's scheduled principal) ----
+    #
+    # For a Price schedule the PMT is constant.  The next installment's
+    # principal portion = PMT - interest_for_one_period.  Interest for one
+    # period is approximated as principal * periodic_rate.  This mirrors the
+    # same PMT estimation already used for fines.
+    period_interest = loan_state.c.principal_balance * periodic_rate
+    next_principal = mw_greatest(0, pmt - period_interest)
+
+    settlement_pmt = (
+        select(
+            next_principal.label("next_principal"),
+        )
+        .select_from(loan_state.join(daily_rates, literal(True)))
+        .correlate(cls)
+        .cte("settlement_pmt", nesting=True)
+    )
+
     # -- Final SELECT: pick requested component ----------------------------
     _component_expr = {
         _COMPONENT_PRINCIPAL: loan_state.c.principal_balance,
@@ -593,13 +668,30 @@ def _build_sql_balance_expression(cls, as_of, meta, component=_COMPONENT_ALL):
             + accrued.c.mora_interest
             + late_fines.c.total_fines
         ),
+        _COMPONENT_SETTLEMENT: (
+            late_fines.c.total_fines
+            + settlement_accrued.c.mora_interest
+            + settlement_accrued.c.regular_interest
+            + settlement_pmt.c.next_principal
+        ),
     }
 
     target_expr = _component_expr[component]
 
+    settlement_tables = (
+        loan_state
+        .join(accrued, literal(True))
+        .join(late_fines, literal(True))
+        .join(settlement_accrued, literal(True))
+        .join(settlement_pmt, literal(True))
+    )
+    standard_tables = loan_state.join(accrued, literal(True)).join(late_fines, literal(True))
+
+    from_tables = settlement_tables if component == _COMPONENT_SETTLEMENT else standard_tables
+
     full_sq = (
         select(target_expr.label("result"))
-        .select_from(loan_state.join(accrued, literal(True)).join(late_fines, literal(True)))
+        .select_from(from_tables)
         .correlate(cls)
         .scalar_subquery()
     )
@@ -681,6 +773,13 @@ def loan_bridge(
     - ``balance_at(date)`` -- total outstanding balance at *date*.
     - ``balance`` -- convenience property for ``balance_at(now())``.
 
+    **Settlement balance:**
+
+    - ``settlement_balance_at(date)`` -- amount to cover next installment
+      via ``pay_installment`` at *date*.
+    - ``settlement_balance`` -- convenience property for
+      ``settlement_balance_at(now())``.
+
     **Component balances (each has an ``_at(date)`` method and a property):**
 
     - ``principal_balance_at`` / ``principal_balance``
@@ -727,6 +826,11 @@ def loan_bridge(
 
         # -- total balance (special: reads current_balance) ----------------
         _attach_balance_hybrid(cls, _meta, "balance", "current_balance", _COMPONENT_ALL)
+
+        # -- settlement balance (next installment payoff via pay_installment)
+        _attach_balance_hybrid(
+            cls, _meta, "settlement_balance", "settlement_balance", _COMPONENT_SETTLEMENT,
+        )
 
         # -- component balances --------------------------------------------
         _COMPONENTS = [

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,23 +1,20 @@
 """Loan class -- everything emerges from the CashFlow."""
 
-import warnings
 from datetime import date, datetime, tzinfo
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 from zoneinfo import ZoneInfo
 
+from ..base_loan import BaseLoan
 from ..cash_flow import CashFlow, CashFlowItem, CashFlowType
 from ..engines import (
     InterestCalculator,
     LoanState,
     MoraStrategy,
-    apply_tolerance_adjustment,
-    build_installments,
     compute_state,
     covered_due_date_count,
-    is_payment_late,
 )
 from ..models import AnticipationResult, Installment, Settlement
-from ..scheduler import BaseScheduler, PaymentSchedule, PaymentScheduleEntry, PriceScheduler
+from ..scheduler import BaseScheduler, PaymentSchedule, PriceScheduler
 from ..tax.base import BaseTax, TaxResult
 from ..time_context import TimeContext
 from ..types.interest_rate import InterestRate
@@ -28,7 +25,7 @@ from ..working_day import EveryDayCalendar, WorkingDayCalendar, effective_penalt
 from .tvm import loan_calculate_anticipation, loan_irr, loan_present_value
 
 
-class Loan:
+class Loan(BaseLoan):
     """Represents a personal loan where everything emerges from the CashFlow.
 
     The CashFlow is the single source of truth. Expected items (the
@@ -105,7 +102,7 @@ class Loan:
         self.cashflow = self._build_initial_cashflow()
 
     # ------------------------------------------------------------------
-    # CashFlow construction
+    # Abstract hook implementations
     # ------------------------------------------------------------------
 
     def _build_initial_cashflow(self) -> CashFlow:
@@ -185,10 +182,6 @@ class Loan:
 
         return CashFlow(items)
 
-    # ------------------------------------------------------------------
-    # Payment recording
-    # ------------------------------------------------------------------
-
     @tz_aware
     def record_payment(
         self,
@@ -245,144 +238,6 @@ class Loan:
 
         return self.settlements[-1]
 
-    def pay_installment(
-        self,
-        amount: Money,
-        description: Optional[str] = None,
-        waive_fines: bool = False,
-        waive_mora: bool = False,
-        discount: Optional[Money] = None,
-    ) -> Settlement:
-        """Pay the next installment.
-
-        Interest accrual depends on timing:
-        - Early/on-time: interest accrues up to the due date.
-        - Late: interest accrues up to self.now().
-
-        When all installments are already paid the payment is recorded
-        as an overpayment (no interest accrual) and a warning is issued.
-
-        After recording the payment, if the principal balance drifts from
-        the schedule's expected ending balance by a small amount (within
-        ``payment_tolerance``), a tolerance adjustment CashFlowItem is
-        added to the cashflow to prevent rounding drift from compounding.
-
-        Args:
-            amount: Payment amount (must be positive).
-            description: Optional description.
-            waive_fines: If True, forgive accumulated fines.
-            waive_mora: If True, forgive accrued mora interest.
-            discount: Flat amount to forgive from obligations.
-        """
-        payment_date = self.now()
-
-        if self._covered_due_date_count() >= len(self.due_dates):
-            warnings.warn(
-                f"All installments already paid. Recording {amount} as overpayment.",
-                stacklevel=2,
-            )
-            return self.record_payment(
-                amount,
-                payment_date=payment_date,
-                interest_date=payment_date,
-                description=description or "Overpayment",
-                waive_fines=waive_fines,
-                waive_mora=waive_mora,
-                discount=discount,
-            )
-
-        next_due = self._next_unpaid_due_date()
-        interest_date = max(payment_date, self._time_ctx.to_datetime(next_due))
-        settlement = self.record_payment(
-            amount,
-            payment_date=payment_date,
-            interest_date=interest_date,
-            description=description,
-            waive_fines=waive_fines,
-            waive_mora=waive_mora,
-            discount=discount,
-        )
-
-        schedule = self.get_original_schedule()
-        for entry in schedule:
-            if entry.due_date == next_due:
-                apply_tolerance_adjustment(
-                    self.cashflow,
-                    entry,
-                    settlement,
-                    payment_date,
-                    interest_date,
-                    self.payment_tolerance,
-                    len(self.due_dates),
-                    self._time_ctx,
-                )
-                break
-
-        return settlement
-
-    def anticipate_payment(
-        self,
-        amount: Money,
-        installments: Optional[List[int]] = None,
-        description: Optional[str] = None,
-        waive_fines: bool = False,
-        waive_mora: bool = False,
-        discount: Optional[Money] = None,
-    ) -> Settlement:
-        """Make an early payment with interest discount.
-
-        Interest is calculated only up to self.now(), so the borrower
-        pays less interest for fewer elapsed days.
-
-        When *installments* is provided (1-based), the corresponding
-        expected cash-flow items are temporally deleted.
-
-        Args:
-            amount: Payment amount (must be positive).
-            installments: 1-based installment numbers to remove.
-            description: Optional description.
-            waive_fines: If True, forgive accumulated fines.
-            waive_mora: If True, forgive accrued mora interest.
-            discount: Flat amount to forgive from obligations.
-        """
-        payment_date = self.now()
-
-        if installments is not None:
-            self._delete_expected_items_for(installments, payment_date)
-
-        return self.record_payment(
-            amount,
-            payment_date=payment_date,
-            interest_date=payment_date,
-            description=description,
-            waive_fines=waive_fines,
-            waive_mora=waive_mora,
-            discount=discount,
-        )
-
-    def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:
-        """Calculate the amount to pay today to eliminate specific installments."""
-        return loan_calculate_anticipation(self, installments)
-
-    def _delete_expected_items_for(self, installments: List[int], effective_date: datetime) -> None:
-        """Temporally delete expected cash-flow items for the given installments."""
-        removed_set = set(installments)
-        for item in self.cashflow.raw_items():
-            entry = item.resolve()
-            if entry is None or entry.kind != CashFlowType.EXPECTED:
-                continue
-            if entry.category.isdisjoint({"interest", "principal"}):
-                continue
-            desc = entry.description or ""
-            for num in removed_set:
-                if desc.endswith(f" {num}"):
-                    item.delete(effective_date)
-                    break
-
-    # ------------------------------------------------------------------
-    # Derived state (computed from CashFlow)
-    # ------------------------------------------------------------------
-
     def _compute_state(self) -> LoanState:
         """Run the forward pass over all payments to derive loan state."""
         return compute_state(
@@ -400,47 +255,7 @@ class Loan:
             calendar=self.working_day_calendar,
         )
 
-    def _payment_entries(self) -> list:
-        """Payment CashFlowEntry objects from the cashflow, sorted by datetime."""
-        entries = [e for e in self.cashflow.items() if "payment" in e.category]
-        return sorted(entries, key=lambda e: e.datetime)
-
-    # ------------------------------------------------------------------
-    # Settlements and installments
-    # ------------------------------------------------------------------
-
-    @property
-    def settlements(self) -> List[Settlement]:
-        """All settlements (derived from CashFlow)."""
-        return self._compute_state().settlements
-
-    @property
-    def installments(self) -> List[Installment]:
-        """The repayment plan as Installment objects (derived from CashFlow)."""
-        state = self._compute_state()
-        return build_installments(
-            self.get_original_schedule(),
-            state.settlements,
-            state.fines_applied,
-            state.principal_balance,
-            self.now(),
-            self._interest,
-            state.last_accrual_end,
-            tz=self._time_ctx.tz,
-            calendar=self.working_day_calendar,
-            grace_period_days=self.grace_period_days,
-        )
-
-    # ------------------------------------------------------------------
-    # Balance properties
-    # ------------------------------------------------------------------
-
-    @property
-    def principal_balance(self) -> Money:
-        """Outstanding principal (derived from CashFlow)."""
-        return self._compute_state().principal_balance
-
-    def _accrued_interest_components(self) -> tuple:
+    def _accrued_interest_components(self) -> Tuple[Money, Money]:
         """Return (regular, mora) accrued interest since last payment."""
         state = self._compute_state()
         days = (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(state.last_accrual_end)).days
@@ -458,31 +273,6 @@ class Loan:
             )
 
         return Money.zero(), Money.zero()
-
-    @property
-    def interest_balance(self) -> Money:
-        """Regular (non-mora) accrued interest since last payment."""
-        return self._accrued_interest_components()[0]
-
-    @property
-    def mora_interest_balance(self) -> Money:
-        """Mora accrued interest since last payment."""
-        return self._accrued_interest_components()[1]
-
-    @property
-    def fine_balance(self) -> Money:
-        """Unpaid fine amount (derived from CashFlow)."""
-        state = self._compute_state()
-        total_fines = (
-            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
-        )
-        outstanding = total_fines - state.fines_paid_total
-        return outstanding if outstanding.is_positive() else Money.zero()
-
-    @property
-    def current_balance(self) -> Money:
-        """Total outstanding balance (principal + interest + mora + fines)."""
-        return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
 
     @property
     def settlement_balance(self) -> Money:
@@ -533,115 +323,71 @@ class Loan:
 
         return fine + mora + regular + next_entry.principal_payment
 
-    @property
-    def is_paid_off(self) -> bool:
-        """Whether the loan is fully paid off."""
-        if self.current_balance.is_zero() or self.current_balance.is_negative():
-            return True
-        return self._all_installments_covered()
-
-    def _all_installments_covered(self) -> bool:
-        """True when every installment has at least one fully-covered allocation.
-
-        Handles the case where schedule divergence leaves a small
-        positive balance but all per-installment allocations pass the
-        tolerance-based ``is_fully_covered`` check.
-
-        Guarded by a residual cap proportional to the number of
-        installments so a large balance is never silently accepted.
-        """
-        installments = self.installments
-        if not installments:
-            return False
-        max_residual = self.payment_tolerance * len(self.due_dates) * len(self.due_dates)
-        if self.current_balance > max_residual:
-            return False
-        return all(any(a.is_fully_covered for a in inst.allocations) for inst in installments)
-
-    @property
-    def overpaid(self) -> Money:
-        """Total amount paid beyond the loan's obligations (derived from CashFlow)."""
-        return self._compute_state().overpaid
-
     # ------------------------------------------------------------------
-    # Fine-related properties and methods
+    # Loan-specific: fines_applied setter
     # ------------------------------------------------------------------
 
-    @property
-    def fines_applied(self) -> Dict[date, Money]:
-        """Fine amounts applied per due date (derived from CashFlow)."""
-        return self._compute_state().fines_applied
-
-    @fines_applied.setter
+    @BaseLoan.fines_applied.setter
     def fines_applied(self, value: Dict[date, Money]) -> None:
         pass
 
-    @property
-    def total_fines(self) -> Money:
-        """Total amount of fines applied."""
-        fines = self.fines_applied
-        if not fines:
-            return Money.zero()
-        return Money(sum(f.raw_amount for f in fines.values()))
+    # ------------------------------------------------------------------
+    # Loan-specific: Anticipation
+    # ------------------------------------------------------------------
 
-    @tz_aware
-    def is_payment_late(self, due_date: date, as_of_date: Optional[datetime] = None) -> bool:
-        """Check if a payment is late considering the grace period."""
-        check = as_of_date if as_of_date is not None else self.now()
-        return is_payment_late(due_date, self.grace_period_days, check, self._time_ctx.tz, self.working_day_calendar)
+    def anticipate_payment(
+        self,
+        amount: Money,
+        installments: Optional[List[int]] = None,
+        description: Optional[str] = None,
+        waive_fines: bool = False,
+        waive_mora: bool = False,
+        discount: Optional[Money] = None,
+    ) -> Settlement:
+        """Make an early payment with interest discount.
 
-    def _on_warp(self, target_date: datetime) -> None:
-        """Hook called by Warp after overriding TimeContext."""
-        self._fine_observation_dates.append(target_date)
+        Interest is calculated only up to self.now(), so the borrower
+        pays less interest for fewer elapsed days.
 
-    def calculate_late_fines(self, as_of_date: Optional[datetime] = None) -> Money:
-        """Compute and record fine observations as of a date.
-
-        Appends the observation date so that subsequent property queries
-        include fines for due dates overdue at that point.
-
-        Returns the amount of NEW fines applied (zero if already applied).
+        When *installments* is provided (1-based), the corresponding
+        expected cash-flow items are temporally deleted.
         """
-        as_of = as_of_date if as_of_date is not None else self.now()
-        old_total = self.total_fines
-        self._fine_observation_dates.append(as_of)
-        new_total = self.total_fines
-        return new_total - old_total
+        payment_date = self.now()
+
+        if installments is not None:
+            self._delete_expected_items_for(installments, payment_date)
+
+        return self.record_payment(
+            amount,
+            payment_date=payment_date,
+            interest_date=payment_date,
+            description=description,
+            waive_fines=waive_fines,
+            waive_mora=waive_mora,
+            discount=discount,
+        )
+
+    def calculate_anticipation(self, installments: List[int]) -> AnticipationResult:
+        """Calculate the amount to pay today to eliminate specific installments."""
+        return loan_calculate_anticipation(self, installments)
+
+    def _delete_expected_items_for(self, installments: List[int], effective_date: datetime) -> None:
+        """Temporally delete expected cash-flow items for the given installments."""
+        removed_set = set(installments)
+        for item in self.cashflow.raw_items():
+            entry = item.resolve()
+            if entry is None or entry.kind != CashFlowType.EXPECTED:
+                continue
+            if entry.category.isdisjoint({"interest", "principal"}):
+                continue
+            desc = entry.description or ""
+            for num in removed_set:
+                if desc.endswith(f" {num}"):
+                    item.delete(effective_date)
+                    break
 
     # ------------------------------------------------------------------
-    # Payment info
-    # ------------------------------------------------------------------
-
-    @property
-    def last_payment_date(self) -> datetime:
-        """Date of the last payment, or disbursement date if none."""
-        return self._compute_state().last_payment_date
-
-    def now(self) -> datetime:
-        """Current datetime (Warp-aware via shared TimeContext)."""
-        return self._time_ctx.now()
-
-    def days_since_last_payment(self) -> int:
-        """Days since the last payment (Warp-aware)."""
-        return (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(self.last_payment_date)).days
-
-    def _covered_due_date_count(self) -> int:
-        """How many due dates have been covered by payments."""
-        return covered_due_date_count(self.principal_balance, self.get_original_schedule())
-
-    def _next_unpaid_due_date(self) -> date:
-        """Find the next due date that hasn't been fully paid.
-
-        Raises:
-            ValueError: If all due dates have been paid.
-        """
-        covered = self._covered_due_date_count()
-        if covered >= len(self.due_dates):
-            raise ValueError("All due dates have been paid")
-        return self.due_dates[covered]
-
-    # ------------------------------------------------------------------
-    # Taxes
+    # Loan-specific: Taxes
     # ------------------------------------------------------------------
 
     @property
@@ -682,81 +428,7 @@ class Loan:
         raise ValueError(f"Due date {due_date} is not in loan's due dates")
 
     # ------------------------------------------------------------------
-    # Schedule
-    # ------------------------------------------------------------------
-
-    def get_original_schedule(self) -> PaymentSchedule:
-        """The original amortization schedule (static, ignores payments)."""
-        return self.scheduler.generate_schedule(
-            self.principal,
-            self.interest_rate,
-            self.due_dates,
-            self.disbursement_date,
-            self._time_ctx.tz,
-        )
-
-    def get_amortization_schedule(self) -> PaymentSchedule:
-        """Current schedule: recorded past entries + projected future."""
-        state = self._compute_state()
-        if not state.settlements:
-            return self.get_original_schedule()
-
-        actual_entries: List[PaymentScheduleEntry] = []
-        prev_balance = self.principal
-        prev_date = self.disbursement_date
-
-        for i, s in enumerate(state.settlements):
-            days = (self._time_ctx.to_date(s.payment_date) - self._time_ctx.to_date(prev_date)).days
-            actual_entries.append(
-                PaymentScheduleEntry(
-                    payment_number=i + 1,
-                    due_date=self._time_ctx.to_date(s.payment_date),
-                    days_in_period=days,
-                    beginning_balance=prev_balance,
-                    payment_amount=s.interest_paid + s.mora_paid + s.principal_paid,
-                    principal_payment=s.principal_paid,
-                    interest_payment=s.interest_paid + s.mora_paid,
-                    ending_balance=s.remaining_balance,
-                )
-            )
-            prev_balance = s.remaining_balance
-            prev_date = s.payment_date
-
-        covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
-        remaining_due_dates = self.due_dates[covered:]
-        if not remaining_due_dates:
-            return PaymentSchedule(entries=actual_entries)
-
-        if state.principal_balance.is_zero() or state.principal_balance.is_negative():
-            return PaymentSchedule(entries=actual_entries)
-
-        projected_schedule = self.scheduler.generate_schedule(
-            state.principal_balance,
-            self.interest_rate,
-            remaining_due_dates,
-            state.last_payment_date,
-            self._time_ctx.tz,
-        )
-
-        projected_entries: List[PaymentScheduleEntry] = []
-        for entry in projected_schedule:
-            projected_entries.append(
-                PaymentScheduleEntry(
-                    payment_number=len(actual_entries) + entry.payment_number,
-                    due_date=entry.due_date,
-                    days_in_period=entry.days_in_period,
-                    beginning_balance=entry.beginning_balance,
-                    payment_amount=entry.payment_amount,
-                    principal_payment=entry.principal_payment,
-                    interest_payment=entry.interest_payment,
-                    ending_balance=entry.ending_balance,
-                )
-            )
-
-        return PaymentSchedule(entries=actual_entries + projected_entries)
-
-    # ------------------------------------------------------------------
-    # Cash flow views
+    # Loan-specific: Cash flow views
     # ------------------------------------------------------------------
 
     def generate_expected_cash_flow(self) -> CashFlow:
@@ -764,7 +436,7 @@ class Loan:
         return self.cashflow.filter_by_kind(CashFlowType.EXPECTED)
 
     # ------------------------------------------------------------------
-    # TVM
+    # Loan-specific: TVM
     # ------------------------------------------------------------------
 
     @tz_aware

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -524,7 +524,14 @@ class Loan:
         else:
             regular, mora = Money.zero(), Money.zero()
 
-        return self.fine_balance + mora + regular + next_entry.principal_payment
+        total_fines = (
+            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
+        )
+        fine = total_fines - state.fines_paid_total
+        if fine.is_negative():
+            fine = Money.zero()
+
+        return fine + mora + regular + next_entry.principal_payment
 
     @property
     def is_paid_off(self) -> bool:

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -485,6 +485,48 @@ class Loan:
         return self.principal_balance + self.interest_balance + self.mora_interest_balance + self.fine_balance
 
     @property
+    def settlement_balance(self) -> Money:
+        """Amount needed to cover the next installment via ``pay_installment``.
+
+        Computes fines + mora + interest (accrued to ``max(now, next_due)``)
+        + the next installment's scheduled principal.  Matches the interest
+        cutoff that ``pay_installment`` uses internally.
+
+        For single-installment or last-installment loans this equals the
+        full payoff amount.  For multi-installment loans with more than one
+        installment remaining, this is less than ``current_balance``.
+        """
+        state = self._compute_state()
+        if not state.principal_balance.is_positive():
+            return Money.zero()
+
+        schedule = self.get_original_schedule()
+        covered = covered_due_date_count(state.principal_balance, schedule)
+        if covered >= len(self.due_dates):
+            return Money.zero()
+
+        next_due = self.due_dates[covered]
+        next_entry = schedule.entries[covered]
+
+        now_date = self._time_ctx.to_date(self.now())
+        interest_cutoff = max(now_date, next_due)
+        days = (interest_cutoff - self._time_ctx.to_date(state.last_accrual_end)).days
+
+        if days > 0:
+            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar)
+            regular, mora = self._interest.compute_accrued_interest(
+                days,
+                state.principal_balance,
+                self._time_ctx.tz,
+                penalty_next_due,
+                state.last_accrual_end,
+            )
+        else:
+            regular, mora = Money.zero(), Money.zero()
+
+        return self.fine_balance + mora + regular + next_entry.principal_payment
+
+    @property
     def is_paid_off(self) -> bool:
         """Whether the loan is fully paid off."""
         if self.current_balance.is_zero() or self.current_balance.is_negative():

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -1,7 +1,7 @@
 """Loan class -- everything emerges from the CashFlow."""
 
 from datetime import date, datetime, tzinfo
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Type, Union
 from zoneinfo import ZoneInfo
 
 from ..base_loan import BaseLoan
@@ -11,7 +11,6 @@ from ..engines import (
     LoanState,
     MoraStrategy,
     compute_state,
-    covered_due_date_count,
 )
 from ..models import AnticipationResult, Settlement
 from ..scheduler import BaseScheduler, PriceScheduler
@@ -21,7 +20,7 @@ from ..types.interest_rate import InterestRate
 from ..types.money import Money
 from ..types.rate import Rate
 from ..tz import ensure_aware, get_tz, tz_aware
-from ..working_day import EveryDayCalendar, WorkingDayCalendar, effective_penalty_due_date
+from ..working_day import EveryDayCalendar, WorkingDayCalendar
 from .tvm import loan_calculate_anticipation, loan_irr, loan_present_value
 
 
@@ -254,74 +253,6 @@ class Loan(BaseLoan):
             fine_observation_dates=self._fine_observation_dates,
             calendar=self.working_day_calendar,
         )
-
-    def _accrued_interest_components(self) -> Tuple[Money, Money]:
-        """Return (regular, mora) accrued interest since last payment."""
-        state = self._compute_state()
-        days = (self._time_ctx.to_date(self.now()) - self._time_ctx.to_date(state.last_accrual_end)).days
-
-        if state.principal_balance.is_positive() and days > 0:
-            covered = covered_due_date_count(state.principal_balance, self.get_original_schedule())
-            next_due = self.due_dates[covered] if covered < len(self.due_dates) else None
-            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar) if next_due else None
-            return self._interest.compute_accrued_interest(
-                days,
-                state.principal_balance,
-                self._time_ctx.tz,
-                penalty_next_due,
-                state.last_accrual_end,
-            )
-
-        return Money.zero(), Money.zero()
-
-    @property
-    def settlement_balance(self) -> Money:
-        """Amount needed to cover the next installment via ``pay_installment``.
-
-        Computes fines + mora + interest (accrued to ``max(now, next_due)``)
-        + the next installment's scheduled principal.  Matches the interest
-        cutoff that ``pay_installment`` uses internally.
-
-        For single-installment or last-installment loans this equals the
-        full payoff amount.  For multi-installment loans with more than one
-        installment remaining, this is less than ``current_balance``.
-        """
-        state = self._compute_state()
-        if not state.principal_balance.is_positive():
-            return Money.zero()
-
-        schedule = self.get_original_schedule()
-        covered = covered_due_date_count(state.principal_balance, schedule)
-        if covered >= len(self.due_dates):
-            return Money.zero()
-
-        next_due = self.due_dates[covered]
-        next_entry = schedule.entries[covered]
-
-        now_date = self._time_ctx.to_date(self.now())
-        interest_cutoff = max(now_date, next_due)
-        days = (interest_cutoff - self._time_ctx.to_date(state.last_accrual_end)).days
-
-        if days > 0:
-            penalty_next_due = effective_penalty_due_date(next_due, self.working_day_calendar)
-            regular, mora = self._interest.compute_accrued_interest(
-                days,
-                state.principal_balance,
-                self._time_ctx.tz,
-                penalty_next_due,
-                state.last_accrual_end,
-            )
-        else:
-            regular, mora = Money.zero(), Money.zero()
-
-        total_fines = (
-            Money(sum(f.raw_amount for f in state.fines_applied.values())) if state.fines_applied else Money.zero()
-        )
-        fine = total_fines - state.fines_paid_total
-        if fine.is_negative():
-            fine = Money.zero()
-
-        return fine + mora + regular + next_entry.principal_payment
 
     # ------------------------------------------------------------------
     # Loan-specific: fines_applied setter

--- a/money_warp/loan/loan.py
+++ b/money_warp/loan/loan.py
@@ -13,8 +13,8 @@ from ..engines import (
     compute_state,
     covered_due_date_count,
 )
-from ..models import AnticipationResult, Installment, Settlement
-from ..scheduler import BaseScheduler, PaymentSchedule, PriceScheduler
+from ..models import AnticipationResult, Settlement
+from ..scheduler import BaseScheduler, PriceScheduler
 from ..tax.base import BaseTax, TaxResult
 from ..time_context import TimeContext
 from ..types.interest_rate import InterestRate

--- a/tests/billing_cycle_loan/conftest.py
+++ b/tests/billing_cycle_loan/conftest.py
@@ -1,12 +1,15 @@
 """Shared fixtures for billing-cycle loan tests."""
 
 from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
-from money_warp import BillingCycleLoan, InterestRate, Money
+from money_warp import BillingCycleLoan, BrazilianWorkingDayCalendar, InterestRate, Money, PriceScheduler
 from money_warp.billing_cycle import MonthlyBillingCycle
 from money_warp.engines import MoraStrategy
+
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
 
 
 @pytest.fixture
@@ -57,4 +60,39 @@ def variable_mora_loan(billing_cycle):
         mora_interest_rate=InterestRate("12% a"),
         mora_rate_resolver=resolver,
         mora_strategy=MoraStrategy.COMPOUND,
+    )
+
+
+@pytest.fixture
+def single_bcl():
+    """Single-installment BCL: 946.62 principal, 4.99% a.m., due Nov 20."""
+    return BillingCycleLoan(
+        principal=Money("946.62"),
+        interest_rate=InterestRate("4.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
+        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        num_installments=1,
+        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("4.99% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+        tz=SAO_PAULO,
+        working_day_calendar=BrazilianWorkingDayCalendar(),
+    )
+
+
+@pytest.fixture
+def multi_bcl():
+    """3-installment BCL: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
+    return BillingCycleLoan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
+        ),
+        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        tz=SAO_PAULO,
     )

--- a/tests/billing_cycle_loan/conftest.py
+++ b/tests/billing_cycle_loan/conftest.py
@@ -87,9 +87,7 @@ def multi_bcl():
     return BillingCycleLoan(
         principal=Money("10000"),
         interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(
-            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
-        ),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]),
         start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
         num_installments=3,
         disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),

--- a/tests/billing_cycle_loan/conftest.py
+++ b/tests/billing_cycle_loan/conftest.py
@@ -1,15 +1,12 @@
-"""Shared fixtures for billing-cycle loan tests."""
+"""Shared fixtures for billing-cycle loan tests (BCL-specific only; common fixtures in tests/conftest.py)."""
 
 from datetime import date, datetime, timezone
-from zoneinfo import ZoneInfo
 
 import pytest
 
-from money_warp import BillingCycleLoan, BrazilianWorkingDayCalendar, InterestRate, Money, PriceScheduler
+from money_warp import BillingCycleLoan, InterestRate, Money
 from money_warp.billing_cycle import MonthlyBillingCycle
 from money_warp.engines import MoraStrategy
-
-SAO_PAULO = ZoneInfo("America/Sao_Paulo")
 
 
 @pytest.fixture
@@ -60,37 +57,4 @@ def variable_mora_loan(billing_cycle):
         mora_interest_rate=InterestRate("12% a"),
         mora_rate_resolver=resolver,
         mora_strategy=MoraStrategy.COMPOUND,
-    )
-
-
-@pytest.fixture
-def single_bcl():
-    """Single-installment BCL: 946.62 principal, 4.99% a.m., due Nov 20."""
-    return BillingCycleLoan(
-        principal=Money("946.62"),
-        interest_rate=InterestRate("4.99% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
-        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        num_installments=1,
-        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        mora_interest_rate=InterestRate("4.99% a.m."),
-        fine_rate=InterestRate("2% a.m."),
-        tz=SAO_PAULO,
-        working_day_calendar=BrazilianWorkingDayCalendar(),
-    )
-
-
-@pytest.fixture
-def multi_bcl():
-    """3-installment BCL: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
-    return BillingCycleLoan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]),
-        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        num_installments=3,
-        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        tz=SAO_PAULO,
     )

--- a/tests/billing_cycle_loan/test_settlement_balance.py
+++ b/tests/billing_cycle_loan/test_settlement_balance.py
@@ -55,9 +55,7 @@ def test_bcl_single_components_sum(single_bcl):
     sched = single_bcl.get_original_schedule()
     with Warp(single_bcl, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         expected_principal = sched.entries[0].principal_payment
-        interest_component = Money(
-            w.settlement_balance.raw_amount - expected_principal.raw_amount
-        )
+        interest_component = Money(w.settlement_balance.raw_amount - expected_principal.raw_amount)
         assert interest_component == sched.entries[0].interest_payment
 
 

--- a/tests/billing_cycle_loan/test_settlement_balance.py
+++ b/tests/billing_cycle_loan/test_settlement_balance.py
@@ -1,0 +1,110 @@
+"""Tests for BillingCycleLoan.settlement_balance with explicit expected values."""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from money_warp import (
+    BillingCycleLoan,
+    BrazilianWorkingDayCalendar,
+    InterestRate,
+    Money,
+    MonthlyBillingCycle,
+    PriceScheduler,
+    Warp,
+)
+
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+
+
+def _single_bcl() -> BillingCycleLoan:
+    return BillingCycleLoan(
+        principal=Money("946.62"),
+        interest_rate=InterestRate("4.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
+        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        num_installments=1,
+        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("4.99% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+        tz=SAO_PAULO,
+        working_day_calendar=BrazilianWorkingDayCalendar(),
+    )
+
+
+def _multi_bcl() -> BillingCycleLoan:
+    return BillingCycleLoan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
+        ),
+        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        tz=SAO_PAULO,
+    )
+
+
+# ------------------------------------------------------------------
+# Single installment
+# ------------------------------------------------------------------
+
+
+def test_bcl_single_early_equals_scheduled_pmt():
+    """Early: settlement_balance equals scheduled PMT."""
+    loan = _single_bcl()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == sched.entries[0].payment_amount
+        assert w.settlement_balance == Money("993.19")
+
+
+def test_bcl_single_early_greater_than_current():
+    """Early: settlement_balance > current_balance."""
+    loan = _single_bcl()
+    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == Money("993.19")
+        assert w.current_balance == Money("977.42")
+        assert w.settlement_balance > w.current_balance
+
+
+def test_bcl_single_late_equals_current():
+    """Late: settlement_balance == current_balance."""
+    loan = _single_bcl()
+    with Warp(loan, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == Money("1019.44")
+        assert w.settlement_balance == w.current_balance
+
+
+def test_bcl_single_components_sum():
+    """settlement_balance = interest_to_due + scheduled_principal (early, no fines)."""
+    loan = _single_bcl()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+        expected_principal = sched.entries[0].principal_payment
+        interest_component = Money(
+            w.settlement_balance.raw_amount - expected_principal.raw_amount
+        )
+        assert interest_component == sched.entries[0].interest_payment
+
+
+# ------------------------------------------------------------------
+# Multi installment
+# ------------------------------------------------------------------
+
+
+def test_bcl_multi_early_equals_first_pmt():
+    """Early: settlement_balance equals installment 1 PMT."""
+    loan = _multi_bcl()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == sched.entries[0].payment_amount
+
+
+def test_bcl_multi_early_less_than_current():
+    """Early: settlement_balance < current_balance."""
+    loan = _multi_bcl()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance < w.current_balance

--- a/tests/billing_cycle_loan/test_settlement_balance.py
+++ b/tests/billing_cycle_loan/test_settlement_balance.py
@@ -1,6 +1,6 @@
 """Tests for BillingCycleLoan.settlement_balance with explicit expected values."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 from money_warp import Money, Warp
@@ -114,3 +114,13 @@ def test_bcl_multi_fully_paid_is_zero(multi_bcl):
 
     with Warp(w3, datetime(2026, 3, 1, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance == Money("0.00")
+
+
+def test_bcl_variable_mora_late_settlement_covers_installment(variable_mora_loan):
+    """Late payment with variable mora resolver: settlement_balance covers next installment."""
+    with Warp(variable_mora_loan, datetime(2025, 4, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(w.settlement_balance)
+        inst = w.installments[0]
+        assert any(
+            a.is_fully_covered for a in inst.allocations
+        ), f"Installment 1 not covered after paying settlement_balance: balance={inst.balance}"

--- a/tests/billing_cycle_loan/test_settlement_balance.py
+++ b/tests/billing_cycle_loan/test_settlement_balance.py
@@ -1,50 +1,11 @@
 """Tests for BillingCycleLoan.settlement_balance with explicit expected values."""
 
-from datetime import date, datetime
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from money_warp import (
-    BillingCycleLoan,
-    BrazilianWorkingDayCalendar,
-    InterestRate,
-    Money,
-    MonthlyBillingCycle,
-    PriceScheduler,
-    Warp,
-)
+from money_warp import Money, Warp
 
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")
-
-
-def _single_bcl() -> BillingCycleLoan:
-    return BillingCycleLoan(
-        principal=Money("946.62"),
-        interest_rate=InterestRate("4.99% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
-        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        num_installments=1,
-        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        mora_interest_rate=InterestRate("4.99% a.m."),
-        fine_rate=InterestRate("2% a.m."),
-        tz=SAO_PAULO,
-        working_day_calendar=BrazilianWorkingDayCalendar(),
-    )
-
-
-def _multi_bcl() -> BillingCycleLoan:
-    return BillingCycleLoan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(
-            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
-        ),
-        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        num_installments=3,
-        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        tz=SAO_PAULO,
-    )
 
 
 # ------------------------------------------------------------------
@@ -52,37 +13,47 @@ def _multi_bcl() -> BillingCycleLoan:
 # ------------------------------------------------------------------
 
 
-def test_bcl_single_early_equals_scheduled_pmt():
+def test_bcl_single_early_equals_scheduled_pmt(single_bcl):
     """Early: settlement_balance equals scheduled PMT."""
-    loan = _single_bcl()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+    sched = single_bcl.get_original_schedule()
+    with Warp(single_bcl, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance == sched.entries[0].payment_amount
         assert w.settlement_balance == Money("993.19")
 
 
-def test_bcl_single_early_greater_than_current():
+def test_bcl_single_early_greater_than_current(single_bcl):
     """Early: settlement_balance > current_balance."""
-    loan = _single_bcl()
-    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(single_bcl, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance == Money("993.19")
         assert w.current_balance == Money("977.42")
         assert w.settlement_balance > w.current_balance
 
 
-def test_bcl_single_late_equals_current():
+def test_bcl_single_ontime_equals_current(single_bcl):
+    """On-time: settlement_balance == current_balance (single installment at due date)."""
+    with Warp(single_bcl, datetime(2025, 11, 20, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == w.current_balance
+
+
+def test_bcl_single_late_equals_current(single_bcl):
     """Late: settlement_balance == current_balance."""
-    loan = _single_bcl()
-    with Warp(loan, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
+    with Warp(single_bcl, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance == Money("1019.44")
         assert w.settlement_balance == w.current_balance
 
 
-def test_bcl_single_components_sum():
+def test_bcl_single_at_disbursement_equals_pmt(single_bcl):
+    """At disbursement: settlement_balance equals scheduled PMT."""
+    sched = single_bcl.get_original_schedule()
+    with Warp(single_bcl, datetime(2025, 10, 21, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == sched.entries[0].payment_amount
+        assert w.settlement_balance == Money("993.19")
+
+
+def test_bcl_single_components_sum(single_bcl):
     """settlement_balance = interest_to_due + scheduled_principal (early, no fines)."""
-    loan = _single_bcl()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+    sched = single_bcl.get_original_schedule()
+    with Warp(single_bcl, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         expected_principal = sched.entries[0].principal_payment
         interest_component = Money(
             w.settlement_balance.raw_amount - expected_principal.raw_amount
@@ -95,16 +66,53 @@ def test_bcl_single_components_sum():
 # ------------------------------------------------------------------
 
 
-def test_bcl_multi_early_equals_first_pmt():
+def test_bcl_multi_early_equals_first_pmt(multi_bcl):
     """Early: settlement_balance equals installment 1 PMT."""
-    loan = _multi_bcl()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    sched = multi_bcl.get_original_schedule()
+    with Warp(multi_bcl, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance == sched.entries[0].payment_amount
+        assert w.settlement_balance == Money("3672.95")
 
 
-def test_bcl_multi_early_less_than_current():
+def test_bcl_multi_early_less_than_current(multi_bcl):
     """Early: settlement_balance < current_balance."""
-    loan = _multi_bcl()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(multi_bcl, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance < w.current_balance
+
+
+def test_bcl_multi_ontime_less_than_current(multi_bcl):
+    """On-time for inst 1: settlement_balance < current_balance (3 installments remain)."""
+    with Warp(multi_bcl, datetime(2025, 12, 20, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == Money("3672.95")
+        assert w.settlement_balance < w.current_balance
+
+
+def test_bcl_multi_after_first_payment_covers_second(multi_bcl):
+    """After paying inst 1, settlement_balance covers inst 2."""
+    sched = multi_bcl.get_original_schedule()
+    with Warp(multi_bcl, datetime(2025, 12, 20, tzinfo=SAO_PAULO)) as w:
+        w.pay_installment(w.settlement_balance)
+        warped = w
+
+    with Warp(warped, datetime(2026, 1, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == sched.entries[1].payment_amount
+
+
+def test_bcl_multi_fully_paid_is_zero(multi_bcl):
+    """After all installments paid, settlement_balance is zero."""
+    sched = multi_bcl.get_original_schedule()
+
+    with Warp(multi_bcl, datetime(2025, 12, 20, tzinfo=SAO_PAULO)) as w:
+        w.pay_installment(sched.entries[0].payment_amount)
+        w1 = w
+
+    with Warp(w1, datetime(2026, 1, 20, tzinfo=SAO_PAULO)) as w:
+        w.pay_installment(sched.entries[1].payment_amount)
+        w2 = w
+
+    with Warp(w2, datetime(2026, 2, 20, tzinfo=SAO_PAULO)) as w:
+        w.pay_installment(sched.entries[2].payment_amount)
+        w3 = w
+
+    with Warp(w3, datetime(2026, 3, 1, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance == Money("0.00")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,9 +76,7 @@ def multi_bcl():
     return BillingCycleLoan(
         principal=Money("10000"),
         interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(
-            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
-        ),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]),
         start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
         num_installments=3,
         disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for invariant tests."""
+"""Shared fixtures available to all test directories."""
 
 from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
@@ -18,9 +18,14 @@ from money_warp import (
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")
 
 
+# ------------------------------------------------------------------
+# Loan fixtures
+# ------------------------------------------------------------------
+
+
 @pytest.fixture
-def loan_single():
-    """Single-installment Loan for invariant tests."""
+def single_installment_loan():
+    """Single-installment Loan: 10k principal, 10% a.m., due Dec 20."""
     return Loan(
         principal=Money("10000"),
         interest_rate=InterestRate("10% a.m."),
@@ -31,8 +36,8 @@ def loan_single():
 
 
 @pytest.fixture
-def loan_multi():
-    """3-installment Loan for invariant tests."""
+def multi_installment_loan():
+    """3-installment Loan: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
     return Loan(
         principal=Money("10000"),
         interest_rate=InterestRate("5% a.m."),
@@ -42,9 +47,14 @@ def loan_multi():
     )
 
 
+# ------------------------------------------------------------------
+# BillingCycleLoan fixtures
+# ------------------------------------------------------------------
+
+
 @pytest.fixture
-def bcl_single():
-    """Single-installment BillingCycleLoan for invariant tests."""
+def single_bcl():
+    """Single-installment BCL: 946.62 principal, 4.99% a.m., due Nov 20."""
     return BillingCycleLoan(
         principal=Money("946.62"),
         interest_rate=InterestRate("4.99% a.m."),
@@ -61,12 +71,14 @@ def bcl_single():
 
 
 @pytest.fixture
-def bcl_multi():
-    """3-installment BillingCycleLoan for invariant tests."""
+def multi_bcl():
+    """3-installment BCL: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
     return BillingCycleLoan(
         principal=Money("10000"),
         interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
+        ),
         start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
         num_installments=3,
         disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),

--- a/tests/invariants/conftest.py
+++ b/tests/invariants/conftest.py
@@ -1,0 +1,77 @@
+"""Shared fixtures for invariant tests."""
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from money_warp import (
+    BillingCycleLoan,
+    BrazilianWorkingDayCalendar,
+    InterestRate,
+    Loan,
+    Money,
+    MonthlyBillingCycle,
+    PriceScheduler,
+)
+
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+
+
+@pytest.fixture
+def loan_single():
+    """Single-installment Loan for invariant tests."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("10% a.m."),
+        due_dates=[date(2025, 12, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+@pytest.fixture
+def loan_multi():
+    """3-installment Loan for invariant tests."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+@pytest.fixture
+def bcl_single():
+    """Single-installment BillingCycleLoan for invariant tests."""
+    return BillingCycleLoan(
+        principal=Money("946.62"),
+        interest_rate=InterestRate("4.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
+        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        num_installments=1,
+        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("4.99% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+        tz=SAO_PAULO,
+        working_day_calendar=BrazilianWorkingDayCalendar(),
+    )
+
+
+@pytest.fixture
+def bcl_multi():
+    """3-installment BillingCycleLoan for invariant tests."""
+    return BillingCycleLoan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
+        ),
+        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        tz=SAO_PAULO,
+    )

--- a/tests/invariants/conftest.py
+++ b/tests/invariants/conftest.py
@@ -66,9 +66,7 @@ def bcl_multi():
     return BillingCycleLoan(
         principal=Money("10000"),
         interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(
-            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
-        ),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]),
         start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
         num_installments=3,
         disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),

--- a/tests/invariants/test_settlement_balance.py
+++ b/tests/invariants/test_settlement_balance.py
@@ -21,52 +21,52 @@ SAO_PAULO = ZoneInfo("America/Sao_Paulo")
 # ------------------------------------------------------------------
 
 
-def test_loan_single_early_settlement_pays_off(loan_single):
+def test_loan_single_early_settlement_pays_off(single_installment_loan):
     """Single-installment Loan: early payment with settlement_balance pays off."""
-    with Warp(loan_single, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_single_ontime_settlement_pays_off(loan_single):
+def test_loan_single_ontime_settlement_pays_off(single_installment_loan):
     """Single-installment Loan: on-time payment with settlement_balance pays off."""
-    with Warp(loan_single, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_single_late_settlement_pays_off(loan_single):
+def test_loan_single_late_settlement_pays_off(single_installment_loan):
     """Single-installment Loan: late payment with settlement_balance pays off."""
-    with Warp(loan_single, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_multi_early_settlement_covers_next_installment(loan_multi):
+def test_loan_multi_early_settlement_covers_next_installment(multi_installment_loan):
     """Multi-installment Loan: early payment covers next installment."""
-    with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
         assert any(a.is_fully_covered for a in inst.allocations), f"Installment 1 not covered: balance={inst.balance}"
 
 
-def test_bcl_single_early_settlement_pays_off(bcl_single):
+def test_bcl_single_early_settlement_pays_off(single_bcl):
     """Single-installment BillingCycleLoan: early payment pays off."""
-    with Warp(bcl_single, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(single_bcl, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_bcl_single_late_settlement_pays_off(bcl_single):
+def test_bcl_single_late_settlement_pays_off(single_bcl):
     """Single-installment BillingCycleLoan: late payment pays off."""
-    with Warp(bcl_single, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
+    with Warp(single_bcl, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_bcl_multi_early_settlement_covers_next_installment(bcl_multi):
+def test_bcl_multi_early_settlement_covers_next_installment(multi_bcl):
     """Multi-installment BillingCycleLoan: early payment covers next installment."""
-    with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(multi_bcl, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
         assert any(a.is_fully_covered for a in inst.allocations), f"Installment 1 not covered: balance={inst.balance}"
@@ -77,33 +77,33 @@ def test_bcl_multi_early_settlement_covers_next_installment(bcl_multi):
 # ------------------------------------------------------------------
 
 
-def test_loan_multi_early_settlement_less_than_current(loan_multi):
+def test_loan_multi_early_settlement_less_than_current(multi_installment_loan):
     """Multi-installment, early: settlement_balance < current_balance."""
-    with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert (
             w.settlement_balance < w.current_balance
         ), f"settlement={w.settlement_balance} should be < current={w.current_balance}"
 
 
-def test_loan_single_early_settlement_gte_current(loan_single):
+def test_loan_single_early_settlement_gte_current(single_installment_loan):
     """Single-installment, early: settlement_balance >= current_balance."""
-    with Warp(loan_single, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert (
             w.settlement_balance >= w.current_balance
         ), f"settlement={w.settlement_balance} should be >= current={w.current_balance}"
 
 
-def test_loan_single_late_settlement_equals_current(loan_single):
+def test_loan_single_late_settlement_equals_current(single_installment_loan):
     """Single-installment, late: settlement_balance == current_balance."""
-    with Warp(loan_single, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         assert (
             w.settlement_balance == w.current_balance
         ), f"settlement={w.settlement_balance} should == current={w.current_balance}"
 
 
-def test_bcl_multi_early_settlement_less_than_current(bcl_multi):
+def test_bcl_multi_early_settlement_less_than_current(multi_bcl):
     """Multi-installment BCL, early: settlement_balance < current_balance."""
-    with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(multi_bcl, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         assert (
             w.settlement_balance < w.current_balance
         ), f"settlement={w.settlement_balance} should be < current={w.current_balance}"

--- a/tests/invariants/test_settlement_balance.py
+++ b/tests/invariants/test_settlement_balance.py
@@ -1,0 +1,189 @@
+"""Invariant tests for settlement_balance.
+
+settlement_balance returns the amount needed to fully cover the next
+installment via pay_installment.  These invariants must hold:
+
+1. pay_installment(settlement_balance) fully covers the next installment.
+2. settlement_balance >= current_balance for single/last installment.
+3. settlement_balance < current_balance for multi-installment (more than 1 remaining).
+4. settlement_balance == current_balance when now >= next_unpaid_due_date.
+"""
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+from money_warp import (
+    BillingCycleLoan,
+    BrazilianWorkingDayCalendar,
+    InterestRate,
+    Loan,
+    Money,
+    MonthlyBillingCycle,
+    PriceScheduler,
+    Warp,
+)
+
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
+
+
+def _make_loan_single() -> Loan:
+    """Single-installment Loan."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("10% a.m."),
+        due_dates=[date(2025, 12, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+def _make_loan_multi() -> Loan:
+    """Multi-installment Loan (3 installments)."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+def _make_bcl_single() -> BillingCycleLoan:
+    """Single-installment BillingCycleLoan."""
+    return BillingCycleLoan(
+        principal=Money("946.62"),
+        interest_rate=InterestRate("4.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
+        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        num_installments=1,
+        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        mora_interest_rate=InterestRate("4.99% a.m."),
+        fine_rate=InterestRate("2% a.m."),
+        tz=SAO_PAULO,
+        working_day_calendar=BrazilianWorkingDayCalendar(),
+    )
+
+
+def _make_bcl_multi() -> BillingCycleLoan:
+    """Multi-installment BillingCycleLoan (3 installments)."""
+    return BillingCycleLoan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        billing_cycle=MonthlyBillingCycle(
+            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
+        ),
+        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        num_installments=3,
+        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
+        scheduler=PriceScheduler,
+        tz=SAO_PAULO,
+    )
+
+
+# ------------------------------------------------------------------
+# Invariant 1: pay_installment(settlement_balance) covers the next installment
+# ------------------------------------------------------------------
+
+
+def test_loan_single_early_settlement_pays_off():
+    """Single-installment Loan: early payment with settlement_balance pays off."""
+    loan = _make_loan_single()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(w.settlement_balance)
+        assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
+
+
+def test_loan_single_ontime_settlement_pays_off():
+    """Single-installment Loan: on-time payment with settlement_balance pays off."""
+    loan = _make_loan_single()
+    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(w.settlement_balance)
+        assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
+
+
+def test_loan_single_late_settlement_pays_off():
+    """Single-installment Loan: late payment with settlement_balance pays off."""
+    loan = _make_loan_single()
+    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(w.settlement_balance)
+        assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
+
+
+def test_loan_multi_early_settlement_covers_next_installment():
+    """Multi-installment Loan: early payment covers next installment."""
+    loan = _make_loan_multi()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        w.pay_installment(w.settlement_balance)
+        inst = w.installments[0]
+        assert any(
+            a.is_fully_covered for a in inst.allocations
+        ), f"Installment 1 not covered: balance={inst.balance}"
+
+
+def test_bcl_single_early_settlement_pays_off():
+    """Single-installment BillingCycleLoan: early payment pays off."""
+    loan = _make_bcl_single()
+    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+        settlement = w.pay_installment(w.settlement_balance)
+        assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
+
+
+def test_bcl_single_late_settlement_pays_off():
+    """Single-installment BillingCycleLoan: late payment pays off."""
+    loan = _make_bcl_single()
+    with Warp(loan, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
+        settlement = w.pay_installment(w.settlement_balance)
+        assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
+
+
+def test_bcl_multi_early_settlement_covers_next_installment():
+    """Multi-installment BillingCycleLoan: early payment covers next installment."""
+    loan = _make_bcl_multi()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+        w.pay_installment(w.settlement_balance)
+        inst = w.installments[0]
+        assert any(
+            a.is_fully_covered for a in inst.allocations
+        ), f"Installment 1 not covered: balance={inst.balance}"
+
+
+# ------------------------------------------------------------------
+# Invariant 2: relationship between settlement_balance and current_balance
+# ------------------------------------------------------------------
+
+
+def test_loan_multi_early_settlement_less_than_current():
+    """Multi-installment, early: settlement_balance < current_balance."""
+    loan = _make_loan_multi()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance < w.current_balance, (
+            f"settlement={w.settlement_balance} should be < current={w.current_balance}"
+        )
+
+
+def test_loan_single_early_settlement_gte_current():
+    """Single-installment, early: settlement_balance >= current_balance."""
+    loan = _make_loan_single()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance >= w.current_balance, (
+            f"settlement={w.settlement_balance} should be >= current={w.current_balance}"
+        )
+
+
+def test_loan_single_late_settlement_equals_current():
+    """Single-installment, late: settlement_balance == current_balance."""
+    loan = _make_loan_single()
+    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == w.current_balance, (
+            f"settlement={w.settlement_balance} should == current={w.current_balance}"
+        )
+
+
+def test_bcl_multi_early_settlement_less_than_current():
+    """Multi-installment BCL, early: settlement_balance < current_balance."""
+    loan = _make_bcl_multi()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+        assert w.settlement_balance < w.current_balance, (
+            f"settlement={w.settlement_balance} should be < current={w.current_balance}"
+        )

--- a/tests/invariants/test_settlement_balance.py
+++ b/tests/invariants/test_settlement_balance.py
@@ -47,9 +47,7 @@ def test_loan_multi_early_settlement_covers_next_installment(loan_multi):
     with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
-        assert any(
-            a.is_fully_covered for a in inst.allocations
-        ), f"Installment 1 not covered: balance={inst.balance}"
+        assert any(a.is_fully_covered for a in inst.allocations), f"Installment 1 not covered: balance={inst.balance}"
 
 
 def test_bcl_single_early_settlement_pays_off(bcl_single):
@@ -71,9 +69,7 @@ def test_bcl_multi_early_settlement_covers_next_installment(bcl_multi):
     with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
-        assert any(
-            a.is_fully_covered for a in inst.allocations
-        ), f"Installment 1 not covered: balance={inst.balance}"
+        assert any(a.is_fully_covered for a in inst.allocations), f"Installment 1 not covered: balance={inst.balance}"
 
 
 # ------------------------------------------------------------------
@@ -84,30 +80,30 @@ def test_bcl_multi_early_settlement_covers_next_installment(bcl_multi):
 def test_loan_multi_early_settlement_less_than_current(loan_multi):
     """Multi-installment, early: settlement_balance < current_balance."""
     with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
-        assert w.settlement_balance < w.current_balance, (
-            f"settlement={w.settlement_balance} should be < current={w.current_balance}"
-        )
+        assert (
+            w.settlement_balance < w.current_balance
+        ), f"settlement={w.settlement_balance} should be < current={w.current_balance}"
 
 
 def test_loan_single_early_settlement_gte_current(loan_single):
     """Single-installment, early: settlement_balance >= current_balance."""
     with Warp(loan_single, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
-        assert w.settlement_balance >= w.current_balance, (
-            f"settlement={w.settlement_balance} should be >= current={w.current_balance}"
-        )
+        assert (
+            w.settlement_balance >= w.current_balance
+        ), f"settlement={w.settlement_balance} should be >= current={w.current_balance}"
 
 
 def test_loan_single_late_settlement_equals_current(loan_single):
     """Single-installment, late: settlement_balance == current_balance."""
     with Warp(loan_single, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
-        assert w.settlement_balance == w.current_balance, (
-            f"settlement={w.settlement_balance} should == current={w.current_balance}"
-        )
+        assert (
+            w.settlement_balance == w.current_balance
+        ), f"settlement={w.settlement_balance} should == current={w.current_balance}"
 
 
 def test_bcl_multi_early_settlement_less_than_current(bcl_multi):
     """Multi-installment BCL, early: settlement_balance < current_balance."""
     with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
-        assert w.settlement_balance < w.current_balance, (
-            f"settlement={w.settlement_balance} should be < current={w.current_balance}"
-        )
+        assert (
+            w.settlement_balance < w.current_balance
+        ), f"settlement={w.settlement_balance} should be < current={w.current_balance}"

--- a/tests/invariants/test_settlement_balance.py
+++ b/tests/invariants/test_settlement_balance.py
@@ -6,79 +6,14 @@ installment via pay_installment.  These invariants must hold:
 1. pay_installment(settlement_balance) fully covers the next installment.
 2. settlement_balance >= current_balance for single/last installment.
 3. settlement_balance < current_balance for multi-installment (more than 1 remaining).
-4. settlement_balance == current_balance when now >= next_unpaid_due_date.
 """
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-from money_warp import (
-    BillingCycleLoan,
-    BrazilianWorkingDayCalendar,
-    InterestRate,
-    Loan,
-    Money,
-    MonthlyBillingCycle,
-    PriceScheduler,
-    Warp,
-)
+from money_warp import Warp
 
 SAO_PAULO = ZoneInfo("America/Sao_Paulo")
-
-
-def _make_loan_single() -> Loan:
-    """Single-installment Loan."""
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("10% a.m."),
-        due_dates=[date(2025, 12, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )
-
-
-def _make_loan_multi() -> Loan:
-    """Multi-installment Loan (3 installments)."""
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )
-
-
-def _make_bcl_single() -> BillingCycleLoan:
-    """Single-installment BillingCycleLoan."""
-    return BillingCycleLoan(
-        principal=Money("946.62"),
-        interest_rate=InterestRate("4.99% a.m."),
-        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 20)]),
-        start_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        num_installments=1,
-        disbursement_date=datetime(2025, 10, 21, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        mora_interest_rate=InterestRate("4.99% a.m."),
-        fine_rate=InterestRate("2% a.m."),
-        tz=SAO_PAULO,
-        working_day_calendar=BrazilianWorkingDayCalendar(),
-    )
-
-
-def _make_bcl_multi() -> BillingCycleLoan:
-    """Multi-installment BillingCycleLoan (3 installments)."""
-    return BillingCycleLoan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        billing_cycle=MonthlyBillingCycle(
-            due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)]
-        ),
-        start_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        num_installments=3,
-        disbursement_date=datetime(2025, 11, 20, tzinfo=SAO_PAULO),
-        scheduler=PriceScheduler,
-        tz=SAO_PAULO,
-    )
 
 
 # ------------------------------------------------------------------
@@ -86,34 +21,30 @@ def _make_bcl_multi() -> BillingCycleLoan:
 # ------------------------------------------------------------------
 
 
-def test_loan_single_early_settlement_pays_off():
+def test_loan_single_early_settlement_pays_off(loan_single):
     """Single-installment Loan: early payment with settlement_balance pays off."""
-    loan = _make_loan_single()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(loan_single, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_single_ontime_settlement_pays_off():
+def test_loan_single_ontime_settlement_pays_off(loan_single):
     """Single-installment Loan: on-time payment with settlement_balance pays off."""
-    loan = _make_loan_single()
-    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+    with Warp(loan_single, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_single_late_settlement_pays_off():
+def test_loan_single_late_settlement_pays_off(loan_single):
     """Single-installment Loan: late payment with settlement_balance pays off."""
-    loan = _make_loan_single()
-    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(loan_single, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_loan_multi_early_settlement_covers_next_installment():
+def test_loan_multi_early_settlement_covers_next_installment(loan_multi):
     """Multi-installment Loan: early payment covers next installment."""
-    loan = _make_loan_multi()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
         assert any(
@@ -121,26 +52,23 @@ def test_loan_multi_early_settlement_covers_next_installment():
         ), f"Installment 1 not covered: balance={inst.balance}"
 
 
-def test_bcl_single_early_settlement_pays_off():
+def test_bcl_single_early_settlement_pays_off(bcl_single):
     """Single-installment BillingCycleLoan: early payment pays off."""
-    loan = _make_bcl_single()
-    with Warp(loan, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(bcl_single, datetime(2025, 11, 10, tzinfo=SAO_PAULO)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_bcl_single_late_settlement_pays_off():
+def test_bcl_single_late_settlement_pays_off(bcl_single):
     """Single-installment BillingCycleLoan: late payment pays off."""
-    loan = _make_bcl_single()
-    with Warp(loan, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
+    with Warp(bcl_single, datetime(2025, 11, 24, tzinfo=SAO_PAULO)) as w:
         settlement = w.pay_installment(w.settlement_balance)
         assert w.is_paid_off, f"Expected is_paid_off but remaining={settlement.remaining_balance}"
 
 
-def test_bcl_multi_early_settlement_covers_next_installment():
+def test_bcl_multi_early_settlement_covers_next_installment(bcl_multi):
     """Multi-installment BillingCycleLoan: early payment covers next installment."""
-    loan = _make_bcl_multi()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         w.pay_installment(w.settlement_balance)
         inst = w.installments[0]
         assert any(
@@ -153,37 +81,33 @@ def test_bcl_multi_early_settlement_covers_next_installment():
 # ------------------------------------------------------------------
 
 
-def test_loan_multi_early_settlement_less_than_current():
+def test_loan_multi_early_settlement_less_than_current(loan_multi):
     """Multi-installment, early: settlement_balance < current_balance."""
-    loan = _make_loan_multi()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(loan_multi, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance < w.current_balance, (
             f"settlement={w.settlement_balance} should be < current={w.current_balance}"
         )
 
 
-def test_loan_single_early_settlement_gte_current():
+def test_loan_single_early_settlement_gte_current(loan_single):
     """Single-installment, early: settlement_balance >= current_balance."""
-    loan = _make_loan_single()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(loan_single, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance >= w.current_balance, (
             f"settlement={w.settlement_balance} should be >= current={w.current_balance}"
         )
 
 
-def test_loan_single_late_settlement_equals_current():
+def test_loan_single_late_settlement_equals_current(loan_single):
     """Single-installment, late: settlement_balance == current_balance."""
-    loan = _make_loan_single()
-    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(loan_single, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == w.current_balance, (
             f"settlement={w.settlement_balance} should == current={w.current_balance}"
         )
 
 
-def test_bcl_multi_early_settlement_less_than_current():
+def test_bcl_multi_early_settlement_less_than_current(bcl_multi):
     """Multi-installment BCL, early: settlement_balance < current_balance."""
-    loan = _make_bcl_multi()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
+    with Warp(bcl_multi, datetime(2025, 12, 10, tzinfo=SAO_PAULO)) as w:
         assert w.settlement_balance < w.current_balance, (
             f"settlement={w.settlement_balance} should be < current={w.current_balance}"
         )

--- a/tests/loan/conftest.py
+++ b/tests/loan/conftest.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from money_warp import InterestRate, Loan, Money
+from money_warp import InterestRate, Loan, Money, PriceScheduler
 
 
 @pytest.fixture
@@ -45,3 +45,27 @@ def partial_payment_loan():
     loan.record_payment(Money("500.00"), payment_date)
 
     return loan, principal, payment_date
+
+
+@pytest.fixture
+def single_installment_loan():
+    """Single-installment Loan: 10k principal, 10% a.m., due Dec 20."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("10% a.m."),
+        due_dates=[date(2025, 12, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+@pytest.fixture
+def multi_installment_loan():
+    """3-installment Loan: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )

--- a/tests/loan/conftest.py
+++ b/tests/loan/conftest.py
@@ -1,10 +1,10 @@
-"""Shared fixtures for loan tests."""
+"""Shared fixtures for loan tests (Loan-specific only; common fixtures in tests/conftest.py)."""
 
 from datetime import date, datetime, timezone
 
 import pytest
 
-from money_warp import InterestRate, Loan, Money, PriceScheduler
+from money_warp import InterestRate, Loan, Money
 
 
 @pytest.fixture
@@ -45,27 +45,3 @@ def partial_payment_loan():
     loan.record_payment(Money("500.00"), payment_date)
 
     return loan, principal, payment_date
-
-
-@pytest.fixture
-def single_installment_loan():
-    """Single-installment Loan: 10k principal, 10% a.m., due Dec 20."""
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("10% a.m."),
-        due_dates=[date(2025, 12, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )
-
-
-@pytest.fixture
-def multi_installment_loan():
-    """3-installment Loan: 10k principal, 5% a.m., due Dec/Jan/Feb 20."""
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )

--- a/tests/loan/test_settlement_balance.py
+++ b/tests/loan/test_settlement_balance.py
@@ -1,0 +1,149 @@
+"""Tests for Loan.settlement_balance with explicit expected values."""
+
+from datetime import date, datetime, timezone
+
+from money_warp import InterestRate, Loan, Money, PriceScheduler, Warp
+
+
+def _single_installment_loan() -> Loan:
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("10% a.m."),
+        due_dates=[date(2025, 12, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+def _multi_installment_loan() -> Loan:
+    return Loan(
+        principal=Money("10000"),
+        interest_rate=InterestRate("5% a.m."),
+        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
+        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
+        scheduler=PriceScheduler,
+    )
+
+
+# ------------------------------------------------------------------
+# Single installment
+# ------------------------------------------------------------------
+
+
+def test_single_early_equals_scheduled_pmt():
+    """Early: settlement_balance equals the scheduled PMT."""
+    loan = _single_installment_loan()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == sched.entries[0].payment_amount
+
+
+def test_single_early_greater_than_current_balance():
+    """Early: settlement_balance > current_balance (extra 10 days interest)."""
+    loan = _single_installment_loan()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == Money("10985.65")
+        assert w.current_balance == Money("10646.75")
+        assert w.settlement_balance > w.current_balance
+
+
+def test_single_ontime_equals_current_balance():
+    """On-time: settlement_balance == current_balance."""
+    loan = _single_installment_loan()
+    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == Money("10985.65")
+        assert w.settlement_balance == w.current_balance
+
+
+def test_single_late_equals_current_balance():
+    """Late: settlement_balance == current_balance (both accrue to now)."""
+    loan = _single_installment_loan()
+    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == Money("11378.83")
+        assert w.settlement_balance == w.current_balance
+
+
+def test_single_late_includes_mora_and_fines():
+    """Late: settlement_balance includes mora interest and fines."""
+    loan = _single_installment_loan()
+    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+        assert w.fine_balance == Money("219.71")
+        assert w.mora_interest_balance == Money("173.47")
+        assert w.settlement_balance == Money("11378.83")
+
+
+def test_single_at_disbursement_equals_scheduled_pmt():
+    """At disbursement: settlement_balance equals PMT (full period ahead)."""
+    loan = _single_installment_loan()
+    with Warp(loan, datetime(2025, 11, 20, tzinfo=timezone.utc)) as w:
+        sched = loan.get_original_schedule()
+        assert w.settlement_balance == sched.entries[0].payment_amount
+
+
+# ------------------------------------------------------------------
+# Multi installment
+# ------------------------------------------------------------------
+
+
+def test_multi_early_equals_first_installment_pmt():
+    """Early: settlement_balance equals installment 1 PMT."""
+    loan = _multi_installment_loan()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == sched.entries[0].payment_amount
+        assert w.settlement_balance == Money("3672.95")
+
+
+def test_multi_early_less_than_current_balance():
+    """Early: settlement_balance < current_balance (1 installment vs all principal)."""
+    loan = _multi_installment_loan()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == Money("3672.95")
+        assert w.current_balance == Money("10326.01")
+        assert w.settlement_balance < w.current_balance
+
+
+def test_multi_after_first_payment_settlement_is_second_pmt():
+    """After paying inst 1, settlement_balance covers inst 2."""
+    loan = _multi_installment_loan()
+    sched = loan.get_original_schedule()
+
+    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(w.settlement_balance)
+        warped = w
+
+    with Warp(warped, datetime(2026, 1, 10, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == sched.entries[1].payment_amount
+
+
+def test_multi_fully_paid_settlement_is_zero():
+    """After all installments paid, settlement_balance is zero."""
+    loan = _multi_installment_loan()
+    sched = loan.get_original_schedule()
+
+    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(sched.entries[0].payment_amount)
+        warped1 = w
+
+    with Warp(warped1, datetime(2026, 1, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(sched.entries[1].payment_amount)
+        warped2 = w
+
+    with Warp(warped2, datetime(2026, 2, 20, tzinfo=timezone.utc)) as w:
+        w.pay_installment(sched.entries[2].payment_amount)
+        warped3 = w
+
+    with Warp(warped3, datetime(2026, 3, 1, tzinfo=timezone.utc)) as w:
+        assert w.settlement_balance == Money("0.00")
+
+
+def test_multi_components_sum():
+    """settlement_balance = interest_to_due + scheduled_principal (no fines/mora)."""
+    loan = _multi_installment_loan()
+    sched = loan.get_original_schedule()
+    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+        expected_principal = sched.entries[0].principal_payment
+        interest_component = Money(
+            w.settlement_balance.raw_amount - expected_principal.raw_amount
+        )
+        assert interest_component == sched.entries[0].interest_payment

--- a/tests/loan/test_settlement_balance.py
+++ b/tests/loan/test_settlement_balance.py
@@ -1,114 +1,74 @@
 """Tests for Loan.settlement_balance with explicit expected values."""
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
-from money_warp import InterestRate, Loan, Money, PriceScheduler, Warp
-
-
-def _single_installment_loan() -> Loan:
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("10% a.m."),
-        due_dates=[date(2025, 12, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )
+from money_warp import Money, Warp
 
 
-def _multi_installment_loan() -> Loan:
-    return Loan(
-        principal=Money("10000"),
-        interest_rate=InterestRate("5% a.m."),
-        due_dates=[date(2025, 12, 20), date(2026, 1, 20), date(2026, 2, 20)],
-        disbursement_date=datetime(2025, 11, 20, tzinfo=timezone.utc),
-        scheduler=PriceScheduler,
-    )
-
-
-# ------------------------------------------------------------------
-# Single installment
-# ------------------------------------------------------------------
-
-
-def test_single_early_equals_scheduled_pmt():
+def test_single_early_equals_scheduled_pmt(single_installment_loan):
     """Early: settlement_balance equals the scheduled PMT."""
-    loan = _single_installment_loan()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    sched = single_installment_loan.get_original_schedule()
+    with Warp(single_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == sched.entries[0].payment_amount
 
 
-def test_single_early_greater_than_current_balance():
+def test_single_early_greater_than_current_balance(single_installment_loan):
     """Early: settlement_balance > current_balance (extra 10 days interest)."""
-    loan = _single_installment_loan()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == Money("10985.65")
         assert w.current_balance == Money("10646.75")
         assert w.settlement_balance > w.current_balance
 
 
-def test_single_ontime_equals_current_balance():
+def test_single_ontime_equals_current_balance(single_installment_loan):
     """On-time: settlement_balance == current_balance."""
-    loan = _single_installment_loan()
-    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == Money("10985.65")
         assert w.settlement_balance == w.current_balance
 
 
-def test_single_late_equals_current_balance():
+def test_single_late_equals_current_balance(single_installment_loan):
     """Late: settlement_balance == current_balance (both accrue to now)."""
-    loan = _single_installment_loan()
-    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == Money("11378.83")
         assert w.settlement_balance == w.current_balance
 
 
-def test_single_late_includes_mora_and_fines():
+def test_single_late_includes_mora_and_fines(single_installment_loan):
     """Late: settlement_balance includes mora interest and fines."""
-    loan = _single_installment_loan()
-    with Warp(loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
+    with Warp(single_installment_loan, datetime(2025, 12, 25, tzinfo=timezone.utc)) as w:
         assert w.fine_balance == Money("219.71")
         assert w.mora_interest_balance == Money("173.47")
         assert w.settlement_balance == Money("11378.83")
 
 
-def test_single_at_disbursement_equals_scheduled_pmt():
+def test_single_at_disbursement_equals_scheduled_pmt(single_installment_loan):
     """At disbursement: settlement_balance equals PMT (full period ahead)."""
-    loan = _single_installment_loan()
-    with Warp(loan, datetime(2025, 11, 20, tzinfo=timezone.utc)) as w:
-        sched = loan.get_original_schedule()
+    sched = single_installment_loan.get_original_schedule()
+    with Warp(single_installment_loan, datetime(2025, 11, 20, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == sched.entries[0].payment_amount
 
 
-# ------------------------------------------------------------------
-# Multi installment
-# ------------------------------------------------------------------
-
-
-def test_multi_early_equals_first_installment_pmt():
+def test_multi_early_equals_first_installment_pmt(multi_installment_loan):
     """Early: settlement_balance equals installment 1 PMT."""
-    loan = _multi_installment_loan()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    sched = multi_installment_loan.get_original_schedule()
+    with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == sched.entries[0].payment_amount
         assert w.settlement_balance == Money("3672.95")
 
 
-def test_multi_early_less_than_current_balance():
+def test_multi_early_less_than_current_balance(multi_installment_loan):
     """Early: settlement_balance < current_balance (1 installment vs all principal)."""
-    loan = _multi_installment_loan()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         assert w.settlement_balance == Money("3672.95")
         assert w.current_balance == Money("10326.01")
         assert w.settlement_balance < w.current_balance
 
 
-def test_multi_after_first_payment_settlement_is_second_pmt():
+def test_multi_after_first_payment_settlement_is_second_pmt(multi_installment_loan):
     """After paying inst 1, settlement_balance covers inst 2."""
-    loan = _multi_installment_loan()
-    sched = loan.get_original_schedule()
-
-    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+    sched = multi_installment_loan.get_original_schedule()
+    with Warp(multi_installment_loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
         w.pay_installment(w.settlement_balance)
         warped = w
 
@@ -116,12 +76,11 @@ def test_multi_after_first_payment_settlement_is_second_pmt():
         assert w.settlement_balance == sched.entries[1].payment_amount
 
 
-def test_multi_fully_paid_settlement_is_zero():
+def test_multi_fully_paid_settlement_is_zero(multi_installment_loan):
     """After all installments paid, settlement_balance is zero."""
-    loan = _multi_installment_loan()
-    sched = loan.get_original_schedule()
+    sched = multi_installment_loan.get_original_schedule()
 
-    with Warp(loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
+    with Warp(multi_installment_loan, datetime(2025, 12, 20, tzinfo=timezone.utc)) as w:
         w.pay_installment(sched.entries[0].payment_amount)
         warped1 = w
 
@@ -137,11 +96,10 @@ def test_multi_fully_paid_settlement_is_zero():
         assert w.settlement_balance == Money("0.00")
 
 
-def test_multi_components_sum():
+def test_multi_components_sum(multi_installment_loan):
     """settlement_balance = interest_to_due + scheduled_principal (no fines/mora)."""
-    loan = _multi_installment_loan()
-    sched = loan.get_original_schedule()
-    with Warp(loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
+    sched = multi_installment_loan.get_original_schedule()
+    with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         expected_principal = sched.entries[0].principal_payment
         interest_component = Money(
             w.settlement_balance.raw_amount - expected_principal.raw_amount

--- a/tests/loan/test_settlement_balance.py
+++ b/tests/loan/test_settlement_balance.py
@@ -101,7 +101,5 @@ def test_multi_components_sum(multi_installment_loan):
     sched = multi_installment_loan.get_original_schedule()
     with Warp(multi_installment_loan, datetime(2025, 12, 10, tzinfo=timezone.utc)) as w:
         expected_principal = sched.entries[0].principal_payment
-        interest_component = Money(
-            w.settlement_balance.raw_amount - expected_principal.raw_amount
-        )
+        interest_component = Money(w.settlement_balance.raw_amount - expected_principal.raw_amount)
         assert interest_component == sched.entries[0].interest_payment


### PR DESCRIPTION
## Summary

- Add `settlement_balance` property to `Loan` and `BillingCycleLoan` that returns the exact amount needed to cover the next installment via `pay_installment`
- Unlike `current_balance` (interest to `now()`), `settlement_balance` accrues interest to `max(now(), next_due)`, matching `pay_installment`'s internal logic
- Exposed as `hybrid_property`/`hybrid_method` in the SA `loan_bridge` (Python + SQL sides)
- Added 11 invariant tests covering early/on-time/late payments for both Loan and BillingCycleLoan

Closes #75

## Test plan

- [ ] `tests/invariants/test_settlement_balance.py` -- 11 tests covering:
  - `pay_installment(settlement_balance)` pays off single-installment loans (early, on-time, late)
  - `pay_installment(settlement_balance)` covers next installment on multi-installment loans
  - `settlement_balance < current_balance` for multi-installment
  - `settlement_balance >= current_balance` for single-installment early
  - `settlement_balance == current_balance` for single-installment late
- [ ] Full test suite passes (5670 tests, 0 failures)
- [ ] SA extension tests pass (302 tests)