### PR TITLE
Update outdated documentation for v0.24–v0.28 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ MoneyWarp is a Python library for working with the time value of money. It treat
 - **Amortization schedules** -- French (Price) and SAC (Inverted Price)
 - **Flexible dates** -- irregular due dates, smart month-end handling
 - **Type-safe interest rates** -- explicit percentage handling, frequency conversions
+- **Percentage type** -- non-temporal flat percentages for fees, fines, MDR
 - **Installments and Settlements** -- first-class repayment plan and payment allocation
+- **Payment waivers** -- waive fines, mora, or overdue interest per payment
+- **Working day calendars** -- business day awareness for penalty deadlines
 - **Tax module** -- Brazilian IOF, grossup, pluggable tax strategy
 - **Timezone-aware** -- UTC by default, configurable globally
 - **Marshmallow extension** -- custom fields for serialization
@@ -94,6 +97,7 @@ Full guides, examples, and API reference at **[tomascorrea.github.io/money-warp]
 - [Quick Start](https://tomascorrea.github.io/money-warp/examples/quickstart/)
 - [Money and Precision](https://tomascorrea.github.io/money-warp/examples/money/)
 - [Interest Rates](https://tomascorrea.github.io/money-warp/examples/interest_rates/)
+- [Percentages](https://tomascorrea.github.io/money-warp/examples/percentages/)
 - [Cash Flow Analysis](https://tomascorrea.github.io/money-warp/examples/cash_flow/)
 - [Date Generation](https://tomascorrea.github.io/money-warp/examples/date_generation/)
 - [Time Machine](https://tomascorrea.github.io/money-warp/examples/time_machine/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/tomascorrea/money-warp/branch/main/graph/badge.svg)](https://codecov.io/gh/tomascorrea/money-warp)
 [![License](https://img.shields.io/github/license/tomascorrea/money-warp)](https://img.shields.io/github/license/tomascorrea/money-warp)
 
-> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 1200+ tests, but the API may evolve.
+> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 5700+ tests, but the API may evolve.
 
 MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as cash flows through time -- and gives you the tools to warp them back and forth between present, future, and everything in between.
 

--- a/docs/examples/fines.md
+++ b/docs/examples/fines.md
@@ -2,7 +2,7 @@
 
 MoneyWarp models late payments realistically: overdue installments incur **fines** (a flat percentage of the missed amount) and **mora interest** (extra daily-compounded interest for the days beyond the due date). Payments are always allocated in strict priority: fines first, then interest, then principal.
 
-All payment methods return a **Settlement** object showing exactly how the payment was allocated (see [Installments & Settlements](#installments--settlements) below).
+All payment methods return a **Settlement** object showing exactly how the payment was allocated (see [Installments & Settlements](#installments-settlements) below).
 
 ## Payment Methods
 
@@ -192,7 +192,76 @@ print(loan.is_payment_late(date(2024, 2, 1), datetime(2024, 2, 5)))  # False
 print(loan.is_payment_late(date(2024, 2, 1), datetime(2024, 2, 9)))  # True
 ```
 
-Note: the grace period only affects **fines**. Mora interest always accrues for every day past the due date, regardless of the grace period.
+The grace period acts as a forgiveness threshold: payments within the grace window incur **neither fine nor mora**. Once the grace period expires, full mora accrues from the **original due date** (not from the grace period end).
+
+## Payment Waivers
+
+All three payment methods (`record_payment`, `pay_installment`, `anticipate_payment`) accept waiver flags that let you forgive specific penalty components on a per-payment basis.
+
+### `waive_fines` and `waive_mora`
+
+When `waive_fines=True`, outstanding fines are not allocated from the payment. When `waive_mora=True`, mora interest is not charged for the overdue period.
+
+```python
+from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, Warp, generate_monthly_dates
+from money_warp.tz import to_date
+
+loan = Loan(
+    Money("10000"),
+    InterestRate("5% a"),
+    [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)],
+)
+
+# Pay late but waive both fines and mora
+with Warp(loan, datetime(2024, 3, 15)) as warped:
+    settlement = warped.pay_installment(
+        Money("856.07"),
+        waive_fines=True,
+        waive_mora=True,
+    )
+    print(f"Fine paid: {settlement.fine_paid}")  # 0.00
+    print(f"Mora paid: {settlement.mora_paid}")  # 0.00
+```
+
+### `waive_overdue_interest`
+
+When `waive_overdue_interest=True`, interest that accrued past the last contractual due date is not charged. This is useful for loans that have matured (all installments past due) where the lender agrees to forgive the overdue interest.
+
+```python
+# Waive overdue interest on a late payment
+with Warp(loan, datetime(2024, 3, 15)) as warped:
+    settlement = warped.pay_installment(
+        Money("856.07"),
+        waive_overdue_interest=True,
+    )
+```
+
+## Flat-Amount Discount
+
+All three payment methods accept a `discount` parameter — a flat `Money` amount subtracted from the interest portion before allocation. This reduces the interest the borrower pays without affecting fines or principal.
+
+```python
+from datetime import datetime
+
+from money_warp import Loan, Money, InterestRate, Warp, generate_monthly_dates
+from money_warp.tz import to_date
+
+loan = Loan(
+    Money("10000"),
+    InterestRate("5% a"),
+    [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)],
+)
+
+# Apply a R$10 discount on interest
+with Warp(loan, datetime(2024, 2, 1)) as warped:
+    settlement = warped.pay_installment(
+        Money("846.07"),
+        discount=Money("10.00"),
+    )
+    print(f"Interest paid: {settlement.interest_paid}")
+```
 
 ## Tracking Fines and Mora via Settlements
 
@@ -290,6 +359,8 @@ Settlements are not stored as separate state — they are reconstructed by query
 | `total_fines` | `Money` | Sum of all fines ever applied |
 | `fine_balance` | `Money` | Unpaid fines (total minus what's been paid off) |
 | `fines_applied` | `Dict[datetime, Money]` | Fine amount applied per due date |
+| `overdue_interest_balance` | `Money` | Regular interest accrued past the contract due date (subset of `interest_balance`) |
+| `settlement_balance` | `Money` | Amount needed to cover the next installment via `pay_installment` (fines + mora + interest + next principal) |
 | `is_paid_off` | `bool` | True only when principal **and** fines are zero |
 | `installments` | `List[Installment]` | Repayment plan with expected/actual amounts (Warp-aware) |
 | `settlements` | `List[Settlement]` | Payment allocation history (Warp-aware) |

--- a/docs/examples/fines.md
+++ b/docs/examples/fines.md
@@ -230,7 +230,7 @@ with Warp(loan, datetime(2024, 3, 15)) as warped:
 When `waive_overdue_interest=True`, interest that accrued past the last contractual due date is not charged. This is useful for loans that have matured (all installments past due) where the lender agrees to forgive the overdue interest.
 
 ```python
-# Waive overdue interest on a late payment
+# Using the loan from the previous example
 with Warp(loan, datetime(2024, 3, 15)) as warped:
     settlement = warped.pay_installment(
         Money("856.07"),
@@ -240,7 +240,7 @@ with Warp(loan, datetime(2024, 3, 15)) as warped:
 
 ## Flat-Amount Discount
 
-All three payment methods accept a `discount` parameter — a flat `Money` amount subtracted from the interest portion before allocation. This reduces the interest the borrower pays without affecting fines or principal.
+All three payment methods accept a `discount` parameter — a flat `Money` amount that reduces the borrower's obligation. The discount is applied in the same priority order as payment allocation: fines first, then mora, then interest, then principal. Any excess cascades to the next component.
 
 ```python
 from datetime import datetime
@@ -254,7 +254,7 @@ loan = Loan(
     [to_date(d) for d in generate_monthly_dates(datetime(2024, 2, 1), 12)],
 )
 
-# Apply a R$10 discount on interest
+# Apply a R$10 discount
 with Warp(loan, datetime(2024, 2, 1)) as warped:
     settlement = warped.pay_installment(
         Money("846.07"),
@@ -360,7 +360,7 @@ Settlements are not stored as separate state — they are reconstructed by query
 | `fine_balance` | `Money` | Unpaid fines (total minus what's been paid off) |
 | `fines_applied` | `Dict[datetime, Money]` | Fine amount applied per due date |
 | `overdue_interest_balance` | `Money` | Regular interest accrued past the contract due date (subset of `interest_balance`) |
-| `settlement_balance` | `Money` | Amount needed to cover the next installment via `pay_installment` (fines + mora + interest + next principal) |
+| `settlement_balance` | `Money` | Amount needed to cover the next installment via `pay_installment` — fines + mora + interest (accrued to `max(now, next_due)`) + next principal |
 | `is_paid_off` | `bool` | True only when principal **and** fines are zero |
 | `installments` | `List[Installment]` | Repayment plan with expected/actual amounts (Warp-aware) |
 | `settlements` | `List[Settlement]` | Payment allocation history (Warp-aware) |

--- a/docs/examples/marshmallow.md
+++ b/docs/examples/marshmallow.md
@@ -116,6 +116,37 @@ result = schema.load(data)
 # {"amount": Money("123.45")}
 ```
 
+### PercentageField
+
+Serializes `Percentage` instances to canonical strings (`"5.00%"`) and deserializes via the `Percentage` constructor, inheriting all its validation (rejects numeric inputs, strings without `%`, temporal suffixes, and negative values).
+
+```python
+from marshmallow import Schema
+from money_warp import Percentage
+from money_warp.ext.marshmallow import PercentageField
+
+class FeeSchema(Schema):
+    mdr = PercentageField()
+
+schema = FeeSchema()
+
+# Serialize
+data = schema.dump({"mdr": Percentage("5%")})
+# {"mdr": "5.00%"}
+
+# Deserialize
+result = schema.load({"mdr": "5.00%"})
+# {"mdr": Percentage('5.00%')}
+```
+
+Optional constructor parameters:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `precision` | `None` | Default precision for `Percentage` construction on load |
+| `rounding` | `None` | Default rounding mode for `Percentage` construction on load |
+| `str_decimals` | `None` | Decimal places for string serialization |
+
 ## Notes
 
 - All fields pass `None` through in both directions.

--- a/docs/examples/sqlalchemy.md
+++ b/docs/examples/sqlalchemy.md
@@ -44,6 +44,30 @@ Additional constructor parameters (`year_size`, `precision`, `rounding`, `str_st
 
 Subclass of `RateType` with `RATE_CLASS = InterestRate`. Same representations, but constructs `InterestRate` on load (rejects negative values).
 
+### PercentageType
+
+Stores `Percentage` instances as canonical strings (`"5.00%"`) in a `String` column. Validation delegates to the `Percentage` constructor, so invalid inputs (numeric, missing `%`, temporal suffix, negative) raise on load.
+
+```python
+from money_warp.ext.sa import PercentageType
+from sqlalchemy import Column, Integer
+from sqlalchemy.orm import DeclarativeBase
+
+class Base(DeclarativeBase): ...
+
+class PartnerFee(Base):
+    __tablename__ = "partner_fees"
+    id = Column(Integer, primary_key=True)
+    mdr = Column(PercentageType())  # stored as "5.00%"
+```
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `precision` | `None` | Default precision for `Percentage` construction on load |
+| `rounding` | `None` | Default rounding mode for `Percentage` construction on load |
+| `str_decimals` | `None` | Decimal places for serialization |
+| `length` | `32` | Length of the underlying `String` column |
+
 ## Bridge Decorators
 
 The bridge system connects SQLAlchemy models to money-warp's Loan engine, providing both Python-side and SQL-side balance calculations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,10 @@ MoneyWarp is a Python library for working with the time value of money. It treat
 - **Amortization schedules** -- French (Price) and SAC (Inverted Price)
 - **Flexible dates** -- irregular due dates, smart month-end handling
 - **Type-safe interest rates** -- explicit percentage handling, frequency conversions
+- **Percentage type** -- non-temporal flat percentages for fees, fines, MDR
 - **Installments and Settlements** -- first-class repayment plan and payment allocation
+- **Payment waivers** -- waive fines, mora, or overdue interest per payment
+- **Working day calendars** -- business day awareness for penalty deadlines
 - **Tax module** -- Brazilian IOF, grossup, pluggable tax strategy
 - **Timezone-aware** -- UTC by default, configurable globally
 - **Marshmallow extension** -- custom fields for serialization
@@ -57,6 +60,7 @@ Explore the comprehensive examples and API reference:
 - **[Quick Start](examples/quickstart.md)** -- get up and running quickly
 - **[Money](examples/money.md)** -- high-precision monetary amounts
 - **[Interest Rates](examples/interest_rates.md)** -- type-safe rate handling and conversions
+- **[Percentages](examples/percentages.md)** -- non-temporal flat percentages for fees, fines, MDR
 - **[Date Generation](examples/date_generation.md)** -- smart payment date utilities
 - **[Present Value & IRR](examples/present_value_irr.md)** -- TVM functions and analysis
 - **[Time Machine](examples/time_machine.md)** -- travel through time with loans

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/tomascorrea/money-warp/branch/main/graph/badge.svg)](https://codecov.io/gh/tomascorrea/money-warp)
 [![License](https://img.shields.io/github/license/tomascorrea/money-warp)](https://img.shields.io/github/license/tomascorrea/money-warp)
 
-> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 1200+ tests, but the API may evolve.
+> **Development Stage Notice** -- MoneyWarp is in active development (alpha). Core classes are stable and covered by 5700+ tests, but the API may evolve.
 
 MoneyWarp is a Python library for working with the time value of money. It treats loans, annuities, and investments as cash flows through time -- and gives you the tools to warp them back and forth between present, future, and everything in between.
 
@@ -87,7 +87,7 @@ MoneyWarp is built around core financial concepts:
 
 ## Quality & Testing
 
-- **1200+ comprehensive tests** with 100% core functionality coverage
+- **5700+ comprehensive tests** with 100% core functionality coverage
 - **Type safety**: Full mypy compatibility with zero type errors
 - **Code quality**: Passes ruff linting and black formatting
 - **Robust numerics**: Scipy-powered calculations for reliability

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -379,3 +379,152 @@ MoneyWarp provides a comprehensive set of classes for financial calculations and
       show_root_heading: true
       show_source: false
       heading_level: 4
+
+## Rate
+
+### Rate
+::: money_warp.Rate
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Billing Cycle Loan
+
+### BillingCycleLoan
+::: money_warp.BillingCycleLoan
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### MoraRateResolver
+::: money_warp.MoraRateResolver
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### BaseBillingCycle
+::: money_warp.BaseBillingCycle
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### MonthlyBillingCycle
+::: money_warp.MonthlyBillingCycle
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### BillingCycleLoanStatement
+::: money_warp.BillingCycleLoanStatement
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Credit Card
+
+### CreditCard
+::: money_warp.CreditCard
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### Statement
+::: money_warp.Statement
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Working Day Calendars
+
+### WorkingDayCalendar
+::: money_warp.WorkingDayCalendar
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### BrazilianWorkingDayCalendar
+::: money_warp.BrazilianWorkingDayCalendar
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### EveryDayCalendar
+::: money_warp.EveryDayCalendar
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### WeekendCalendar
+::: money_warp.WeekendCalendar
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Engines
+
+### MoraStrategy
+::: money_warp.MoraStrategy
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Time Context
+
+### TimeContext
+::: money_warp.TimeContext
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Additional Models
+
+### AnticipationResult
+::: money_warp.AnticipationResult
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+## Cash Flow Types
+
+### CashFlowEntry
+::: money_warp.CashFlowEntry
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### ExpectedCashFlowEntry
+::: money_warp.ExpectedCashFlowEntry
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### HappenedCashFlowEntry
+::: money_warp.HappenedCashFlowEntry
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4
+
+### CashFlowType
+::: money_warp.CashFlowType
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 4


### PR DESCRIPTION
## Summary

- Fix factual error in `docs/examples/fines.md`: grace period now eliminates both fines and mora (changed in v0.24.1)
- Document `waive_fines`, `waive_mora`, `waive_overdue_interest` flags and `discount` parameter on payment methods
- Document `settlement_balance` and `overdue_interest_balance` properties
- Add Percentages link to README.md and docs/index.md
- Add 3 new features to the Features list (Percentage type, working day calendars, payment waivers)
- Add 17 missing public API classes to `docs/modules.md` API Reference
- Document `PercentageField` in Marshmallow extension docs
- Document `PercentageType` in SQLAlchemy extension docs
- Fix pre-existing broken anchor link in fines.md

Closes #85

## Test plan

- [x] `poetry run mkdocs build` succeeds with no broken references
- [x] Full test suite passes (5712 tests)
- [x] No code changes — documentation only