### PR TITLE
chore(ci): bump first-party Actions to Node 24-compatible versions

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -22,7 +22,7 @@ runs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PostgreSQL
         run: |
@@ -42,7 +42,7 @@ jobs:
           echo "$(pg_config --bindir)" >> $GITHUB_PATH
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -50,7 +50,7 @@ jobs:
         uses: snok/install-poetry@v1
 
       - name: Load cached venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .tox
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env

--- a/.github/workflows/on-release-pypi.yml
+++ b/.github/workflows/on-release-pypi.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env
@@ -40,7 +40,7 @@ jobs:
       contents: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env

--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -10,6 +10,6 @@ jobs:
   validate-codecov-config:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Validate codecov configuration
         run: curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate


### PR DESCRIPTION
## Summary

Bumps the three first-party Actions flagged by the v0.30.0 release run's Node 20 deprecation warning:

- `actions/checkout`: `v3` / `v4` -> `v6` (`v6.0.2`)
- `actions/cache`: `v4` -> `v5` (`v5.0.5`)
- `actions/setup-python`: `v5` -> `v6` (`v6.2.0`)

11 pin bumps across 4 files. Third-party Actions (`snok/install-poetry`, `pypa/gh-action-pypi-publish`, `codecov/codecov-action`) were not in the warning and stay as-is.

CI-only change. No Python source, no package version bump, no new release.

Closes #97.

## Test plan

- [ ] `quality` job (uses `checkout@v6` + `cache@v5` + composite `setup-poetry-env` which now uses `setup-python@v6` + `cache@v5`) goes green.
- [ ] `tox (3.10)` and `tox (3.11)` jobs (use `checkout@v6` + `setup-python@v6` + `cache@v5`) go green.
- [ ] `check-docs` job (uses `checkout@v6` + composite `setup-poetry-env`) goes green.
- [ ] No new deprecation warnings in the run log.

`on-release-pypi.yml` and `validate-codecov-config.yml` are not exercised by PR CI; the bumps in those files mirror the same actions validated by `on-release-main.yml`, so risk is low. They'll be exercised on the next release / next `codecov.yaml` change.