### PR TITLE
fix: record per-installment discount split so is_fully_paid honors it

### DIFF
--- a/knowledge/loan.md
+++ b/knowledge/loan.md
@@ -176,11 +176,11 @@ Waivers are applied first. When `waive_fines=True` and a discount is also provid
 
 ### Implementation
 
-The discount amount is stored on `CashFlowEntry` (via the `discount: Money` field, default `Money.zero()`) and read by the forward pass during payment processing. After computing effective caps and applying waivers, the forward pass reduces each cap in priority order by the discount amount. Fines absorbed by the discount are added to `fines_paid_total` so `fine_balance` correctly reaches zero. Principal absorbed by the discount reduces `running_principal` directly.
+The discount amount is stored on `CashFlowEntry` (via the `discount: Money` field, default `Money.zero()`) and read by the forward pass during payment processing. After computing effective caps and applying waivers, `_apply_waivers_and_discounts` reduces each cap in priority order by the discount amount and returns the per-category split (`fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted`) on `_WaiverResult`. Those four totals flow into `allocate_payment_into_installments`, which distributes them across the touched installments by the same priority and records the result on every `Allocation`. Fines absorbed by the discount are added to `fines_paid_total` so `fine_balance` correctly reaches zero. Principal absorbed by the discount reduces `running_principal` directly.
 
-### Settlement Fields
+### Settlement and Installment Fields
 
-`Settlement` includes `discount_applied: Money` (default `Money.zero()`). This records the total discount amount given for the payment. The per-component breakdown (how much was absorbed from fines, mora, interest, principal) stays internal to the forward pass.
+`Settlement.discount_applied: Money` records the total discount amount given for the payment. The per-category breakdown is exposed on each `Allocation` (`fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted`) and aggregated onto the corresponding `Installment` (`fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted`), so `Installment.balance` and `Installment.is_fully_paid` agree with the loan-level `remaining_balance` when a discount is applied.
 
 ## Forward Pass: `compute_state`
 
@@ -301,10 +301,13 @@ A loan is **not** a group of installments. Installments are a **consequence** of
 
 A frozen dataclass built by `build_installments` from settlements + schedule. Warp-aware.
 
-Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations`.
+Fields: `number`, `due_date`, `days_in_period`, `expected_payment`, `expected_principal`, `expected_interest`, `expected_mora`, `expected_fine`, `principal_paid`, `interest_paid`, `mora_paid`, `fine_paid`, `allocations`, `balance_tolerance`, `fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted`.
 
-- `balance` — amount still owed to fully settle this installment.
+The `*_discounted` fields aggregate the discount portion each allocation absorbed for that component. They default to `Money.zero()` so discount-free payments produce identical installments to before.
+
+- `balance` — amount still owed to fully settle this installment: `total_expected - total_paid - total_discounted`, collapsed to zero within `balance_tolerance`.
 - `is_fully_paid` — `True` when `balance` is within tolerance of zero.
+- `total_discounted` — sum of the four `*_discounted` fields.
 
 Per-installment allocation is a reporting view produced by `engines.distribute_into_installments` (not on the Installment class).
 
@@ -316,7 +319,9 @@ Fields: `payment_amount`, `payment_date`, `fine_paid`, `interest_paid`, `mora_pa
 
 ### Allocation
 
-Defined in `loan/allocation.py`. Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`.
+Defined in `models/allocation.py`. Fields: `installment_number`, `principal_allocated`, `interest_allocated`, `mora_allocated`, `fine_allocated`, `is_fully_covered`, `fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted`.
+
+The `*_discounted` fields default to `Money.zero()` and record the portion of the payment's `discount` that absorbed each component for this installment. They mirror the `*_allocated` fields for the cash payment. `total_allocated` and `total_discounted` are convenience properties.
 
 Shared between Settlement (forward view) and Installment (reverse view).
 
@@ -483,3 +488,13 @@ This aligns the coverage flag with the tolerance-adjustment mechanism: a residua
 **Scope:** Both `Loan` and `BillingCycleLoan` were affected and fixed.
 
 **Lesson:** When a tolerance-based flag (`is_fully_covered`) at the per-installment level coexists with an exact check (`is_paid_off`) at the loan level, the loan-level check must have a fallback that respects the per-installment tolerance. Otherwise the two levels can disagree, leaving consumers in an inconsistent state.
+
+### Installment.is_fully_paid ignored the discount (fixed 2026-05-21)
+
+**Symptom:** Calling `pay_installment(amount, discount=...)` with `amount + discount == expected_payment` left `Installment.balance > 0` and `Installment.is_fully_paid == False`. The loan-level `remaining_balance` and `Settlement.discount_applied` were correct, so the loan paid off cleanly while the per-installment view contradicted itself. `Allocation.is_fully_covered` followed `is_fully_paid` and was therefore also wrong.
+
+**Root cause:** `_apply_waivers_and_discounts` reduced the loan-level fine, mora, and interest caps by the discount they absorbed, but only the principal residual leaked back out (`_WaiverResult.principal_discounted`). The per-category discount portions were never recorded on the resulting `Allocation`, so `Installment.from_schedule_entry` saw only the cash `*_paid` and treated the discounted portion as still owed.
+
+**Fix:** Added per-category `*_discounted` fields to `Allocation`, `Installment`, and the internal `_InstallmentExpectation`, all defaulting to `Money.zero()`. `_WaiverResult` now exposes all four loan-level discount totals; `allocate_payment_into_installments` distributes them across the touched installments in the same fine→mora→interest→principal priority via `_split_component`. `Installment.balance` subtracts `total_discounted` alongside `total_paid`, restoring the invariant `Installment.is_fully_paid iff expected_payment − (paid + discounted) ≤ balance_tolerance`. `_finalize_settlements_coverage` continues to align `Allocation.is_fully_covered` with the post-payment view in one place, so the flag automatically follows.
+
+**Lesson:** When a loan-level adjustment shrinks downstream caps, every consumer that walks per-installment obligations must also receive the breakdown — otherwise the per-installment view silently disagrees with the loan-level view. Recording the per-category split on the same data structure that already carries the cash allocation keeps the two views in lockstep.

--- a/money_warp/engines/allocation.py
+++ b/money_warp/engines/allocation.py
@@ -8,7 +8,7 @@ the cashflow and schedule, never by a public :class:`Installment` view.
 
 from dataclasses import dataclass, field
 from datetime import date
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from ..models import Allocation
 from ..types.money import Money
@@ -102,10 +102,10 @@ def distribute_into_installments(
     interest_total: Money,
     principal_total: Money,
     balance_tolerance: Money = BALANCE_TOLERANCE,
-    fine_discount_total: Money = None,
-    mora_discount_total: Money = None,
-    interest_discount_total: Money = None,
-    principal_discount_total: Money = None,
+    fine_discount_total: Optional[Money] = None,
+    mora_discount_total: Optional[Money] = None,
+    interest_discount_total: Optional[Money] = None,
+    principal_discount_total: Optional[Money] = None,
 ) -> List[Allocation]:
     """Distribute loan-level totals into per-installment allocations.
 
@@ -298,10 +298,10 @@ def allocate_payment_into_installments(
     interest_cap: Money,
     mora_cap: Money,
     balance_tolerance: Money = BALANCE_TOLERANCE,
-    fine_discount_total: Money = None,
-    mora_discount_total: Money = None,
-    interest_discount_total: Money = None,
-    principal_discount_total: Money = None,
+    fine_discount_total: Optional[Money] = None,
+    mora_discount_total: Optional[Money] = None,
+    interest_discount_total: Optional[Money] = None,
+    principal_discount_total: Optional[Money] = None,
 ) -> Tuple[Money, Money, Money, Money, List[Allocation]]:
     """Allocate a payment across installments in priority order.
 

--- a/money_warp/engines/allocation.py
+++ b/money_warp/engines/allocation.py
@@ -6,7 +6,7 @@ the cashflow and schedule, never by a public :class:`Installment` view.
 ``compute_state`` can stay strictly downstream of the cashflow.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import List, Tuple
 
@@ -24,6 +24,10 @@ class _InstallmentExpectation:
     and no public exposure. Built directly from the schedule, prior
     allocations, accrued mora, and fines applied — i.e. from primitives
     the forward pass already has on hand.
+
+    Prior discount portions (``*_discounted``) are tracked alongside
+    prior payments so the next payment sees a previously-discounted
+    installment as covered and does not re-target it.
     """
 
     number: int
@@ -37,12 +41,20 @@ class _InstallmentExpectation:
     mora_paid: Money
     fine_paid: Money
     balance_tolerance: Money
+    fine_discounted: Money = field(default_factory=Money.zero)
+    mora_discounted: Money = field(default_factory=Money.zero)
+    interest_discounted: Money = field(default_factory=Money.zero)
+    principal_discounted: Money = field(default_factory=Money.zero)
+
+    @property
+    def total_discounted(self) -> Money:
+        return self.fine_discounted + self.mora_discounted + self.interest_discounted + self.principal_discounted
 
     @property
     def balance(self) -> Money:
         total_expected = self.expected_principal + self.expected_interest + self.expected_mora + self.expected_fine
         total_paid = self.principal_paid + self.interest_paid + self.mora_paid + self.fine_paid
-        remaining = total_expected - total_paid
+        remaining = total_expected - total_paid - self.total_discounted
         if not remaining.is_positive() or remaining <= self.balance_tolerance:
             return Money.zero()
         return remaining
@@ -90,6 +102,10 @@ def distribute_into_installments(
     interest_total: Money,
     principal_total: Money,
     balance_tolerance: Money = BALANCE_TOLERANCE,
+    fine_discount_total: Money = None,
+    mora_discount_total: Money = None,
+    interest_discount_total: Money = None,
+    principal_discount_total: Money = None,
 ) -> List[Allocation]:
     """Distribute loan-level totals into per-installment allocations.
 
@@ -104,6 +120,13 @@ def distribute_into_installments(
     the real value. Keeping the per-event step out of the loop is what
     lets us guarantee one and only one writer for that flag.
 
+    The ``*_discount_total`` parameters carry the discount portion that
+    ``_apply_waivers_and_discounts`` already deducted from the loan-level
+    caps. They are distributed across the same installments in
+    fine→mora→interest→principal priority so the per-installment view
+    can mark a discounted installment as fully paid. Discount portions
+    do not consume the payment pool.
+
     A residual sweep at the end ensures ``sum(allocations.X) ==
     X_total`` for every component (loan-level accrual can exceed what
     installments absorb due to rounding, partial periods, or
@@ -116,34 +139,44 @@ def distribute_into_installments(
     mora_remaining = mora_total
     interest_remaining = interest_total
     principal_remaining = principal_total
+    fine_discount_remaining = fine_discount_total if fine_discount_total is not None else Money.zero()
+    mora_discount_remaining = mora_discount_total if mora_discount_total is not None else Money.zero()
+    interest_discount_remaining = interest_discount_total if interest_discount_total is not None else Money.zero()
+    principal_discount_remaining = principal_discount_total if principal_discount_total is not None else Money.zero()
     allocations: List[Allocation] = []
 
     for exp in expectations:
         if exp.is_fully_paid or exp.balance <= balance_tolerance:
             continue
 
-        fine_owed = exp.expected_fine - exp.fine_paid
-        fine_alloc = Money(min(max(fine_owed.raw_amount, 0), fine_remaining.raw_amount))
-        fine_remaining = fine_remaining - fine_alloc
-
-        mora_owed = exp.expected_mora - exp.mora_paid
-        mora_alloc = Money(min(max(mora_owed.raw_amount, 0), mora_remaining.raw_amount))
-        mora_remaining = mora_remaining - mora_alloc
-
-        interest_owed = exp.expected_interest - exp.interest_paid
-        interest_alloc = Money(min(max(interest_owed.raw_amount, 0), interest_remaining.raw_amount))
-        interest_remaining = interest_remaining - interest_alloc
-
-        principal_owed = exp.expected_principal - exp.principal_paid
-        principal_alloc = Money(min(max(principal_owed.raw_amount, 0), principal_remaining.raw_amount))
-        principal_remaining = principal_remaining - principal_alloc
+        fine_alloc, fine_remaining, fine_disc, fine_discount_remaining = _split_component(
+            owed=exp.expected_fine - exp.fine_paid - exp.fine_discounted,
+            pay_pool=fine_remaining,
+            discount_pool=fine_discount_remaining,
+        )
+        mora_alloc, mora_remaining, mora_disc, mora_discount_remaining = _split_component(
+            owed=exp.expected_mora - exp.mora_paid - exp.mora_discounted,
+            pay_pool=mora_remaining,
+            discount_pool=mora_discount_remaining,
+        )
+        interest_alloc, interest_remaining, interest_disc, interest_discount_remaining = _split_component(
+            owed=exp.expected_interest - exp.interest_paid - exp.interest_discounted,
+            pay_pool=interest_remaining,
+            discount_pool=interest_discount_remaining,
+        )
+        principal_alloc, principal_remaining, principal_disc, principal_discount_remaining = _split_component(
+            owed=exp.expected_principal - exp.principal_paid - exp.principal_discounted,
+            pay_pool=principal_remaining,
+            discount_pool=principal_discount_remaining,
+        )
 
         total = fine_alloc + mora_alloc + interest_alloc + principal_alloc
+        total_disc = fine_disc + mora_disc + interest_disc + principal_disc
         if total.is_positive():
-            is_covered = total + balance_tolerance >= exp.balance
+            covered = total + total_disc + balance_tolerance >= exp.balance
 
-            if not is_covered:
-                shortfall = exp.balance - total
+            if not covered:
+                shortfall = exp.balance - total - total_disc
                 fine_extra, shortfall, fine_remaining = _absorb(shortfall, fine_remaining)
                 mora_extra, shortfall, mora_remaining = _absorb(shortfall, mora_remaining)
                 interest_extra, shortfall, interest_remaining = _absorb(shortfall, interest_remaining)
@@ -153,6 +186,7 @@ def distribute_into_installments(
                 interest_alloc = interest_alloc + interest_extra
                 principal_alloc = principal_alloc + principal_extra
 
+        if total.is_positive() or total_disc.is_positive():
             allocations.append(
                 Allocation(
                     installment_number=exp.number,
@@ -161,11 +195,38 @@ def distribute_into_installments(
                     mora_allocated=mora_alloc,
                     fine_allocated=fine_alloc,
                     is_fully_covered=False,
+                    fine_discounted=fine_disc,
+                    mora_discounted=mora_disc,
+                    interest_discounted=interest_disc,
+                    principal_discounted=principal_disc,
                 )
             )
 
     _apply_residual(allocations, expectations, fine_total, mora_total, interest_total, principal_total)
     return allocations
+
+
+def _split_component(
+    owed: Money,
+    pay_pool: Money,
+    discount_pool: Money,
+) -> Tuple[Money, Money, Money, Money]:
+    """Split a single component's obligation between payment and discount pools.
+
+    Fills the payment allocation first (cash), then the discount
+    allocation, capping both at the per-installment ``owed`` remaining
+    after each step. Returns the four updated values:
+    ``(pay_alloc, pay_pool_remaining, discount_alloc, discount_pool_remaining)``.
+    """
+    owed_raw = max(owed.raw_amount, 0)
+    pay_raw = min(owed_raw, pay_pool.raw_amount)
+    pay_alloc = Money(pay_raw)
+    pay_pool = pay_pool - pay_alloc
+    owed_after_pay = owed_raw - pay_raw
+    disc_raw = min(owed_after_pay, discount_pool.raw_amount)
+    discount_alloc = Money(disc_raw)
+    discount_pool = discount_pool - discount_alloc
+    return pay_alloc, pay_pool, discount_alloc, discount_pool
 
 
 def _absorb(shortfall: Money, pool: Money) -> Tuple[Money, Money, Money]:
@@ -212,6 +273,10 @@ def _apply_residual(
             mora_allocated=Money(last.mora_allocated.raw_amount + m_diff),
             fine_allocated=Money(last.fine_allocated.raw_amount + f_diff),
             is_fully_covered=last.is_fully_covered,
+            fine_discounted=last.fine_discounted,
+            mora_discounted=last.mora_discounted,
+            interest_discounted=last.interest_discounted,
+            principal_discounted=last.principal_discounted,
         )
     elif expectations:
         allocations.append(
@@ -233,6 +298,10 @@ def allocate_payment_into_installments(
     interest_cap: Money,
     mora_cap: Money,
     balance_tolerance: Money = BALANCE_TOLERANCE,
+    fine_discount_total: Money = None,
+    mora_discount_total: Money = None,
+    interest_discount_total: Money = None,
+    principal_discount_total: Money = None,
 ) -> Tuple[Money, Money, Money, Money, List[Allocation]]:
     """Allocate a payment across installments in priority order.
 
@@ -246,6 +315,14 @@ def allocate_payment_into_installments(
     *balance_tolerance* controls the sub-cent threshold used by the
     per-installment distribution.  Defaults to the engine-wide
     ``BALANCE_TOLERANCE``.
+
+    The ``*_discount_total`` parameters carry the per-category discount
+    amounts that ``_apply_waivers_and_discounts`` already absorbed at
+    the loan level. They are forwarded to
+    :func:`distribute_into_installments` so each allocation records the
+    discount portion it covered, making
+    :attr:`Installment.is_fully_paid` consistent with the loan-level
+    ``remaining_balance``.
 
     Returns:
         (fine_total, mora_total, interest_total, principal_total, allocations)
@@ -264,6 +341,10 @@ def allocate_payment_into_installments(
         interest_paid,
         principal_paid,
         balance_tolerance=balance_tolerance,
+        fine_discount_total=fine_discount_total,
+        mora_discount_total=mora_discount_total,
+        interest_discount_total=interest_discount_total,
+        principal_discount_total=principal_discount_total,
     )
 
     return fine_paid, mora_paid, interest_paid, principal_paid, allocations

--- a/money_warp/engines/forward_pass.py
+++ b/money_warp/engines/forward_pass.py
@@ -218,6 +218,10 @@ def _build_expectations(
         prior_interest = Money(sum(a.interest_allocated.raw_amount for a in allocs))
         prior_mora = Money(sum(a.mora_allocated.raw_amount for a in allocs))
         prior_fine = Money(sum(a.fine_allocated.raw_amount for a in allocs))
+        prior_principal_discounted = Money(sum(a.principal_discounted.raw_amount for a in allocs))
+        prior_interest_discounted = Money(sum(a.interest_discounted.raw_amount for a in allocs))
+        prior_mora_discounted = Money(sum(a.mora_discounted.raw_amount for a in allocs))
+        prior_fine_discounted = Money(sum(a.fine_discounted.raw_amount for a in allocs))
 
         expected_fine = prior_fine if waive_fines else fines_applied.get(entry.due_date, Money.zero())
 
@@ -267,6 +271,10 @@ def _build_expectations(
                 mora_paid=prior_mora,
                 fine_paid=prior_fine,
                 balance_tolerance=balance_tolerance,
+                fine_discounted=prior_fine_discounted,
+                mora_discounted=prior_mora_discounted,
+                interest_discounted=prior_interest_discounted,
+                principal_discounted=prior_principal_discounted,
             )
         )
 
@@ -343,6 +351,9 @@ class _WaiverResult:
     effective_fine_cap: Money
     effective_mora_cap: Money
     interest_cap: Money
+    fine_discounted: Money
+    mora_discounted: Money
+    interest_discounted: Money
     principal_discounted: Money
     fines_waived: Money
     mora_waived: Money
@@ -358,7 +369,15 @@ def _apply_waivers_and_discounts(
     fines_applied: Dict[date, Money],
     fines_paid_total: Money,
 ) -> _WaiverResult:
-    """Apply waive_fines, waive_mora, and discount to caps."""
+    """Apply waive_fines, waive_mora, and discount to caps.
+
+    The per-category discount amounts (``fine_discounted``,
+    ``mora_discounted``, ``interest_discounted``,
+    ``principal_discounted``) are returned alongside the reduced caps
+    so the allocator can record them on each :class:`Allocation`. That
+    keeps the per-installment view's ``balance`` consistent with the
+    loan-level ``remaining_balance`` when a discount is applied.
+    """
     fines_waived = Money.zero()
     mora_waived = Money.zero()
     effective_fine_cap = fine_balance
@@ -391,6 +410,9 @@ def _apply_waivers_and_discounts(
         effective_fine_cap=effective_fine_cap,
         effective_mora_cap=effective_mora_cap,
         interest_cap=interest_cap,
+        fine_discounted=fine_discounted,
+        mora_discounted=mora_discounted,
+        interest_discounted=interest_discounted,
         principal_discounted=discount_remaining,
         fines_waived=fines_waived,
         mora_waived=mora_waived,
@@ -657,6 +679,10 @@ def compute_state(
             interest_cap=wd.interest_cap,
             mora_cap=wd.effective_mora_cap,
             balance_tolerance=balance_tolerance,
+            fine_discount_total=wd.fine_discounted,
+            mora_discount_total=wd.mora_discounted,
+            interest_discount_total=wd.interest_discounted,
+            principal_discount_total=wd.principal_discounted,
         )
 
         fines_paid_total = wd.fines_paid_total + fine_paid
@@ -778,6 +804,10 @@ def _finalize_settlements_coverage(
                 mora_allocated=alloc.mora_allocated,
                 fine_allocated=alloc.fine_allocated,
                 is_fully_covered=target,
+                fine_discounted=alloc.fine_discounted,
+                mora_discounted=alloc.mora_discounted,
+                interest_discounted=alloc.interest_discounted,
+                principal_discounted=alloc.principal_discounted,
             )
 
 

--- a/money_warp/models/allocation.py
+++ b/money_warp/models/allocation.py
@@ -1,6 +1,6 @@
 """Allocation data structure for per-installment payment breakdown."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ..types.money import Money
 
@@ -10,7 +10,10 @@ class Allocation:
     """Breakdown of a payment's allocation to a single installment.
 
     Each allocation shows how much principal, interest, mora, and fine
-    from a payment were attributed to a specific installment.
+    from a payment were attributed to a specific installment, plus how
+    much of the payment's ``discount`` covered each component. The
+    discount fields default to zero so payments without a discount keep
+    their original shape.
     """
 
     installment_number: int
@@ -19,8 +22,25 @@ class Allocation:
     mora_allocated: Money
     fine_allocated: Money
     is_fully_covered: bool
+    # ``dataclass`` rejects any non-(list/dict/set) instance as a plain
+    # default — even immutable ones — so ``Money`` must be supplied via
+    # ``default_factory`` despite being effectively immutable.
+    fine_discounted: Money = field(default_factory=Money.zero)
+    mora_discounted: Money = field(default_factory=Money.zero)
+    interest_discounted: Money = field(default_factory=Money.zero)
+    principal_discounted: Money = field(default_factory=Money.zero)
 
     @property
     def total_allocated(self) -> Money:
         """Sum of all components allocated to this installment."""
         return self.principal_allocated + self.interest_allocated + self.mora_allocated + self.fine_allocated
+
+    @property
+    def total_discounted(self) -> Money:
+        """Sum of discount portions absorbed by this installment.
+
+        Mirrors :attr:`total_allocated` for the payment's ``discount``
+        contribution. A payment without a discount has every component
+        at zero.
+        """
+        return self.fine_discounted + self.mora_discounted + self.interest_discounted + self.principal_discounted

--- a/money_warp/models/installment.py
+++ b/money_warp/models/installment.py
@@ -16,7 +16,8 @@ class Installment:
     """A single installment in a loan repayment plan.
 
     Represents the borrower's obligation for one period: what is expected,
-    what has actually been paid, and the detailed per-payment allocations.
+    what has actually been paid, what has been covered by a discount,
+    and the detailed per-payment allocations.
 
     Installments are derived views -- the Loan builds them on demand
     from the CashFlow and the schedule.
@@ -27,6 +28,10 @@ class Installment:
     ``DEFAULT_BALANCE_TOLERANCE``); :class:`Loan` and
     :class:`BillingCycleLoan` propagate their own configurable value
     through every installment snapshot they build.
+
+    The ``*_discounted`` fields aggregate the discount portion each
+    allocation absorbed for that component. They default to zero so
+    discount-free payments produce identical installments to before.
     """
 
     number: int
@@ -46,6 +51,15 @@ class Installment:
     # default — even immutable ones — so ``Money`` must be supplied via
     # ``default_factory`` despite being effectively immutable.
     balance_tolerance: Money = field(default_factory=lambda: DEFAULT_BALANCE_TOLERANCE)
+    fine_discounted: Money = field(default_factory=Money.zero)
+    mora_discounted: Money = field(default_factory=Money.zero)
+    interest_discounted: Money = field(default_factory=Money.zero)
+    principal_discounted: Money = field(default_factory=Money.zero)
+
+    @property
+    def total_discounted(self) -> Money:
+        """Sum of discount portions absorbed by this installment."""
+        return self.fine_discounted + self.mora_discounted + self.interest_discounted + self.principal_discounted
 
     @property
     def balance(self) -> Money:
@@ -54,11 +68,12 @@ class Installment:
         Positive residuals within ``balance_tolerance`` collapse to zero
         so ``is_fully_paid`` agrees with ``Allocation.is_fully_covered``
         on rounding artifacts that the tolerance-adjustment mechanism
-        absorbs.
+        absorbs. The discount portions are treated as covered, mirroring
+        what ``Settlement.discount_applied`` reports at the loan level.
         """
         total_expected = self.expected_principal + self.expected_interest + self.expected_mora + self.expected_fine
         total_paid = self.principal_paid + self.interest_paid + self.mora_paid + self.fine_paid
-        remaining = total_expected - total_paid
+        remaining = total_expected - total_paid - self.total_discounted
         if not remaining.is_positive() or remaining <= self.balance_tolerance:
             return Money.zero()
         return remaining
@@ -87,12 +102,17 @@ class Installment:
 
         ``balance_tolerance`` is forwarded to the constructed Installment
         so ``balance`` and ``is_fully_paid`` honor the loan-level
-        setting.
+        setting. The ``*_discounted`` fields are derived from the
+        allocations so callers never need to compute them.
         """
         principal_paid = Money(sum(a.principal_allocated.raw_amount for a in allocations))
         interest_paid = Money(sum(a.interest_allocated.raw_amount for a in allocations))
         mora_paid = Money(sum(a.mora_allocated.raw_amount for a in allocations))
         fine_paid = Money(sum(a.fine_allocated.raw_amount for a in allocations))
+        fine_discounted = Money(sum(a.fine_discounted.raw_amount for a in allocations))
+        mora_discounted = Money(sum(a.mora_discounted.raw_amount for a in allocations))
+        interest_discounted = Money(sum(a.interest_discounted.raw_amount for a in allocations))
+        principal_discounted = Money(sum(a.principal_discounted.raw_amount for a in allocations))
 
         return cls(
             number=entry.payment_number,
@@ -109,4 +129,8 @@ class Installment:
             fine_paid=fine_paid,
             allocations=allocations,
             balance_tolerance=balance_tolerance,
+            fine_discounted=fine_discounted,
+            mora_discounted=mora_discounted,
+            interest_discounted=interest_discounted,
+            principal_discounted=principal_discounted,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "money_warp"
-version = "0.29.1"
+version = "0.30.0"
 description = "MoneyWarp – Bend time. Model cash."
 license = "MIT"
 authors = ["Tomas Correa <tomas.correa@gmail.com>"]

--- a/tests/billing_cycle_loan/test_discount_installment_view.py
+++ b/tests/billing_cycle_loan/test_discount_installment_view.py
@@ -1,0 +1,93 @@
+"""Regression test for the bug where Installment.is_fully_paid ignored
+the discount applied to a payment.
+
+When ``pay_installment(amount, discount=...)`` is called and
+``amount + discount`` exactly covers ``expected_payment``, the per-
+installment view used to report ``balance > 0`` and ``is_fully_paid is
+False`` even though the loan-level ``remaining_balance`` was correct
+and ``Settlement.discount_applied`` recorded the discount.
+
+The root cause was that ``_apply_waivers_and_discounts`` shrank the
+loan-level fine / mora / interest caps by the discount portion they
+consumed without recording that portion on the per-installment
+``Allocation``. The installment therefore saw only the cash payment in
+``*_paid`` and considered the discounted residual still owed.
+"""
+
+from datetime import date, datetime
+
+from money_warp import (
+    BillingCycleLoan,
+    InterestRate,
+    Money,
+    MonthlyBillingCycle,
+    PriceScheduler,
+    Warp,
+)
+
+
+def test_installment_is_fully_paid_when_amount_plus_discount_equals_expected():
+    """Amount + discount == expected_payment must mark the installment fully paid.
+
+    The reproducer is a 2-installment BCL whose first installment is
+    paid with R$2.58 plus a R$0.02 discount, equal to its R$2.60
+    scheduled payment. Before the fix, ``inst.balance`` was R$0.02 and
+    ``inst.is_fully_paid`` was ``False``; the allocation flag was kept
+    in sync and therefore also wrong.
+    """
+    loan = BillingCycleLoan(
+        principal=Money("5.04"),
+        interest_rate=InterestRate("1.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 10), date(2025, 12, 10)]),
+        start_date=datetime(2025, 10, 9),
+        num_installments=2,
+        disbursement_date=datetime(2025, 10, 9),
+        scheduler=PriceScheduler,
+    )
+
+    expected_payment = loan.get_original_schedule().entries[0].payment_amount
+    assert expected_payment == Money("2.60")
+
+    with Warp(loan, datetime(2025, 11, 5)) as warped:
+        settlement = warped.pay_installment(
+            Money("2.58"),
+            discount=Money("0.02"),
+            waive_overdue_interest=True,
+        )
+        inst = warped.installments[0]
+
+        assert settlement.discount_applied == Money("0.02")
+        assert Money("2.58") + Money("0.02") == inst.expected_payment
+
+        assert inst.balance == Money.zero(), f"balance={inst.balance}"
+        assert inst.is_fully_paid is True
+        assert settlement.allocations[0].is_fully_covered is True
+
+
+def test_loan_level_remaining_balance_unchanged_by_fix():
+    """The loan-level ``remaining_balance`` was correct before the fix.
+
+    Pinning the exact value protects against any regression where the
+    per-installment fix accidentally double-counts the discount at the
+    loan level.
+    """
+    loan = BillingCycleLoan(
+        principal=Money("5.04"),
+        interest_rate=InterestRate("1.99% a.m."),
+        billing_cycle=MonthlyBillingCycle(due_dates=[date(2025, 11, 10), date(2025, 12, 10)]),
+        start_date=datetime(2025, 10, 9),
+        num_installments=2,
+        disbursement_date=datetime(2025, 10, 9),
+        scheduler=PriceScheduler,
+    )
+
+    with Warp(loan, datetime(2025, 11, 5)) as warped:
+        settlement = warped.pay_installment(
+            Money("2.58"),
+            discount=Money("0.02"),
+            waive_overdue_interest=True,
+        )
+
+        assert settlement.principal_paid == Money("2.49")
+        assert settlement.interest_paid == Money("0.09")
+        assert settlement.remaining_balance == Money("2.55")

--- a/tests/loan/test_discount_installment_view.py
+++ b/tests/loan/test_discount_installment_view.py
@@ -1,0 +1,203 @@
+"""Per-installment consistency tests for ``pay_installment(discount=...)``.
+
+When the cash payment plus the discount exactly covers an installment's
+total obligation, the per-installment view must agree with the
+loan-level ``remaining_balance``:
+
+* ``Installment.is_fully_paid`` is ``True``
+* ``Installment.balance`` is zero
+* ``Allocation.is_fully_covered`` is ``True``
+
+These tests pin that invariant across every discount-target category:
+interest, fines, mora, a mix of all three, and a principal-heavy
+discount on a tiny installment. The companion test in
+``tests/billing_cycle_loan/test_discount_installment_view.py`` covers
+the exact reproducer from the bug report on ``BillingCycleLoan``.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from money_warp import InterestRate, Loan, Money, Warp
+
+
+def _late_loan() -> Loan:
+    """Single-installment loan paid 14 days late.
+
+    Obligations on 2025-02-15 are pinned by
+    ``tests/loan/test_discount.py`` and probed independently:
+    principal 10_000.00, interest 49.61, mora 22.49, fine 502.48.
+    """
+    return Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        fine_rate=InterestRate("5% annual"),
+    )
+
+
+def _on_time_loan() -> Loan:
+    return Loan(
+        Money("10000.00"),
+        InterestRate("6% a"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_discount_on_interest_only_makes_installment_fully_paid():
+    """Plain ``Loan`` mirror of the BCL regression: discount fills the
+    interest gap and the installment becomes fully paid.
+    """
+    loan = _on_time_loan()
+    expected_payment = loan.get_original_schedule().entries[0].payment_amount
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(expected_payment - Money("0.10"), discount=Money("0.10"))
+        inst = w.installments[0]
+
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert inst.interest_discounted == Money("0.10")
+    assert settlement.allocations[0].is_fully_covered is True
+
+
+def test_discount_on_fines_only_makes_installment_fully_paid():
+    """Discount equal to the accrued fine, payment covers the rest in cash."""
+    loan = _late_loan()
+    pay_dt = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    with Warp(loan, pay_dt) as w:
+        settlement = w.pay_installment(
+            Money("10072.10"),
+            discount=Money("502.48"),
+        )
+        inst = w.installments[0]
+
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert inst.fine_discounted == Money("502.48")
+    assert inst.fine_paid == Money.zero()
+    assert inst.mora_paid == Money("22.49")
+    assert inst.interest_paid == Money("49.61")
+    assert inst.principal_paid == Money("10000.00")
+    assert settlement.allocations[0].is_fully_covered is True
+    assert settlement.remaining_balance == Money.zero()
+
+
+def test_discount_on_mora_only_makes_installment_fully_paid():
+    """``waive_fines`` clears the fine, the discount absorbs the accrued mora."""
+    loan = _late_loan()
+    pay_dt = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    with Warp(loan, pay_dt) as w:
+        settlement = w.pay_installment(
+            Money("10049.61"),
+            waive_fines=True,
+            discount=Money("22.49"),
+        )
+        inst = w.installments[0]
+
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert inst.mora_discounted == Money("22.49")
+    assert inst.mora_paid == Money.zero()
+    assert inst.interest_paid == Money("49.61")
+    assert inst.principal_paid == Money("10000.00")
+    assert settlement.allocations[0].is_fully_covered is True
+    assert settlement.remaining_balance == Money.zero()
+
+
+def test_discount_mix_spills_from_fines_through_mora_into_interest():
+    """Discount larger than fine + mora consumes the difference from interest."""
+    loan = _late_loan()
+    pay_dt = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    discount = Money("502.48") + Money("22.49") + Money("30.00")
+    amount = Money("10000.00") + (Money("49.61") - Money("30.00"))
+
+    with Warp(loan, pay_dt) as w:
+        settlement = w.pay_installment(amount, discount=discount)
+        inst = w.installments[0]
+
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert inst.fine_discounted == Money("502.48")
+    assert inst.mora_discounted == Money("22.49")
+    assert inst.interest_discounted == Money("30.00")
+    assert inst.principal_discounted == Money.zero()
+    assert inst.interest_paid == Money("19.61")
+    assert inst.principal_paid == Money("10000.00")
+    assert settlement.allocations[0].is_fully_covered is True
+    assert settlement.remaining_balance == Money.zero()
+
+
+def test_discount_covers_principal_of_tiny_final_installment():
+    """A tiny final installment whose principal is mostly covered by discount
+    is still marked fully paid.
+
+    The discount is large enough that, after the (effectively zero)
+    interest cap is consumed, the leftover spills into
+    ``principal_discounted``. With ``amount=$0.01`` and
+    ``discount=$0.99``, the entire R$1.00 principal is settled — R$0.01
+    in cash, R$0.99 by discount.
+    """
+    loan = Loan(
+        Money("1.00"),
+        InterestRate("0.001% annual"),
+        [date(2025, 2, 1)],
+        disbursement_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    expected_payment = loan.get_original_schedule().entries[0].payment_amount
+
+    with Warp(loan, datetime(2025, 2, 1, tzinfo=timezone.utc)) as w:
+        settlement = w.pay_installment(Money("0.01"), discount=expected_payment - Money("0.01"))
+        inst = w.installments[0]
+
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert inst.principal_discounted.is_positive()
+    assert inst.principal_paid + inst.principal_discounted == inst.expected_principal
+    assert settlement.allocations[0].is_fully_covered is True
+    assert settlement.remaining_balance == Money.zero()
+
+
+@pytest.mark.parametrize(
+    "scenario,amount,discount,waive_fines",
+    [
+        ("fines", "10072.10", "502.48", False),
+        ("mora", "10049.61", "22.49", True),
+        ("mix", "10019.61", "554.97", False),
+    ],
+    ids=["fines_only", "mora_only", "mix_fine_mora_interest"],
+)
+def test_late_payment_discount_keeps_loan_level_balance_at_zero(
+    scenario: str,
+    amount: str,
+    discount: str,
+    waive_fines: bool,
+) -> None:
+    """The loan-level invariant must hold across every late-payment discount target.
+
+    Independent of how the discount is split per category, ``amount +
+    discount`` covers the full obligation, so the loan must be paid off
+    and the installment view must agree.
+    """
+    loan = _late_loan()
+    pay_dt = datetime(2025, 2, 15, tzinfo=timezone.utc)
+
+    with Warp(loan, pay_dt) as w:
+        settlement = w.pay_installment(
+            Money(amount),
+            discount=Money(discount),
+            waive_fines=waive_fines,
+        )
+        inst = w.installments[0]
+
+    assert settlement.remaining_balance == Money.zero()
+    assert inst.is_fully_paid is True
+    assert inst.balance == Money.zero()
+    assert settlement.allocations[0].is_fully_covered is True
+    assert settlement.discount_applied == Money(discount)

--- a/tests/loan/test_discount_installment_view.py
+++ b/tests/loan/test_discount_installment_view.py
@@ -165,16 +165,15 @@ def test_discount_covers_principal_of_tiny_final_installment():
 
 
 @pytest.mark.parametrize(
-    "scenario,amount,discount,waive_fines",
+    "amount,discount,waive_fines",
     [
-        ("fines", "10072.10", "502.48", False),
-        ("mora", "10049.61", "22.49", True),
-        ("mix", "10019.61", "554.97", False),
+        ("10072.10", "502.48", False),
+        ("10049.61", "22.49", True),
+        ("10019.61", "554.97", False),
     ],
     ids=["fines_only", "mora_only", "mix_fine_mora_interest"],
 )
 def test_late_payment_discount_keeps_loan_level_balance_at_zero(
-    scenario: str,
     amount: str,
     discount: str,
     waive_fines: bool,


### PR DESCRIPTION
## Summary

`pay_installment(amount, discount=...)` was leaving the per-installment view inconsistent with the loan-level view: when `amount + discount == expected_payment`, `Installment.balance` reported the discounted portion as still owed and `Installment.is_fully_paid` returned `False`. `Settlement.discount_applied` and `remaining_balance` were already correct, so the loan paid off cleanly while the installment view contradicted itself.

Root cause: `_apply_waivers_and_discounts` reduced the loan-level fine / mora / interest caps by the discount they absorbed, but only the leftover that hit principal leaked back out (`_WaiverResult.principal_discounted`). The per-category split was never recorded on the resulting `Allocation`, so `Installment.from_schedule_entry` saw only the cash `*_paid` and treated the discounted portion as still owed.

Fix:

- Add defaulted `fine_discounted`, `mora_discounted`, `interest_discounted`, `principal_discounted` fields to `Allocation`, `Installment`, and the internal `_InstallmentExpectation`.
- Expose all four loan-level discount totals on `_WaiverResult` and thread them through `allocate_payment_into_installments` -> `distribute_into_installments`, which now splits them across the touched installments in the same fine -> mora -> interest -> principal priority via a new `_split_component` helper.
- `Installment.balance` subtracts `total_discounted` alongside `total_paid`, restoring the invariant `Installment.is_fully_paid iff expected_payment - (paid + discounted) <= balance_tolerance`.
- `_finalize_settlements_coverage` continues to align `Allocation.is_fully_covered` with the post-payment `Installment.is_fully_paid` in one place, so the allocation flag now follows for free.

Version bump to `0.30.0` (new defaulted fields on public `Allocation` / `Installment`). Knowledge file refreshed: Discount, Installment, Allocation sections rewritten and a new Key Learnings entry added.

## Test plan

- [x] Regression test from the bug report (`tests/billing_cycle_loan/test_discount_installment_view.py::test_installment_is_fully_paid_when_amount_plus_discount_equals_expected`) — passes.
- [x] Loan-level numbers pinned unchanged for the reproducer (`principal_paid=2.49`, `interest_paid=0.09`, `remaining_balance=2.55`).
- [x] Category coverage in `tests/loan/test_discount_installment_view.py`: discount on interest only, fines only, mora only, mix spilling from fines through mora into interest, and a tiny final installment whose principal is mostly covered by discount. All five pass plus a parametrized loan-level invariant.
- [x] Existing discount suites (`tests/loan/test_discount.py`, `tests/billing_cycle_loan/test_discount.py`) untouched and green.
- [x] Full suite: `poetry run pytest` -> `5730 passed, 3450 deselected in 61.83s`.
- [x] Property-based invariants (`tests/invariants/`, including `test_coverage_consistency.py`) all green.
- [x] `poetry run black` + ruff via `pre-commit run --files ...` both pass on every changed file.

No public signature changed (`pay_installment` / `Warp` are untouched); new fields default to `Money.zero()` for backward compatibility; `Installment` stays a frozen dataclass; `BALANCE_TOLERANCE` is unchanged.